### PR TITLE
Fix stale satellite/targets sections when re-querying a future date

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -105,9 +105,9 @@ export default function App() {
     setLoading(true)
     try {
       setReport(await fetchNight(q))
-      setReportWeather(weather)
+      setReportWeather(weather && !wxForecastUnavailable)
       setReportTargets(targets)
-      setReportSatellites(satellites)
+      setReportSatellites(satellites && !satUnavailable)
     } catch (err) {
       setReport(null)
       setError(err instanceof ApiRequestError ? err.message : 'Something went wrong.')

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -488,7 +488,11 @@ function TargetsTable({ targets, report }: { targets: VisibleTarget[]; report: N
     | { kind: 'header'; type: string; key: string }
     | { kind: 'target'; target: VisibleTarget; key: string }
 
-  if (sorted.length === 0) return null
+  if (sorted.length === 0) return (
+    <p className="sat-notice" style={{ paddingTop: 10 }}>
+      No non-Milky-Way targets meet prime criteria (≥40° altitude, ≥1h window) this night.
+    </p>
+  )
 
   const rows: RowItem[] = []
   for (const g of groups) {
@@ -835,11 +839,13 @@ export default function ReportCard({
         <WeatherTable points={r.weather_points} tz={tz} imperial={imperial} />
       )}
 
-      {showTargets && (
+      {showTargets && (() => {
+        const primeCount = r.visible_targets.filter(t => isPrime(t, r.dark_intervals)).length
+        return (
         <details className="targets" open>
           <summary>
             Prime Targets
-            {r.visible_targets.length > 0 ? ` (${r.visible_targets.length})` : ''}
+            {primeCount > 0 ? ` (${primeCount})` : ''}
           </summary>
           {r.visible_targets.length === 0
             ? <p className="sat-notice" style={{ paddingTop: 10 }}>No prime targets for this night.</p>
@@ -858,7 +864,8 @@ export default function ReportCard({
               </>
           }
         </details>
-      )}
+        )
+      })()}
 
       {showSatellites && (
         <details className="sat-section" open>


### PR DESCRIPTION
## Summary

- **Satellite section phantom card**: `setReportSatellites` was saving the checkbox state (`true`) regardless of whether satellites were actually requested. For dates >10 days out, `satUnavailable=true` disables the checkbox but the section still rendered, showing a misleading "No visible satellite passes this night." Fixed by gating on `satellites && !satUnavailable` (same logic used to build the query).
- **Weather section same bug**: `setReportWeather` had the same pattern; fixed to `weather && !wxForecastUnavailable`.
- **Prime Targets count mismatch**: The `<details>` summary showed `r.visible_targets.length` (all targets the API returned), but `TargetsTable` client-side-filters to prime targets only. On a moon-heavy or far-future night, all targets could fail `isPrime`, leaving the dropdown open but empty while the badge still showed e.g. "(19)". Fixed by computing the filtered count with `isPrime` before rendering the summary.
- **Empty TargetsTable fallback**: `TargetsTable` previously returned `null` when no targets passed `isPrime`. It now renders an explanatory message so users know visible targets exist but none qualify.

## Test plan

- [ ] Query today's date with all options selected — everything renders as before
- [ ] Change date to >10 days out — Satellites checkbox disables; after submit, Satellite Passes section does **not** appear
- [ ] Change date to >7 days out — Weather checkbox disables; after submit, Weather section does **not** appear
- [ ] On a night with moon interference on all targets, Prime Targets shows no count badge and the dropdown shows the "No non-Milky-Way targets meet prime criteria" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)