### PR TITLE
Fix: urllib3 preload_content=True breaks resp.read() — weather/TLE silently fail

### DIFF
--- a/PyNightSkyPredictor/_http.py
+++ b/PyNightSkyPredictor/_http.py
@@ -44,7 +44,7 @@ def urlopen(url, *args, timeout=10, **kwargs):
             "GET", full,
             headers=headers,
             timeout=urllib3.Timeout(total=timeout),
-            preload_content=True,
+            preload_content=False,
         )
     except urllib3.exceptions.TimeoutError as exc:
         raise urllib.error.URLError("timed out") from exc


### PR DESCRIPTION
## Summary

- `_http.urlopen` was passing `preload_content=True` to urllib3's `request()`, which pre-reads the response body into `resp.data` but exhausts the internal read buffer
- All callers use `with _http.urlopen(...) as resp: data = resp.read()` — with `preload_content=True`, `resp.read()` returns `b""`, so `json.loads(b"")` raises a `JSONDecodeError`
- This silently killed **every outbound HTTP fetch**: Open-Meteo weather forecasts, 7Timer seeing/transparency data, TLE downloads from Celestrak, and darksky tile downloads
- Fix: switch to `preload_content=False` (urllib3 default) so callers can read the body normally; the TLS session-reuse benefit of the connection pool is preserved because urllib3 releases the connection back to the pool when the `with` block exits after the body is drained

## Test plan

- [ ] Fetch a night report with `weather=true` and confirm `weather_points` is non-empty and `wx_source` shows `Open-Meteo + 7Timer`
- [ ] Confirm TLE fetches work (satellites toggle)
- [ ] Confirmed locally: `wx.forecast(40.7, -74.0)` returns 168 hourly points with source `Open-Meteo + 7Timer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)