### PR TITLE
perf(find_nearby): parallel geocoding, pooled client, dedup, Overpass fix (Tier 0)

### DIFF
--- a/PyNightSkyPredictor/cache.py
+++ b/PyNightSkyPredictor/cache.py
@@ -254,12 +254,41 @@ class DynamoCache:
         return count
 
 
+# ── Hit/miss instrumentation ────────────────────────────────────────────────
+# A single global counter on the module-level get() chokepoint. Two int adds per
+# lookup — negligible always-on cost — so profilers (see darksky.find_nearby) can
+# attribute time to cache misses without threading a stats object through callers.
+# A non-None return counts as a hit; None (missing OR expired) counts as a miss.
+
+class _CacheStats:
+    __slots__ = ("hits", "misses")
+
+    def __init__(self):
+        self.hits = 0
+        self.misses = 0
+
+    def reset(self) -> None:
+        self.hits = 0
+        self.misses = 0
+
+    def snapshot(self) -> tuple[int, int]:
+        return self.hits, self.misses
+
+
+stats = _CacheStats()
+
+
 # ── Module-level API (delegates to the active backend) ──────────────────────
 # Callers use cache.get(...) / cache.set(...) etc.; these thin wrappers keep that
 # surface stable while the underlying store is backend-selected via ports.
 
 def get(key: str):
-    return ports.get_backend().cache.get(key)
+    value = ports.get_backend().cache.get(key)
+    if value is None:
+        stats.misses += 1
+    else:
+        stats.hits += 1
+    return value
 
 
 def get_stale(key: str):

--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -24,6 +24,7 @@ SQM conversions
   Falchi : SQM = 22.08 − 2.5 × log10((La+0.252)/0.252)  (La in mcd/m²)
 """
 
+import contextlib
 import io
 import json
 import logging
@@ -31,6 +32,7 @@ import math
 import os
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
 import urllib.request
 import zipfile
@@ -456,6 +458,18 @@ _DIRS_16 = [
 
 _MAX_SEARCH_RADIUS  = 150   # beyond this the Overpass query grows unreliable and driving isn't practical
 
+# Tier-3 (Nominatim) spatial pre-dedup radius. A dark candidate within this many
+# miles of an already-named result is skipped without a network probe, because
+# adjacent dark pixels reverse-geocode to the same settlement. Matches the
+# long-standing _cluster_points default so it never collapses sites further apart
+# than the clustering stage already treats as distinct.
+_NAME_DEDUP_MILES = 8.0
+
+# Main public Overpass instance. The overpass.private.coffee mirror was tried but
+# is unreachable (connections hang to timeout); other community mirrors
+# (kumi.systems, openstreetmap.ru, mail.ru) also failed to respond, while
+# overpass-api.de answers the areas-in-radius query reliably (~7-8 s). Respect its
+# usage policy via the self-throttle below.
 _OVERPASS_URL    = "https://overpass-api.de/api/interpreter"
 _NOMINATIM_URL   = "https://nominatim.openstreetmap.org/reverse"
 _OVER_WATER      = "__water__"   # sentinel: Nominatim found no state/county — ocean or large water body
@@ -465,7 +479,7 @@ _GEO_CACHE_TTL   = 90 * 24 * 3600   # 90 days
 _PADUS_H3_FILENAME = "darkhours_padus_h3.parquet"
 _PADUS_UNAVAILABLE = object()   # singleton: tried to load, file missing or unreadable
 _padus_h3_cache: "dict | object | None" = None  # None = not yet attempted
-_OVERPASS_SLEEP  = 1.0               # minimum seconds between Overpass requests
+_OVERPASS_SLEEP  = 1.0               # minimum seconds between Overpass requests (overpass-api.de policy)
 _NOMINATIM_SLEEP = 1.1               # minimum seconds between Nominatim requests
 
 # Thread-safe rate-limit state
@@ -484,6 +498,49 @@ _AREA_PRIORITY = {
 }
 
 
+# Reverse-geocode fan-out width for backends with no per-second policy (AWS Location).
+# Each find_nearby on the aws backend issues at most this many concurrent geocode
+# calls; keep it modest so aggregate TPS across concurrent worker Lambdas stays under
+# the SearchPlaceIndexForPosition service quota (default ~50 req/s, raisable).
+_GEOCODE_MAX_WORKERS = int(os.environ.get("PYNIGHTSKY_GEOCODE_WORKERS", "8"))
+
+# Shared boto3 'location' client (built once per process, reused across calls and
+# threads). Rebuilding it per call reloads the service model and discards the HTTP
+# connection pool — paying a fresh TLS handshake every request. botocore low-level
+# clients are thread-safe for calls, so a single pooled client backs the parallel
+# reverse-geocode fan-out. Double-checked locking guards the one-time construction.
+_location_client = None
+_location_client_lock = threading.Lock()
+
+
+def _location():
+    """Return the process-wide AWS Location client, building it lazily once."""
+    global _location_client
+    if _location_client is None:
+        with _location_client_lock:
+            if _location_client is None:
+                import boto3
+                from botocore.config import Config
+                region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+                _location_client = boto3.client(
+                    "location",
+                    region_name=region,
+                    # Pool ≥ fan-out width so parallel calls don't queue on connections;
+                    # adaptive retries absorb ThrottlingException near the TPS quota.
+                    config=Config(
+                        max_pool_connections=max(_GEOCODE_MAX_WORKERS + 2, 10),
+                        retries={"max_attempts": 5, "mode": "adaptive"},
+                    ),
+                )
+    return _location_client
+
+
+def _reset_location_client() -> None:
+    """Drop the cached AWS Location client (used by tests, mirrors ports.reset_backend)."""
+    global _location_client
+    _location_client = None
+
+
 def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> None:
     """Annotate each cluster dict with drive_minutes (int | None) via AWS Location route matrix.
 
@@ -492,10 +549,9 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
     """
     if not clusters:
         return
-    import boto3
     calc_name = os.environ.get("PYNIGHTSKY_ROUTE_CALCULATOR", "pynightsky-route-calculator")
     try:
-        client = boto3.client("location")
+        client = _location()
         resp = client.calculate_route_matrix(
             CalculatorName=calc_name,
             DeparturePositions=[[origin_lon, origin_lat]],
@@ -1146,8 +1202,6 @@ def _aws_location_settlement(lat: float, lon: float) -> str | None:
     _OVER_WATER sentinel / None.  Results are cached identically so the
     two implementations are interchangeable.
     """
-    import boto3
-
     cache_key = f"nominatim_rev|{lat:.3f}|{lon:.3f}"   # reuse same cache namespace
     cached = cache.get(cache_key)
     if cached is not None:
@@ -1155,7 +1209,7 @@ def _aws_location_settlement(lat: float, lon: float) -> str | None:
 
     index_name = os.environ.get("PYNIGHTSKY_PLACE_INDEX", "pynightsky-place-index")
     try:
-        client = boto3.client("location")
+        client = _location()
         resp = client.search_place_index_for_position(
             IndexName=index_name,
             Position=[lon, lat],        # AWS expects [lon, lat]
@@ -1325,6 +1379,79 @@ def _is_in_us(lat: float, lon: float) -> bool:
     return (18.0 <= lat <= 72.0) and (-180.0 <= lon <= -66.0)
 
 
+def _offline_tier_name(
+    c: dict,
+    padus_index: "dict | None",
+    natural_areas: "list | None",
+) -> "tuple[str, str | None]":
+    """Resolve the offline naming tiers (1 PAD-US, 2 Overpass) for one candidate.
+
+    Returns one of:
+      ("discard", None) — PAD-US blacklisted cell (military/tribal/restricted land).
+      ("name", str)     — named by PAD-US (good Unit_Nm) or an Overpass area match.
+      ("tier3", None)   — needs the network reverse-geocoder (Tier 3).
+
+    No I/O beyond the in-memory PAD-US index and Overpass area list, so it is cheap
+    to call twice (prefetch planning + the main loop).
+    """
+    lat, lon = c["lat"], c["lon"]
+    padus_verified = False
+    if padus_index is not None:
+        try:
+            hit = _padus_h3_lookup(lat, lon, padus_index)
+            if hit is not None:
+                unit_nm, is_blacklisted = hit
+                if is_blacklisted:
+                    return ("discard", None)  # hard stop: restricted land
+                padus_verified = True
+                if _is_good_padus_name(unit_nm):
+                    return ("name", unit_nm)  # optimal hit: no network needed
+        except Exception as exc:
+            log.debug("PAD-US H3 lookup failed (%.4f, %.4f): %s", lat, lon, exc)
+            # treat as miss → fall through to Tier 2
+    # Tier 2 only when PAD-US had no polygon hit; never discard on an Overpass miss.
+    if not padus_verified and natural_areas:
+        nm = _best_area_name_for_cluster(lat, lon, natural_areas)
+        if nm:
+            return ("name", nm)
+    return ("tier3", None)
+
+
+def _parallel_prefetch_settlements(
+    candidates: list,
+    padus_index: "dict | None",
+    natural_areas: "list | None",
+) -> dict:
+    """Concurrently reverse-geocode the spatially-distinct Tier-3 candidates.
+
+    Used only on backends with no per-second policy (AWS Location). Candidates that
+    Tiers 1-2 already name or discard are excluded; the remainder are clustered at
+    _NAME_DEDUP_MILES so only one representative per ~8 mi area is fetched (mirroring
+    the serial path's spatial dedup), and those reps are geocoded in parallel.
+
+    Returns {(round(lat,3), round(lon,3)): settlement_result}, where the value is
+    whatever _settlement returned (a name / "" / None / _OVER_WATER). The main loop
+    reads names from this map instead of issuing the calls serially.
+    """
+    need = [c for c in candidates
+            if _offline_tier_name(c, padus_index, natural_areas)[0] == "tier3"]
+    if not need:
+        return {}
+    reps = _cluster_points(need, merge_miles=_NAME_DEDUP_MILES)
+    out: dict = {}
+    workers = min(_GEOCODE_MAX_WORKERS, len(reps))
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(_settlement, c["lat"], c["lon"]): c for c in reps}
+        for fut in futures:
+            c = futures[fut]
+            try:
+                out[(round(c["lat"], 3), round(c["lon"], 3))] = fut.result()
+            except Exception as exc:
+                log.debug("parallel settlement failed (%.4f, %.4f): %s",
+                          c["lat"], c["lon"], exc)
+    return out
+
+
 def _jit_geocode_candidates(
     candidates: list,
     max_results: int,
@@ -1333,60 +1460,60 @@ def _jit_geocode_candidates(
     padus_index: "dict | None" = None,
     exclude: "set[str] | None" = None,
 ) -> list:
-    """Reverse-geocode candidates one-at-a-time using a three-tier strategy.
+    """Reverse-geocode candidates with a three-tier naming strategy.
 
     Tier 1 — PAD-US H3 spatial index (when padus_index is not None):
       Blacklisted cell      → candidate discarded (military/tribal/restricted).
       Non-blacklisted + good Unit_Nm → name used; Overpass and _settlement() skipped.
       Non-blacklisted + junk Unit_Nm → PAD-US-verified; falls to Tier 3 for naming.
       No PAD-US cell hit    → falls to Tier 2.
-      Exception             → logged; candidate treated as a PAD-US miss.
 
-    Tier 2 — Overpass natural areas (for naming only, not gating):
-      Only reached when PAD-US had no polygon hit (padus_verified still False).
-      Skipped entirely when PAD-US found a polygon (the land is already verified).
-      Match found   → use Overpass area name directly.
-      No match      → fall through to Tier 3 (never discard on Overpass miss).
+    Tier 2 — Overpass natural areas (naming only, not gating):
+      Reached only when PAD-US had no polygon hit. Match → use the area name;
+      no match → fall through to Tier 3 (never discard on an Overpass miss).
 
     Tier 3 — Reverse geocoder (_settlement):
-      Called when name is still None after Tier 1/2.
-      _OVER_WATER → candidate discarded. None → coordinate fallback used.
+      Reached when Tiers 1-2 produced no name. _OVER_WATER → candidate discarded;
+      None → coordinate fallback used.
 
-    Dedup by name: each unique name appears at most once regardless of distance.
-    max_results cap unchanged.
+    Concurrency: the public Nominatim instance (local backend) forbids parallel/bulk
+    access, so it keeps the lazy serial path. On the aws backend (AWS Location, no
+    per-second policy) the Tier-3 calls are prefetched in parallel up front and the
+    loop reads names from memory — see _parallel_prefetch_settlements.
+
+    Dedup: each unique name appears at most once. Tier-3 candidates also get a spatial
+    pre-dedup (see _NAME_DEDUP_MILES) that skips a candidate adjacent to an
+    already-named result. max_results cap unchanged.
     """
     seen_keys: set[str] = set(exclude) if exclude else set()
     dark_clusters: list = []
+    kept_coords: list[tuple[float, float]] = []   # (lat, lon) of accepted results
+
+    # On backends with no per-second policy (AWS Location), fetch the Tier-3 names
+    # concurrently so the loop below resolves them from memory instead of one serial
+    # network round-trip per candidate. Empty on the local/Nominatim backend.
+    prefetch = (_parallel_prefetch_settlements(candidates, padus_index, natural_areas)
+                if ports.get_backend()._name == "aws" else {})
+
     for c in candidates:
         lat, lon = c["lat"], c["lon"]
-        name: str | None = None
-        padus_verified = False
+        kind, name = _offline_tier_name(c, padus_index, natural_areas)
+        if kind == "discard":
+            continue  # PAD-US blacklist: military/tribal/restricted land
 
-        # ── Tier 1: PAD-US H3 spatial index ──────────────────────────────────
-        if padus_index is not None:
-            try:
-                hit = _padus_h3_lookup(lat, lon, padus_index)
-                if hit is not None:
-                    unit_nm, is_blacklisted = hit
-                    if is_blacklisted:
-                        continue  # hard stop: military/tribal/restricted land
-                    padus_verified = True
-                    if _is_good_padus_name(unit_nm):
-                        name = unit_nm  # optimal hit: skip all network calls
-            except Exception as exc:
-                log.debug("PAD-US H3 lookup failed (%.4f, %.4f): %s", lat, lon, exc)
-                # treat as miss → fall through to Tier 2
-
-        # ── Tier 2: Overpass natural areas (naming only, not gating) ─────────
-        # Reached only when PAD-US had no hit (padus_verified still False).
-        # Skipped entirely when PAD-US found a polygon (land already verified).
-        # No match → fall through to Tier 3; never discard on Overpass miss.
-        if name is None and not padus_verified and natural_areas:
-            name = _best_area_name_for_cluster(lat, lon, natural_areas)
-
-        # ── Tier 3: Reverse geocoder ──────────────────────────────────────────
-        if name is None:
-            name = _settlement(lat, lon)
+        if kind == "tier3":
+            # Spatial pre-dedup: skip when within _NAME_DEDUP_MILES of an already-kept
+            # result — adjacent dark pixels reverse-geocode to the same settlement, so
+            # probing them only yields a duplicate name. Profiling a Phoenix search
+            # found 36 of 43 probes were such duplicates (median 5.3 mi from their kept
+            # twin), the single largest contributor to find_nearby latency.
+            if any(_haversine_miles(lat, lon, klat, klon) <= _NAME_DEDUP_MILES
+                   for klat, klon in kept_coords):
+                continue
+            key = (round(lat, 3), round(lon, 3))
+            # Prefetched on aws; otherwise (local, or a non-representative pixel whose
+            # rep was dropped) fall back to a single direct call.
+            name = prefetch[key] if key in prefetch else _settlement(lat, lon)
             if name == _OVER_WATER:
                 continue
             if not name:
@@ -1398,9 +1525,59 @@ def _jit_geocode_candidates(
         seen_keys.add(name)
         c["name"] = name
         dark_clusters.append(c)
+        kept_coords.append((lat, lon))
         if len(dark_clusters) == max_results:
             break
     return dark_clusters
+
+
+# ---------------------------------------------------------------------------
+# find_nearby profiling (opt-in via PYNIGHTSKY_PROFILE=1)
+# ---------------------------------------------------------------------------
+# find_nearby has three very different cost centres — disk-bound raster window
+# reads, CPU-bound numpy/scipy passes, and network-bound reverse-geocoding whose
+# cost is dominated by cache misses (each Nominatim miss waits _NOMINATIM_SLEEP).
+# The profiler attributes wall-clock time to each phase and pairs it with the
+# cache hit/miss delta so a slow run can be diagnosed as "cold cache" vs "slow
+# I/O" vs "CPU". Disabled by default → the phase() context manager is a no-op.
+
+_PROFILE = os.environ.get("PYNIGHTSKY_PROFILE", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+class _Profiler:
+    """Accumulate per-phase wall-clock timings. Near-zero cost when disabled."""
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+        self.timings: list[tuple[str, float]] = []
+        self._cache_start = (0, 0)
+        if enabled:
+            self._cache_start = cache.stats.snapshot()
+
+    @contextlib.contextmanager
+    def phase(self, name: str):
+        if not self.enabled:
+            yield
+            return
+        h0, m0 = cache.stats.snapshot()
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            dt = (time.perf_counter() - t0) * 1000.0
+            h1, m1 = cache.stats.snapshot()
+            self.timings.append((name, dt))
+            log.info("[profile] %-26s %8.1f ms  (cache +%dh/+%dm)",
+                     name, dt, h1 - h0, m1 - m0)
+
+    def report(self) -> None:
+        if not self.enabled:
+            return
+        total = sum(dt for _, dt in self.timings)
+        h, m = cache.stats.snapshot()
+        dh, dm = h - self._cache_start[0], m - self._cache_start[1]
+        log.info("[profile] %-26s %8.1f ms  (cache %dh/%dm this call)",
+                 "TOTAL (sum of phases)", total, dh, dm)
 
 
 def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
@@ -1424,7 +1601,9 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
 
     Returns None if light pollution data is unavailable (rasterio not installed).
     """
-    origin_info = lookup(lat, lon)
+    prof = _Profiler(_PROFILE)
+    with prof.phase("origin lookup"):
+        origin_info = lookup(lat, lon)
     if origin_info is None:
         return None
 
@@ -1447,18 +1626,21 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
     _min_lon, _max_lon = lon - _deg_lon, lon + _deg_lon
 
     # ── Single window read per raster dataset ─────────────────────────────────
-    viirs_arr  = _load_raster_window("viirs",  _min_lat, _max_lat, _min_lon, _max_lon)
-    falchi_arr = _load_raster_window(
-        "falchi", _min_lat, _max_lat, _min_lon, _max_lon,
-        out_shape=viirs_arr.shape if viirs_arr is not None else None,
-    )
+    with prof.phase("viirs window read"):
+        viirs_arr  = _load_raster_window("viirs",  _min_lat, _max_lat, _min_lon, _max_lon)
+    with prof.phase("falchi window read"):
+        falchi_arr = _load_raster_window(
+            "falchi", _min_lat, _max_lat, _min_lon, _max_lon,
+            out_shape=viirs_arr.shape if viirs_arr is not None else None,
+        )
 
     # ── Dark-sky candidates (pure numpy, no scipy required) ───────────────────
-    dark_candidates = _extract_dark_sky_candidates(
-        viirs_arr, falchi_arr,
-        _min_lat, _max_lat, _min_lon, _max_lon,
-        lat, lon, radius_miles, dark_threshold,
-    )
+    with prof.phase("extract dark candidates"):
+        dark_candidates = _extract_dark_sky_candidates(
+            viirs_arr, falchi_arr,
+            _min_lat, _max_lat, _min_lon, _max_lon,
+            lat, lon, radius_miles, dark_threshold,
+        )
 
     # all_darker: any pixel darker than origin — used only for best_available
     # when no proper dark clusters are found.  Computed lazily to avoid
@@ -1471,53 +1653,55 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
     _N_BANDS     = 6     # distance bands used in both extract and cluster selection
 
     # Calculate priority: Bortle 1/2 are "MUST HAVES" (boosted), 3+ are distance-based
-    for pt in dark_candidates:
-        if pt["bortle_class"] <= 2:
-            pt["priority_score"] = pt["distance_miles"] * (radius_miles * 0.25)
-        else:
-            pt["priority_score"] = pt["distance_miles"]
+    with prof.phase("cluster + band select"):
+        for pt in dark_candidates:
+            if pt["bortle_class"] <= 2:
+                pt["priority_score"] = pt["distance_miles"] * (radius_miles * 0.25)
+            else:
+                pt["priority_score"] = pt["distance_miles"]
 
-    dark_candidates.sort(key=lambda p: p["priority_score"])
+        dark_candidates.sort(key=lambda p: p["priority_score"])
 
-    # Cluster spatially (pure CPU) to collapse adjacent pixels into geographic areas.
-    # Then select clusters via stratified distance sampling: take up to _PER_BAND
-    # clusters per distance band (darkest/nearest first within each band).
-    # Without stratification, a nearest-first cap silently drops all distant
-    # dark areas when the entire search radius is one Bortle class (e.g. Bortle 1).
-    _per_band    = max(1, _MAX_DARK_CANDIDATES // _N_BANDS)
-    _band_width  = radius_miles / _N_BANDS
-    all_clusters = _cluster_points(dark_candidates, merge_miles=1) if dark_candidates else []
-    selected: list = []
-    for _band in range(_N_BANDS):
-        _lo, _hi = _band * _band_width, (_band + 1) * _band_width
-        _band_clusters = sorted(
-            [c for c in all_clusters if _lo <= c["distance_miles"] < _hi],
-            key=lambda c: (c["bortle_class"], c["distance_miles"]),
-        )[:_per_band]
-        selected.extend(_band_clusters)
-    dark_candidates = sorted(selected, key=lambda c: (c["bortle_class"], c["distance_miles"]))
+        # Cluster spatially (pure CPU) to collapse adjacent pixels into geographic areas.
+        # Then select clusters via stratified distance sampling: take up to _PER_BAND
+        # clusters per distance band (darkest/nearest first within each band).
+        # Without stratification, a nearest-first cap silently drops all distant
+        # dark areas when the entire search radius is one Bortle class (e.g. Bortle 1).
+        _per_band    = max(1, _MAX_DARK_CANDIDATES // _N_BANDS)
+        _band_width  = radius_miles / _N_BANDS
+        all_clusters = _cluster_points(dark_candidates, merge_miles=1) if dark_candidates else []
+        selected: list = []
+        for _band in range(_N_BANDS):
+            _lo, _hi = _band * _band_width, (_band + 1) * _band_width
+            _band_clusters = sorted(
+                [c for c in all_clusters if _lo <= c["distance_miles"] < _hi],
+                key=lambda c: (c["bortle_class"], c["distance_miles"]),
+            )[:_per_band]
+            selected.extend(_band_clusters)
+        dark_candidates = sorted(selected, key=lambda c: (c["bortle_class"], c["distance_miles"]))
 
     # ── Light dome candidates (scipy blob detection on the same viirs_arr) ─────
     dome_clusters = []
-    if _HAS_SCIPY and viirs_arr is not None:
-        raw_domes = _find_light_domes_from_array(
-            viirs_arr, _min_lat, _max_lat, _min_lon, _max_lon,
-            tier_min_bortle=8,
-        )
-        for dlat, dlon, dbortle in raw_domes:
-            dist  = _haversine_miles(lat, lon, dlat, dlon)
-            if dist < 5:
-                continue
-            if dbortle > origin_bortle and dbortle >= min(origin_bortle + 2, 10):
-                dome_clusters.append({
-                    "lat":            dlat,
-                    "lon":            dlon,
-                    "bortle_class":   dbortle,
-                    "sqm":            None,
-                    "distance_miles": round(dist, 1),
-                    "direction":      _bearing_label(lat, lon, dlat, dlon),
-                    "name":           None,
-                })
+    with prof.phase("light dome detection"):
+        if _HAS_SCIPY and viirs_arr is not None:
+            raw_domes = _find_light_domes_from_array(
+                viirs_arr, _min_lat, _max_lat, _min_lon, _max_lon,
+                tier_min_bortle=8,
+            )
+            for dlat, dlon, dbortle in raw_domes:
+                dist  = _haversine_miles(lat, lon, dlat, dlon)
+                if dist < 5:
+                    continue
+                if dbortle > origin_bortle and dbortle >= min(origin_bortle + 2, 10):
+                    dome_clusters.append({
+                        "lat":            dlat,
+                        "lon":            dlon,
+                        "bortle_class":   dbortle,
+                        "sqm":            None,
+                        "distance_miles": round(dist, 1),
+                        "direction":      _bearing_label(lat, lon, dlat, dlon),
+                        "name":           None,
+                    })
 
     # Take 2× the display limit so dedup has buffer to fill _MAX_DOMES unique names.
     dome_clusters = sorted(dome_clusters, key=lambda p: (-p["bortle_class"], p["distance_miles"]))[:_MAX_DOMES * 2]
@@ -1528,38 +1712,41 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
 
     best_available = None
     best_candidate = None
-    if not dark_candidates and origin_bortle > 1:
-        # Lazy: only run the second numpy pass when there are no proper dark clusters.
-        # Uses a looser threshold (anything darker than origin) to find a fallback.
-        all_darker = _extract_dark_sky_candidates(
-            viirs_arr, falchi_arr,
-            _min_lat, _max_lat, _min_lon, _max_lon,
-            lat, lon, radius_miles, dark_threshold=origin_bortle - 1,
-        )
-    if all_darker:
-        best_candidate = sorted(
-            all_darker, key=lambda p: (p["bortle_class"], p["distance_miles"])
-        )[0]
+    with prof.phase("best-available numpy pass"):
+        if not dark_candidates and origin_bortle > 1:
+            # Lazy: only run the second numpy pass when there are no proper dark clusters.
+            # Uses a looser threshold (anything darker than origin) to find a fallback.
+            all_darker = _extract_dark_sky_candidates(
+                viirs_arr, falchi_arr,
+                _min_lat, _max_lat, _min_lon, _max_lon,
+                lat, lon, radius_miles, dark_threshold=origin_bortle - 1,
+            )
+        if all_darker:
+            best_candidate = sorted(
+                all_darker, key=lambda p: (p["bortle_class"], p["distance_miles"])
+            )[0]
 
     # Resolve the origin's settlement name so it can be excluded from results —
     # there is no point surfacing a dark candidate named after the city you're in.
     # Also exclude the county's principal city (e.g. "Los Angeles, CA" when searching
     # from Culver City), populated as a free side-effect of _nominatim_settlement().
-    _origin_settlement = _settlement(lat, lon)
-    _exclude: set[str] = set()
-    if _origin_settlement and _origin_settlement != _OVER_WATER:
-        _exclude.add(_origin_settlement)
-        # Add sub-region/county-derived city to catch mismatches where the origin
-        # reverse-geocodes to a different granularity than nearby candidates.
-        # _settlement() side-populates nominatim_county|... for both backends.
-        _county_city = _get_nominatim_county_city(lat, lon)
-        if _county_city:
-            _exclude.add(_county_city)
+    with prof.phase("origin settlement"):
+        _origin_settlement = _settlement(lat, lon)
+        _exclude: set[str] = set()
+        if _origin_settlement and _origin_settlement != _OVER_WATER:
+            _exclude.add(_origin_settlement)
+            # Add sub-region/county-derived city to catch mismatches where the origin
+            # reverse-geocodes to a different granularity than nearby candidates.
+            # _settlement() side-populates nominatim_county|... for both backends.
+            _county_city = _get_nominatim_county_city(lat, lon)
+            if _county_city:
+                _exclude.add(_county_city)
 
     # Load PAD-US H3 index once per search (US searches only — PAD-US is US-only data).
     # Candidates are already land-filtered by _extract_dark_sky_candidates(_glm.is_land()),
     # so the PAD-US check here is the first spatial tier, not a water filter.
-    _padus_index = _load_padus_h3_index() if _is_in_us(lat, lon) else None
+    with prof.phase("padus index load"):
+        _padus_index = _load_padus_h3_index() if _is_in_us(lat, lon) else None
 
     # Fetch Overpass natural areas in background while dome naming runs.
     # One network call covers the entire search radius; all cluster matching
@@ -1574,64 +1761,71 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
         areas_thread.start()
 
     # Name light domes (main thread — gives Overpass time to complete)
-    for dome in dome_clusters:
-        dome_name = _settlement(dome["lat"], dome["lon"])
-        dome["name"] = dome_name or f"{dome['lat']:.2f}°, {dome['lon']:.2f}°"
+    with prof.phase("dome naming (geocode)"):
+        for dome in dome_clusters:
+            dome_name = _settlement(dome["lat"], dome["lon"])
+            dome["name"] = dome_name or f"{dome['lat']:.2f}°, {dome['lon']:.2f}°"
 
-    # Deduplicate by name; list is sorted by (bortle desc, distance asc) so we keep
-    # the nearest occurrence of each city name.
-    _seen_dome_names: set[str] = set()
-    _deduped_domes: list = []
-    for dome in dome_clusters:
-        if dome["name"] not in _seen_dome_names:
-            _seen_dome_names.add(dome["name"])
-            _deduped_domes.append(dome)
-    dome_clusters = _deduped_domes[:_MAX_DOMES]
+        # Deduplicate by name; list is sorted by (bortle desc, distance asc) so we keep
+        # the nearest occurrence of each city name.
+        _seen_dome_names: set[str] = set()
+        _deduped_domes: list = []
+        for dome in dome_clusters:
+            if dome["name"] not in _seen_dome_names:
+                _seen_dome_names.add(dome["name"])
+                _deduped_domes.append(dome)
+        dome_clusters = _deduped_domes[:_MAX_DOMES]
 
     if _use_overpass:
-        areas_thread.join(timeout=_OVERPASS_JOIN_TIMEOUT_S)
-        if areas_thread.is_alive():
-            log.warning("Overpass join timed out after %ss; falling back to geocoding only",
-                        _OVERPASS_JOIN_TIMEOUT_S)
+        with prof.phase("overpass join (net)"):
+            areas_thread.join(timeout=_OVERPASS_JOIN_TIMEOUT_S)
+            if areas_thread.is_alive():
+                log.warning("Overpass join timed out after %ss; falling back to geocoding only",
+                            _OVERPASS_JOIN_TIMEOUT_S)
 
     # 1. Name the best_candidate separately if it exists
     if best_candidate:
-        name = _best_area_name_for_cluster(best_candidate["lat"], best_candidate["lon"], natural_areas) or \
-               _settlement(best_candidate["lat"], best_candidate["lon"])
-        best_candidate["name"] = None if name == _OVER_WATER else (name or f"{best_candidate['lat']:.2f}°, {best_candidate['lon']:.2f}°")
-        if best_candidate["name"] is not None:
-            best_available = best_candidate
+        with prof.phase("best-candidate naming"):
+            name = _best_area_name_for_cluster(best_candidate["lat"], best_candidate["lon"], natural_areas) or \
+                   _settlement(best_candidate["lat"], best_candidate["lon"])
+            best_candidate["name"] = None if name == _OVER_WATER else (name or f"{best_candidate['lat']:.2f}°, {best_candidate['lon']:.2f}°")
+            if best_candidate["name"] is not None:
+                best_available = best_candidate
 
     # 2. JIT: geocode and deduplicate dark candidates, stop at _MAX_RESULTS
     # Pass natural_areas=None (not []) when Overpass is disabled so the Tier 2 discard
     # gate is bypassed — an empty list would incorrectly discard all non-PAD-US candidates
     # on the AWS backend where Overpass is not used.
-    dark_clusters = _jit_geocode_candidates(
-        dark_candidates, _MAX_RESULTS,
-        natural_areas if _use_overpass else None,
-        padus_index=_padus_index,
-        exclude=_exclude,
-    )
+    with prof.phase("jit geocode candidates"):
+        dark_clusters = _jit_geocode_candidates(
+            dark_candidates, _MAX_RESULTS,
+            natural_areas if _use_overpass else None,
+            padus_index=_padus_index,
+            exclude=_exclude,
+        )
 
     if best_candidate is not None:
         best_available = best_candidate
 
     # Drive-time annotation (AWS backend only)
-    needs_drive = dark_clusters + ([best_available] if best_available else [])
-    if ports.get_backend()._name == "aws":
-        _aws_drive_times(lat, lon, needs_drive)
+    with prof.phase("drive times (aws)"):
+        needs_drive = dark_clusters + ([best_available] if best_available else [])
+        if ports.get_backend()._name == "aws":
+            _aws_drive_times(lat, lon, needs_drive)
 
-        # Sky quality first; drive time is only a tie-breaker for identical bortle_class
-        needs_drive.sort(key=lambda c: (
-            c["bortle_class"],
-            c["drive_minutes"] if c["drive_minutes"] is not None else 999,
-        ))
-        # Re-assign back to dark_clusters (excluding the best_available)
-        dark_clusters = needs_drive[:len(dark_clusters)]
-    else:
-        # Keep existing distance-based sort for local backend
-        for c in needs_drive:
-            c["drive_minutes"] = None
+            # Sky quality first; drive time is only a tie-breaker for identical bortle_class
+            needs_drive.sort(key=lambda c: (
+                c["bortle_class"],
+                c["drive_minutes"] if c["drive_minutes"] is not None else 999,
+            ))
+            # Re-assign back to dark_clusters (excluding the best_available)
+            dark_clusters = needs_drive[:len(dark_clusters)]
+        else:
+            # Keep existing distance-based sort for local backend
+            for c in needs_drive:
+                c["drive_minutes"] = None
+
+    prof.report()
 
     # --- CHANGED: has_dark_sky logic ---
     return {

--- a/PyNightSkyPredictor/location.py
+++ b/PyNightSkyPredictor/location.py
@@ -143,11 +143,11 @@ def _geocode_via_nominatim(name: str, query: str) -> dict | None:
 
 def _geocode_via_aws(name: str, query: str) -> dict | None:
     """Forward-geocode using AWS Location Service (aws backend only)."""
-    import boto3
+    from . import darksky  # reuse the process-wide pooled 'location' client
     index_name = os.environ.get("PYNIGHTSKY_PLACE_INDEX", "pynightsky-place-index")
     log.debug("Cache miss for '%s', geocoding via AWS Location (query: '%s')...", name, query)
     try:
-        client = boto3.client("location")
+        client = darksky._location()
         resp = client.search_place_index_for_text(
             IndexName=index_name,
             Text=query,

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -1,0 +1,113 @@
+# find_nearby Performance — Profiling Results & Recommendations
+
+Record of the 2026-06-09 performance investigation into `darksky.find_nearby`.
+Reproduce with the tooling in `scripts/` (see bottom).
+
+## TL;DR
+
+`find_nearby` was network-bound on cold searches: ~85–95% of wall time was reverse
+geocoding + an Overpass call that always timed out. Two bugs were fixed and two
+optimizations shipped; a real worker run then showed the bottleneck has **moved to
+cold-start CPU cost** (PAD-US index load), not the network.
+
+## Instrumentation (kept, opt-in)
+
+- `cache.stats` — hit/miss counter at the `cache.get` chokepoint (`cache.py`).
+- Per-phase profiler in `find_nearby`, enabled with `PYNIGHTSKY_PROFILE=1`; logs each
+  phase's wall time + cache hit/miss delta (`darksky.py`).
+
+## Baseline (local backend, radius 60 mi, city-centre origins)
+
+| Origin | Wall | cache hit-rate | Note |
+|---|---:|---:|---|
+| Los Angeles | 28.9 s | 0% | cold |
+| New York | 26.4 s | 9% | |
+| Chicago | 27.5 s | 8% | |
+| Denver | 1.3 s | 50% | Overpass result cached |
+| Phoenix | 62.0 s | 2% | 42 geocode misses |
+| Atlanta | 36.0 s | 5% | |
+| LA (repeat, warm) | 1.3 s | 92% | everything cached |
+
+Representative phase breakdown (LA cold, 28.9 s): `overpass join` **15007 ms** (timeout
+every call), `jit geocode candidates` **9421 ms** (9 Nominatim misses × ~1.1 s),
+`padus index load` 2306 ms (one-time), `light dome detection` 937 ms, raster reads ~280 ms.
+
+### Root causes
+1. **Dead Overpass endpoint.** `overpass.private.coffee` (in the working tree) was
+   unreachable → a guaranteed 15 s join timeout, and zero natural-area names. Only
+   `overpass-api.de` of the mirrors tested responded (~7.6 s).
+2. **Duplicate-dominated reverse geocoding.** Nominatim is 1.1 s/miss and serial; on
+   Phoenix **36 of 43 probes were duplicate town names** (adjacent dark pixels → same
+   settlement, median 5.3 mi apart).
+
+## Fixes shipped (Tier 0)
+
+| Change | Effect |
+|---|---|
+| Revert Overpass URL to `overpass-api.de` | 15 s timeout → ~7.6 s, real names (local/CLI backend only; aws disables Overpass) |
+| 8-mi geocode pre-dedup (`_NAME_DEDUP_MILES`) | Phoenix cold probes 43 → 25 (−42%) |
+| **A:** parallel reverse-geocode on aws backend | ~4× (see below); forbidden on Nominatim by policy, so aws-only |
+| **B:** pooled, reused boto3 `location` client | no per-call client rebuild / dropped connection pool |
+
+## Real worker validation (aws backend, in-region Lambda)
+
+Built the worker image from the working tree, deployed an isolated
+`pynightsky-worker-proftest` Lambda (x86_64, 2 GB, reused worker role,
+`PYNIGHTSKY_PROFILE=1`), invoked via synthetic SQS event, read CloudWatch, tore down.
+
+| Run | `jit geocode candidates` | cold misses | effective/call |
+|---|---:|---:|---:|
+| Serial (Phoenix, workers=1) | 1746 ms | 20 | ~87 ms |
+| Parallel (Dallas, workers=8) | 339 ms | 16 | ~21 ms |
+
+- **AWS Location ≈ 87 ms/call in-region** (vs 1.1 s on public Nominatim).
+- **Parallel geocode ≈ 4×**, matching the offline 4.8× (`scripts/profile_parallel_geocode.py`).
+- **New dominant cold cost: `padus index load` = 5–24 s per cold container** (parquet→dict
+  build, CPU-bound; ~2.3 s on a laptop, much slower on throttled Lambda vCPU). Once per
+  container.
+- The 10 s init pre-warm (`_prewarm_rasters`) **timed out**, so the first job still pays
+  cold S3 COG reads.
+- Net: with parallel geocode in, `find_nearby` on the worker is **cold-start/CPU-bound**.
+
+## Provider latency reference
+
+| Provider | Use | Observed latency |
+|---|---|---|
+| AWS Location (SearchPlaceIndexForPosition) | reverse geocode (aws) | ~87 ms/call in-region |
+| Nominatim | reverse/forward geocode (local) | ~1.1 s/call (self-throttled; policy: 1 req/s, no parallel) |
+| Overpass (`overpass-api.de`) | natural-area names (local) | ~7.6 s/query |
+| Open-Meteo / 7Timer | weather | sub-second |
+| Celestrak | TLEs | sub-second |
+
+Live connectivity for every provider is covered by `tests/test_provider_smoke.py`
+(`PYNIGHTSKY_LIVE=1 pytest -m live`).
+
+## Recommendations (prioritized)
+
+**Tier 0 — done (this change):** Overpass fix, 8-mi dedup, A (parallel geocode), B (pooled client).
+
+**Tier 1 — high impact, low effort**
+1. Bump worker Lambda memory (2 GB → 3–4 GB): vCPU scales with memory; cuts the CPU-bound
+   PAD-US load, dome detection, numpy, and init. One-line CDK change.
+2. Pre-build the PAD-US index into a load-optimized format (pickled dict / int-keyed H3
+   cells) so cold load is a deserialize, not a CPU loop. Biggest cold-start win.
+
+**Tier 2 — high impact, medium effort**
+3. Load only the regional PAD-US subset covering the search bbox (partitioned parquet or
+   DynamoDB-by-cell) instead of the whole US index per container.
+4. Resolve the init pre-warm timeout: drop the prewarm and rely on VSI cache after job 1,
+   or use provisioned concurrency if job latency is user-visible.
+
+**Tier 3 — medium**
+5. Speed up scipy dome detection (2–4.5 s): downsample the window, or cache per coarse origin.
+6. Pre-warm the geocode cache for popular origins (reuse the EventBridge warmer pattern).
+7. Request an AWS Location TPS quota increase before scaling parallel geocode widely
+   (~50 req/s account default; adaptive retries already cushion bursts).
+
+## Reproduce
+
+- `scripts/profile_find_nearby.py` — per-phase profile across cities (warm + `--cold`).
+- `scripts/diag_geocode_waste.py` — classify reverse-geocode probes (kept/duplicate/water).
+- `scripts/profile_parallel_geocode.py` — offline serial-vs-parallel A/B (stubbed latency).
+- `scripts/profile_aws.sh` + `scripts/aws_one_search.py` — run one search against the real
+  aws backend with profiling (needs an authenticated session).

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ markers =
     eph: marks tests requiring the de421.bsp ephemeris file (skip with -m "not eph")
     aws: integration tests hitting real AWS (skipped unless PYNIGHTSKY_CACHE_TABLE +
          PYNIGHTSKY_RASTER_BUCKET + credentials are set; run with -m aws)
+    live: smoke tests hitting real external provider APIs (Open-Meteo, 7Timer,
+         Celestrak, Nominatim, AWS Location; skipped unless PYNIGHTSKY_LIVE=1)

--- a/scripts/aws_one_search.py
+++ b/scripts/aws_one_search.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run a single find_nearby against the REAL aws backend, with profiling.
+
+Intended to be launched via scripts/profile_aws.sh (which sets the resource env
+vars). Makes live AWS calls: S3 range-reads of the COGs, DynamoDB cache get/set,
+AWS Location reverse-geocode + route matrix. All small/within free tier; the only
+writes are geocode entries into the shared prod cache (intended, beneficial).
+"""
+import argparse
+import logging
+import time
+
+from PyNightSkyPredictor import cache, darksky, ports
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lat", type=float, default=33.4484)      # Phoenix, AZ (worst case earlier)
+    ap.add_argument("--lon", type=float, default=-112.0740)
+    ap.add_argument("--radius", type=int, default=60)
+    ap.add_argument("--workers", type=int, help="override PYNIGHTSKY_GEOCODE_WORKERS")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    if args.workers:
+        darksky._GEOCODE_MAX_WORKERS = args.workers
+
+    backend = ports.get_backend()._name
+    print(f"backend={backend}  geocode_workers={darksky._GEOCODE_MAX_WORKERS}  "
+          f"({args.lat}, {args.lon}) r={args.radius}mi")
+    if backend != "aws":
+        print("!! backend is not 'aws' — set PYNIGHTSKY_BACKEND=aws (use scripts/profile_aws.sh)")
+        return
+
+    cache.stats.reset()
+    t0 = time.perf_counter()
+    res = darksky.find_nearby(args.lat, args.lon, args.radius)
+    wall = (time.perf_counter() - t0) * 1000.0
+    h, m = cache.stats.snapshot()
+
+    if res is None:
+        print("find_nearby returned None (raster/data unavailable)")
+        return
+    print(f"\nwall={wall:.1f} ms  origin Bortle {res['origin_bortle']}  "
+          f"results={len(res['results'])}  domes={len(res['light_domes'])}  "
+          f"cache {h}h/{m}m")
+    print("results:")
+    for r in res["results"]:
+        dm = r.get("drive_minutes")
+        print(f"  B{r['bortle_class']}  {r['distance_miles']:>5} mi  "
+              f"{(str(dm) + ' min') if dm is not None else '   -   '}  {r['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diag_geocode_waste.py
+++ b/scripts/diag_geocode_waste.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Classify why _jit_geocode_candidates burns Nominatim calls for a bright origin.
+
+Wraps _settlement to tag every Tier-3 probe as water / none / duplicate / kept,
+then runs find_nearby against a fresh cache so every probe is a live call.
+"""
+import os, sys, tempfile
+from collections import Counter
+from pathlib import Path
+
+os.environ["PYNIGHTSKY_PROFILE"] = "0"
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from PyNightSkyPredictor import cache, darksky, ports  # noqa: E402
+
+LAT, LON, RADIUS = 33.4484, -112.0740, 60   # Phoenix, AZ
+
+tally = Counter()
+seen_names: dict[str, tuple[float, float]] = {}   # name -> first (lat, lon) kept
+dup_dists: list[float] = []                        # duplicate's dist to its kept twin
+_orig = darksky._settlement
+
+
+def _traced(lat, lon):
+    r = _orig(lat, lon)
+    if r == darksky._OVER_WATER:
+        tally["water"] += 1
+    elif not r:
+        tally["none(coord-fallback)"] += 1
+    elif r in seen_names:
+        tally["duplicate"] += 1
+        klat, klon = seen_names[r]
+        dup_dists.append(darksky._haversine_miles(lat, lon, klat, klon))
+    else:
+        tally["kept"] += 1
+        seen_names[r] = (lat, lon)
+    return r
+
+
+darksky._settlement = _traced
+
+backend = ports.get_backend()
+with tempfile.TemporaryDirectory() as tmp:
+    backend._cache = cache.LocalFileCache(Path(tmp))
+    darksky._bortle_mem_cache.clear()
+    cache.stats.reset()
+    res = darksky.find_nearby(LAT, LON, RADIUS)
+    h, m = cache.stats.snapshot()
+
+print(f"Phoenix radius={RADIUS}  results={len(res['results'])}  domes={len(res['light_domes'])}")
+print(f"cache: {h} hits / {m} misses")
+print("Tier-3 _settlement probe classification:")
+for k, v in tally.most_common():
+    print(f"  {k:24s} {v}")
+print(f"  {'TOTAL probes':24s} {sum(tally.values())}")
+if dup_dists:
+    dup_dists.sort()
+    import statistics
+    print(f"duplicate→kept distance (mi): min={dup_dists[0]:.1f} "
+          f"median={statistics.median(dup_dists):.1f} max={dup_dists[-1]:.1f}")
+    for thr in (2, 5, 8, 12, 20):
+        n = sum(1 for d in dup_dists if d <= thr)
+        print(f"  dups within {thr:2d} mi of kept twin: {n}/{len(dup_dists)}")

--- a/scripts/profile_aws.sh
+++ b/scripts/profile_aws.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Profile find_nearby against the REAL aws backend with profiling on.
+#
+# Prereqs:
+#   1. An authenticated AWS session (e.g. `aws sso login --profile <p>` / `aws login`).
+#   2. Export the deployment resource names (kept out of source on purpose):
+#        export PYNIGHTSKY_RASTER_BUCKET=<your raster bucket>
+#        export PYNIGHTSKY_CACHE_TABLE=<your cache table>
+#      (place index / route calculator default to the CDK names; override if changed.)
+#
+# Usage:
+#   scripts/profile_aws.sh                                  # Phoenix, 60 mi
+#   scripts/profile_aws.sh --lat 34.05 --lon -118.24 --radius 60
+#   scripts/profile_aws.sh --workers 1                      # serial baseline
+#
+# Makes live, billable (tiny / free-tier) AWS calls and writes geocode entries
+# into the shared cache.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export AWS_PROFILE="${AWS_PROFILE:-default}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+export PYNIGHTSKY_BACKEND=aws
+export PYNIGHTSKY_RASTER_BUCKET="${PYNIGHTSKY_RASTER_BUCKET:?set PYNIGHTSKY_RASTER_BUCKET to your raster bucket}"
+export PYNIGHTSKY_CACHE_TABLE="${PYNIGHTSKY_CACHE_TABLE:?set PYNIGHTSKY_CACHE_TABLE to your cache table}"
+export PYNIGHTSKY_PLACE_INDEX="${PYNIGHTSKY_PLACE_INDEX:-pynightsky-place-index}"
+export PYNIGHTSKY_ROUTE_CALCULATOR="${PYNIGHTSKY_ROUTE_CALCULATOR:-pynightsky-route-calculator}"
+export PYNIGHTSKY_PROFILE=1
+
+echo "Authenticated as: $(aws sts get-caller-identity --query Arn --output text)"
+exec .venv/bin/python scripts/aws_one_search.py "$@"

--- a/scripts/profile_find_nearby.py
+++ b/scripts/profile_find_nearby.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Profiling harness for darksky.find_nearby.
+
+Runs find_nearby against a set of central (city-centre) origins and prints the
+per-phase wall-clock breakdown emitted by the in-code profiler, alongside the
+cache hit/miss delta for each call.
+
+  WARM pass  — uses the existing on-disk geocode cache (the typical steady state).
+  COLD pass  — redirects the cache to a throwaway temp dir and drops in-process
+               caches, so every reverse-geocode is a miss and real network calls
+               are made. This exposes the worst-case naming cost.
+
+Usage:
+    .venv/bin/python scripts/profile_find_nearby.py            # warm, all cities
+    .venv/bin/python scripts/profile_find_nearby.py --cold     # + one cold run
+    .venv/bin/python scripts/profile_find_nearby.py --radius 100
+"""
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+os.environ.setdefault("PYNIGHTSKY_PROFILE", "1")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PyNightSkyPredictor import cache, darksky, ports  # noqa: E402
+
+darksky._PROFILE = True  # force on even if env was set late
+
+# City-centre origins — deliberately bright (Bortle 7-9) so the full naming /
+# dome-detection path runs (a rural origin short-circuits much of it).
+LOCATIONS = [
+    ("Los Angeles, CA", 34.0522, -118.2437),
+    ("New York, NY",    40.7128,  -74.0060),
+    ("Chicago, IL",     41.8781,  -87.6298),
+    ("Denver, CO",      39.7392, -104.9903),
+    ("Phoenix, AZ",     33.4484, -112.0740),
+    ("Atlanta, GA",     33.7490,  -84.3880),
+]
+
+
+def _run(label, lat, lon, radius):
+    print(f"\n{'=' * 72}\n{label}  ({lat}, {lon})  radius={radius} mi\n{'=' * 72}")
+    cache.stats.reset()
+    t0 = time.perf_counter()
+    res = darksky.find_nearby(lat, lon, radius)
+    wall = (time.perf_counter() - t0) * 1000.0
+    h, m = cache.stats.snapshot()
+    if res is None:
+        print("  -> find_nearby returned None (rasterio unavailable?)")
+        return
+    print(f"  wall={wall:8.1f} ms   origin Bortle {res['origin_bortle']}   "
+          f"results={len(res['results'])}  domes={len(res['light_domes'])}  "
+          f"cache {h}h/{m}m  hit-rate={h / max(h + m, 1) * 100:4.0f}%")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--radius", type=int, default=60)
+    ap.add_argument("--cold", action="store_true",
+                    help="also run one origin against a fresh (empty) cache")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    # Quiet the noisy per-pixel/per-call debug logs; we only want [profile] lines.
+    logging.getLogger("PyNightSkyPredictor.darksky").setLevel(logging.INFO)
+
+    print(f"Backend: {ports.get_backend()._name}   "
+          f"PROFILE={darksky._PROFILE}   radius={args.radius} mi")
+
+    # ── WARM pass (existing disk cache) ──────────────────────────────────────
+    print("\n########## WARM PASS (existing on-disk cache) ##########")
+    for label, lat, lon in LOCATIONS:
+        _run(label, lat, lon, args.radius)
+
+    # ── WARM repeat of first city (in-process caches now hot) ────────────────
+    print("\n########## WARM REPEAT (in-process caches hot) ##########")
+    label, lat, lon = LOCATIONS[0]
+    _run(label, lat, lon, args.radius)
+
+    # ── COLD pass (fresh empty cache, real network calls) ────────────────────
+    if args.cold:
+        print("\n########## COLD PASS (empty cache, live network) ##########")
+        backend = ports.get_backend()
+        saved_cache = backend._cache
+        with tempfile.TemporaryDirectory() as tmp:
+            backend._cache = cache.LocalFileCache(Path(tmp))
+            darksky._bortle_mem_cache.clear()
+            label, lat, lon = LOCATIONS[0]
+            _run(label, lat, lon, args.radius)
+        backend._cache = saved_cache
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_parallel_geocode.py
+++ b/scripts/profile_parallel_geocode.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Offline profile of the aws-backend parallel reverse-geocode path (A) + client (B).
+
+Real AWS isn't available here, so _settlement is stubbed with a fixed latency that
+simulates an AWS Location call (no 1.1s Nominatim throttle — AWS has no per-sec policy).
+We run the SAME candidate set through:
+  * local backend  → serial path (one stubbed call at a time)
+  * aws backend    → _parallel_prefetch_settlements fan-out, loop reads from memory
+and compare wall time, call count, and — critically — that the RESULTS are identical.
+Then we check B: _location() returns a cached singleton with the pooled Config.
+"""
+import os
+import sys
+import time
+from copy import deepcopy
+from pathlib import Path
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("PYNIGHTSKY_PLACE_INDEX", "test-index")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PyNightSkyPredictor import darksky, ports  # noqa: E402
+
+SETTLE_LATENCY_S = 0.10   # simulated AWS Location round-trip
+_calls = {"n": 0}
+
+
+def _stub_settlement(lat, lon):
+    """Deterministic name by 0.5° cell so within-cell points share a name (duplicates)."""
+    _calls["n"] += 1
+    time.sleep(SETTLE_LATENCY_S)
+    cell_lat, cell_lon = round(lat * 2), round(lon * 2)
+    return f"Town {cell_lat}_{cell_lon}, ST"
+
+
+def _make_candidates(n_areas=16, per_area=4):
+    """n_areas distinct 0.5°-separated areas, each with per_area points <8mi apart
+    (so spatial dedup collapses each area to one rep). Sorted nearest-first."""
+    cands = []
+    for a in range(n_areas):
+        base_lat = 39.0 + a * 0.6          # 0.6° apart  → distinct cells & >8mi
+        base_lon = -118.0 + a * 0.05
+        for p in range(per_area):
+            cands.append({
+                "lat": base_lat + p * 0.01,    # ~0.7mi steps → same area
+                "lon": base_lon + p * 0.01,
+                "bortle_class": 2,
+                "sqm": 21.8,
+                "distance_miles": round(10 + a * 5 + p * 0.1, 1),
+                "direction": "N",
+                "name": None,
+            })
+    return cands
+
+
+def _run(backend_name, candidates, max_results):
+    os.environ["PYNIGHTSKY_BACKEND"] = backend_name
+    ports.reset_backend()
+    _calls["n"] = 0
+    t0 = time.perf_counter()
+    out = darksky._jit_geocode_candidates(
+        deepcopy(candidates), max_results, natural_areas=None, padus_index=None,
+    )
+    wall = (time.perf_counter() - t0) * 1000.0
+    keys = [(r["name"], round(r["lat"], 4), round(r["lon"], 4)) for r in out]
+    return wall, _calls["n"], keys
+
+
+def main():
+    darksky._settlement = _stub_settlement     # patch the network call
+    candidates = _make_candidates()
+    max_results = 10
+
+    print(f"candidates={len(candidates)}  max_results={max_results}  "
+          f"workers={darksky._GEOCODE_MAX_WORKERS}  stub_latency={SETTLE_LATENCY_S*1000:.0f}ms\n")
+
+    s_wall, s_calls, s_keys = _run("local", candidates, max_results)
+    p_wall, p_calls, p_keys = _run("aws", candidates, max_results)
+
+    print(f"{'serial (local/Nominatim path)':32s} wall={s_wall:8.1f} ms  geocode_calls={s_calls}")
+    print(f"{'parallel (aws/AWS Location path)':32s} wall={p_wall:8.1f} ms  geocode_calls={p_calls}")
+    print(f"\nspeedup: {s_wall / p_wall:.1f}x")
+    print(f"results identical: {s_keys == p_keys}  (serial={len(s_keys)}, parallel={len(p_keys)} results)")
+    if s_keys != p_keys:
+        print("  serial  :", s_keys)
+        print("  parallel:", p_keys)
+
+    # ── B: client singleton + pooled config ──────────────────────────────────
+    darksky._reset_location_client()
+    c1 = darksky._location()
+    c2 = darksky._location()
+    cfg = c1.meta.config
+    print(f"\n[B] _location() singleton: {c1 is c2}")
+    print(f"[B] max_pool_connections={cfg.max_pool_connections}  "
+          f"retries={cfg.retries}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -10,6 +10,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_location_client():
+    """darksky caches one process-wide boto3 'location' client; drop it between tests
+    so each test's patched boto3.client is the one actually used."""
+    import PyNightSkyPredictor.darksky as _darksky
+    _darksky._reset_location_client()
+    yield
+    _darksky._reset_location_client()
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def _aws_env(monkeypatch):

--- a/tests/test_provider_smoke.py
+++ b/tests/test_provider_smoke.py
@@ -1,0 +1,99 @@
+"""Live provider smoke tests — hit each external provider's API exactly once.
+
+These make REAL network calls, so they are opt-in: skipped unless PYNIGHTSKY_LIVE=1
+is set (keeps the default `pytest` run offline and deterministic). Run with:
+
+    PYNIGHTSKY_LIVE=1 python -m pytest -m live -q
+
+Covers every outbound data provider the engine depends on:
+  * Open-Meteo            — primary weather forecast
+  * 7Timer ASTRO         — seeing / transparency weather
+  * Celestrak            — satellite TLEs
+  * Nominatim            — forward geocoding (local backend)
+  * AWS Location         — forward geocoding (aws backend; additionally needs the
+                           aws backend env + credentials, else skipped)
+
+Each test asserts only that the provider is reachable and returns a sane payload —
+a connectivity/health check, not a correctness test of the parsing logic (those
+live in the per-module unit tests with mocked responses).
+"""
+import os
+
+import pytest
+
+pytestmark = pytest.mark.live
+
+# A bright, unambiguous location all providers can answer for.
+_DENVER_LAT, _DENVER_LON = 39.7392, -104.9903
+_ISS_NORAD = 25544  # ISS (ZARYA) — always present in Celestrak's catalogue
+
+
+@pytest.fixture(autouse=True)
+def _require_live():
+    if not os.environ.get("PYNIGHTSKY_LIVE"):
+        pytest.skip("set PYNIGHTSKY_LIVE=1 to run live provider smoke tests")
+
+
+# ── Weather providers ────────────────────────────────────────────────────────
+
+def test_open_meteo_live():
+    from PyNightSkyPredictor import weather
+    points = weather.OpenMeteoProvider().forecast(_DENVER_LAT, _DENVER_LON)
+    assert points, "Open-Meteo returned no forecast points"
+    assert points[0].cloud_cover_pct is not None
+
+
+def test_seventimer_live():
+    from PyNightSkyPredictor import weather
+    points = weather.SevenTimerProvider().forecast(_DENVER_LAT, _DENVER_LON)
+    assert points, "7Timer returned no forecast points"
+
+
+# ── Celestrak (TLE) ──────────────────────────────────────────────────────────
+
+def test_celestrak_live():
+    from PyNightSkyPredictor import tle_provider
+    raw = tle_provider._fetch_tle_raw(_ISS_NORAD)
+    lines = [ln for ln in raw.splitlines() if ln.strip()]
+    assert any(ln.startswith("1 ") for ln in lines), "no TLE line 1 from Celestrak"
+    assert any(ln.startswith("2 ") for ln in lines), "no TLE line 2 from Celestrak"
+
+
+# ── Location providers ───────────────────────────────────────────────────────
+
+def test_nominatim_live():
+    from PyNightSkyPredictor import location
+    entry = location._geocode_via_nominatim("Denver, CO", "Denver, CO")
+    assert entry is not None, "Nominatim returned no result for Denver, CO"
+    assert entry["lat"] == pytest.approx(_DENVER_LAT, abs=0.4)
+    assert entry["lon"] == pytest.approx(_DENVER_LON, abs=0.4)
+
+
+def test_aws_location_live():
+    required = ("PYNIGHTSKY_CACHE_TABLE", "PYNIGHTSKY_RASTER_BUCKET")
+    if os.environ.get("PYNIGHTSKY_BACKEND") != "aws" or any(
+        not os.environ.get(v) for v in required
+    ):
+        pytest.skip(
+            "set PYNIGHTSKY_BACKEND=aws + "
+            + ", ".join(required)
+            + " (and AWS creds) to run the AWS Location smoke"
+        )
+    from PyNightSkyPredictor import ports, location
+    ports.reset_backend()
+    try:
+        entry = location._geocode_via_aws("Denver, CO", "Denver, CO")
+    except RuntimeError as e:
+        # Distinguish "creds not usable in this environment" (skip) from a real
+        # provider/service error (fail). Local SSO/login-based creds need
+        # botocore[crt]; in Lambda/CI a task role resolves cleanly.
+        msg = str(e).lower()
+        if any(s in msg for s in ("credential", "botocore[crt]", "missing dependency",
+                                  "unable to locate")):
+            pytest.skip(f"AWS credentials not usable for boto3 here: {e}")
+        raise
+    finally:
+        ports.reset_backend()
+    assert entry is not None, "AWS Location returned no result for Denver, CO"
+    assert entry["lat"] == pytest.approx(_DENVER_LAT, abs=0.4)
+    assert entry["lon"] == pytest.approx(_DENVER_LON, abs=0.4)


### PR DESCRIPTION
## Tier 0 of the find_nearby performance work

Profiling found cold `find_nearby` searches were network-bound: a dead Overpass endpoint (15 s timeout every call) + serial Nominatim reverse-geocoding dominated by duplicate town names.

### Changes
- **Overpass fix** — revert dead `overpass.private.coffee` → `overpass-api.de` (only reachable mirror); restore 1.0 s throttle. *Local/CLI backend only.*
- **8-mi geocode pre-dedup** (`_NAME_DEDUP_MILES`) — skip the network probe for a Tier-3 candidate adjacent to an already-named result. Phoenix cold probes 43→25 (−42%).
- **A: parallel reverse-geocoding on the aws backend** — AWS Location has no per-second policy (public Nominatim keeps the serial path per its usage policy). Real-worker A/B: **~4×** (serial 20 misses=1746 ms vs parallel(8) 16=339 ms; ~87 ms/call in-region).
- **B: pooled boto3 `location` client** — built once and reused (was rebuilt per call), restoring connection reuse.
- **Instrumentation (opt-in)** — `cache.stats` hit/miss counter + `PYNIGHTSKY_PROFILE` phase profiler.

### Tests & docs
- `tests/test_provider_smoke.py` — live smoke hitting each provider once (Open-Meteo, 7Timer, Celestrak, Nominatim, AWS Location); `live` marker, `PYNIGHTSKY_LIVE=1`.
- `docs/PERF_FINDNEARBY.md` — full results + prioritized recommendations (Tier 1+: PAD-US load is now the dominant cold-start cost).
- `scripts/` — profiling + diagnostic harnesses.

Full suite: 390 passed, 7 skipped (live/aws auto-skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)