### PR TITLE
fix(security): bump AL2023 base digest + time-box libsolv HIGH CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,16 @@
+# Accepted, time-boxed CVE suppressions for the Trivy image scan.
+# Each entry MUST have a justification and be removed once upstream ships a fix.
+#
+# ── libsolv (Amazon Linux 2023 base image) ──────────────────────────────────
+# 4 HIGH CVEs in libsolv 0.7.22-1.amzn2023.0.3. A fix (0.7.22-1.amzn2023.0.4)
+# exists in the advisory DB but is NOT yet published to the AL2023 package repos
+# (verified 2026-06-09: latest `amazonlinux:2023` + `dnf upgrade` still installs
+# .0.3). libsolv is dnf's dependency resolver — it is invoked only during
+# `docker build`, never at Lambda runtime — so these metadata/PGP parser overflow
+# CVEs have no runtime attack surface in the deployed function.
+# REMOVE these four lines once AL2023 publishes libsolv 0.7.22-1.amzn2023.0.4
+# (then a routine base-digest bump clears them at the source).
+CVE-2026-48863
+CVE-2026-48864
+CVE-2026-9149
+CVE-2026-9150

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # manylinux wheel + bundled GDAL work, incl. /vsis3), and currently 0 CVEs.
 # Pinned by digest for reproducible builds; Dependabot (docker ecosystem) bumps it
 # when AWS republishes the tag, which is how we pick up base-OS security patches.
-FROM amazonlinux:2023@sha256:ad882807c6c88f478186fa2632637380e06071a303e2b3bd96ab71846a77c6a3
+FROM amazonlinux:2023@sha256:267b42d61c8eb5537270b62ec97b73bb104708d9245d343b5eeb1d92f0f65d3d
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,7 +1,7 @@
 # Lambda variant of the API image: same Amazon Linux 2023 runtime as the App Runner
 # image, plus the AWS Lambda Web Adapter so the *unchanged* FastAPI/uvicorn app runs
 # as a Lambda container behind a Function URL (no code changes, no Mangum).
-FROM amazonlinux:2023@sha256:ad882807c6c88f478186fa2632637380e06071a303e2b3bd96ab71846a77c6a3
+FROM amazonlinux:2023@sha256:267b42d61c8eb5537270b62ec97b73bb104708d9245d343b5eeb1d92f0f65d3d
 
 # Lambda Web Adapter (external extension): bridges Lambda invokes <-> local uvicorn.
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -4,7 +4,7 @@
 # SQS events. It needs rasterio/GDAL + the de421.bsp ephemeris to run plan_trip, so
 # it's a container (not the tiny warmer zip). Staying on AL2023 + non-root avoids
 # Trivy DS-0002 (the AWS Lambda base image would run as root).
-FROM amazonlinux:2023@sha256:ad882807c6c88f478186fa2632637380e06071a303e2b3bd96ab71846a77c6a3
+FROM amazonlinux:2023@sha256:267b42d61c8eb5537270b62ec97b73bb104708d9245d343b5eeb1d92f0f65d3d
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/scripts/security_scan.sh
+++ b/scripts/security_scan.sh
@@ -40,8 +40,9 @@ run "Trivy (repo secrets)"             "${TRIVY[@]}" fs --scanners secret --exit
 
 if docker image inspect pynightsky-api:latest >/dev/null 2>&1; then
   docker save pynightsky-api:latest -o /tmp/_pns_scan.tar
-  run "Trivy (image CVEs)" docker run --rm -v /tmp:/scan aquasec/trivy:latest \
-    image --input /scan/_pns_scan.tar --severity HIGH,CRITICAL --exit-code 1 -q
+  run "Trivy (image CVEs)" docker run --rm -v /tmp:/scan -v "$PWD:/repo" aquasec/trivy:latest \
+    image --input /scan/_pns_scan.tar --ignorefile /repo/.trivyignore \
+    --severity HIGH,CRITICAL --exit-code 1 -q
   rm -f /tmp/_pns_scan.tar
 else
   echo ""; echo "=== Trivy (image CVEs) ==="; echo "  SKIP: pynightsky-api:latest not built locally (CI builds + scans it)"


### PR DESCRIPTION
Clears the **pre-existing** Trivy image-CVE gate failure (4 HIGH `libsolv` CVEs from the Amazon Linux 2023 base image — unrelated to the Tier 0 perf work).

### Changes
- **Bump** pinned `amazonlinux:2023` digest `ad8828…` → `267b42…` across `Dockerfile`, `Dockerfile.lambda`, `Dockerfile.worker`.
- **Time-boxed `.trivyignore`** for `CVE-2026-48863/48864/9149/9150`. The fix (`libsolv 0.7.22-1.amzn2023.0.4`) isn't in the AL2023 repos yet (verified: latest base + `dnf upgrade` still installs `.0.3`), so a bump alone can't clear it. Justification: libsolv is dnf's resolver, invoked only at `docker build`, never at Lambda runtime → no runtime attack surface. **Remove the ignores when AL2023 ships `.0.4`.**
- **`security_scan.sh`**: image scan now mounts the repo + `--ignorefile /repo/.trivyignore`.

### Verification
Built `pynightsky-api:latest` on the new base + ran the gate's Trivy image scan with the ignore file → **exit 0**, no other HIGH/CRITICAL introduced. Test suite: 390 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)