### PR TITLE
perf(padus): columnar uint64 index load (~35x faster cold start)

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -1303,11 +1303,28 @@ def _padus_h3_path() -> "Path | None":
     return None
 
 
-def _load_padus_h3_index() -> "dict[str, tuple[str, bool]] | None":
-    """Lazy-load the PAD-US H3 index once per process; return cached dict thereafter.
+class _PadusIndex:
+    """Columnar PAD-US H3 index: a sorted uint64 cell array plus parallel name and
+    blacklist arrays. Replaces a ~1.4M-entry Python dict — the dict build dominated
+    worker cold starts (~1.8 s locally, 5-24 s on Lambda's throttled vCPU). Lookups
+    binary-search the cell array (see _padus_h3_lookup); names stay as an Arrow array
+    and are materialised one element at a time, only on a hit."""
 
-    Returns None (and caches that failure) if h3 is not installed, the parquet
-    file is missing, or the read fails — callers degrade gracefully to Tier 2/3.
+    __slots__ = ("cells", "names", "blacklist")
+
+    def __init__(self, cells, names, blacklist):
+        self.cells = cells          # np.ndarray[uint64], ascending
+        self.names = names          # pyarrow Array (large_string), aligned to cells
+        self.blacklist = blacklist  # np.ndarray[bool], aligned to cells
+
+
+def _load_padus_h3_index() -> "_PadusIndex | None":
+    """Lazy-load the PAD-US H3 index once per process; return the cached index after.
+
+    The index is columnar (see _PadusIndex), so loading is a parquet read into numpy
+    arrays rather than a ~1.4M-object Python dict build. Returns None (and caches that
+    failure) if h3/numpy/pyarrow is unavailable, the parquet is missing, or the read
+    fails — callers degrade gracefully to Tier 2/3.
     """
     global _padus_h3_cache
     if _padus_h3_cache is _PADUS_UNAVAILABLE:
@@ -1326,13 +1343,23 @@ def _load_padus_h3_index() -> "dict[str, tuple[str, bool]] | None":
         return None
 
     try:
+        import numpy as np
         import pyarrow.parquet as pq
         tbl = pq.read_table(str(path), columns=["h3_cell", "Unit_Nm", "is_blacklisted"])
-        cells      = tbl.column("h3_cell").to_pylist()
-        unit_names = tbl.column("Unit_Nm").to_pylist()
-        blacklists = tbl.column("is_blacklisted").to_pylist()
-        _padus_h3_cache = dict(zip(cells, zip(unit_names, blacklists)))
-        log.debug("PAD-US H3 index loaded: %d cells.", len(_padus_h3_cache))
+        cells     = tbl.column("h3_cell").to_numpy(zero_copy_only=False).astype(np.uint64, copy=False)
+        names     = tbl.column("Unit_Nm")
+        blacklist = tbl.column("is_blacklisted").to_numpy(zero_copy_only=False)
+        # The parquet is written sorted by cell (build + migrate scripts), so
+        # np.searchsorted is valid. Guard cheaply (~ms) and sort if it ever isn't.
+        if cells.size and not bool(np.all(cells[:-1] <= cells[1:])):
+            import pyarrow as pa
+            order     = np.argsort(cells, kind="stable")
+            cells     = cells[order]
+            names     = names.take(pa.array(order))
+            blacklist = blacklist[order]
+        names = names.combine_chunks()   # single Arrow array → O(1) indexing on a hit
+        _padus_h3_cache = _PadusIndex(cells, names, blacklist)
+        log.debug("PAD-US H3 index loaded: %d cells (columnar).", cells.size)
     except Exception as exc:
         log.debug("PAD-US H3 index load failed: %s", exc)
         _padus_h3_cache = _PADUS_UNAVAILABLE
@@ -1344,11 +1371,20 @@ def _load_padus_h3_index() -> "dict[str, tuple[str, bool]] | None":
 def _padus_h3_lookup(
     lat: float,
     lon: float,
-    index: "dict[str, tuple[str, bool]]",
+    index: "_PadusIndex",
 ) -> "tuple[str, bool] | None":
-    """Return (Unit_Nm, is_blacklisted) for the H3 cell at (lat, lon), or None."""
-    cell = _h3_lib.latlng_to_cell(lat, lon, 7)
-    return index.get(cell)
+    """Return (Unit_Nm, is_blacklisted) for the H3 cell at (lat, lon), or None.
+
+    Binary-searches the sorted uint64 cell array; the name is materialised from the
+    Arrow array only on a hit.
+    """
+    import numpy as np
+    cell  = _h3_lib.str_to_int(_h3_lib.latlng_to_cell(lat, lon, 7))
+    cells = index.cells
+    i = int(np.searchsorted(cells, np.uint64(cell)))
+    if i < cells.size and cells[i] == cell:
+        return (index.names[i].as_py(), bool(index.blacklist[i]))
+    return None
 
 
 def _is_good_padus_name(unit_nm: "str | None") -> bool:

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -104,8 +104,50 @@ Live connectivity for every provider is covered by `tests/test_provider_smoke.py
 7. Request an AWS Location TPS quota increase before scaling parallel geocode widely
    (~50 req/s account default; adaptive retries already cushion bursts).
 
+## Benchmark log
+
+One variable at a time; numbers kept for later reference.
+
+### Tier 1 · Item 2 — PAD-US index: dict build → columnar uint64 + binary search (2026-06-09)
+
+The cold load built a ~1.37M-entry Python dict from string-keyed parquet
+(`to_pylist` ×3 → `dict(zip(...))`). Replaced with a sorted `uint64` cell array +
+parallel name/blacklist arrays, looked up via `np.searchsorted`; names stay in Arrow
+and are materialised only on a hit. Parquet regenerated to uint64-sorted (build +
+`scripts/migrate_padus_uint64.py`).
+
+Local benchmark (`scripts/bench_padus_load.py`, 5 cold iters, M-series laptop):
+
+| Metric | Before (dict) | After (columnar) |
+|---|---:|---:|
+| Index load, median | **1787.7 ms** | **53.7 ms** (~33× faster) |
+| Index load, min | 1645.0 ms | 52.5 ms |
+| Lookup | 0.85 µs/pt | 2.54 µs/pt (≈0.3 ms total per search — negligible) |
+| Parquet size | 10.6 MB | 3.5 MB |
+| Correctness | — | 0 mismatches over 50,006 checks ✅ |
+
+**In-region confirmation** (throwaway worker, x86_64/2 GB — same config as the baseline,
+so only the index-load variable changed). Cold `padus index load`, 4 samples:
+
+| Cold sample | padus index load |
+|---|---:|
+| 1 — first-ever container | 17178 ms (one-time Lambda image lazy-load tax) |
+| 2 | 463.8 ms |
+| 3 | 454.9 ms |
+| 4 | 424.4 ms |
+
+Steady cold-container load **≈ 450 ms, down from the baseline 15–24 s (~35×)** — matches
+the laptop ratio. The first container after a fresh image deploy still pays a one-time
+~17 s image-load tax (Lambda fetches/decompresses layers on first touch; the old build
+paid this *plus* its dict build). Residual fix for that tax if ever needed: provisioned
+concurrency. Tests: 390 passed. This likely makes Tier 2 item 3 (regional subset) unnecessary.
+
+Not yet benchmarked: Item 1 (memory bump) — deferred (single-threaded load already has
+≥1 vCPU at 2 GB, so it won't help this phase; revisit for Init + dome detection).
+
 ## Reproduce
 
+- `scripts/bench_padus_load.py` — PAD-US load + lookup benchmark (`--verify-against` for correctness).
 - `scripts/profile_find_nearby.py` — per-phase profile across cities (warm + `--cold`).
 - `scripts/diag_geocode_waste.py` — classify reverse-geocode probes (kept/duplicate/water).
 - `scripts/profile_parallel_geocode.py` — offline serial-vs-parallel A/B (stubbed latency).

--- a/scripts/bench_padus_load.py
+++ b/scripts/bench_padus_load.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Benchmark the PAD-US H3 index load + lookup (the cold-start cost in find_nearby).
+
+Times darksky._load_padus_h3_index() over several cold iterations (resetting the
+module cache each time) and times a batch of lookups. Run it before and after the
+columnar rewrite to compare the SAME entry points.
+
+  --verify-against <string-parquet>  cross-check every lookup against a reference
+                                     dict built from the original string-keyed
+                                     parquet (correctness gate for the migration).
+"""
+import argparse
+import random
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from PyNightSkyPredictor import darksky  # noqa: E402
+
+# Mix of public land (expect hits), cities, and ocean (expect None).
+SAMPLE_PTS = [
+    (36.0544, -112.1401, "Grand Canyon NP"),
+    (44.4280, -110.5885, "Yellowstone NP"),
+    (37.8651, -119.5383, "Yosemite NP"),
+    (40.7128, -74.0060, "New York City"),
+    (33.4484, -112.0740, "Phoenix"),
+    (25.0, -90.0, "Gulf of Mexico (ocean)"),
+]
+
+
+def bench_load(iters: int):
+    times = []
+    idx = None
+    for _ in range(iters):
+        darksky._padus_h3_cache = None          # force a cold load
+        t0 = time.perf_counter()
+        idx = darksky._load_padus_h3_index()
+        times.append((time.perf_counter() - t0) * 1000.0)
+    return idx, times
+
+
+def bench_lookup(idx, n_random=200_000):
+    # Sample points first (and print), then a large random-coordinate batch for timing.
+    for lat, lon, label in SAMPLE_PTS:
+        print(f"    {label:28s} -> {darksky._padus_h3_lookup(lat, lon, idx)}")
+    pts = [(random.uniform(25, 49), random.uniform(-124, -67)) for _ in range(n_random)]
+    t0 = time.perf_counter()
+    hits = 0
+    for lat, lon in pts:
+        if darksky._padus_h3_lookup(lat, lon, idx) is not None:
+            hits += 1
+    dt = time.perf_counter() - t0
+    return n_random, hits, dt
+
+
+def verify_against(string_parquet: str, idx) -> int:
+    """Compare new-index lookups to a reference dict from the original string parquet."""
+    import pyarrow.parquet as pq
+    import h3
+    print(f"\n[verify] building reference dict from {string_parquet} ...")
+    tbl = pq.read_table(string_parquet, columns=["h3_cell", "Unit_Nm", "is_blacklisted"])
+    cells = tbl.column("h3_cell").to_pylist()
+    names = tbl.column("Unit_Nm").to_pylist()
+    bls = tbl.column("is_blacklisted").to_pylist()
+    ref = dict(zip(cells, zip(names, bls)))
+    # Compare on a large random sample of known cells (cell-center -> lookup).
+    sample = random.sample(cells, min(50_000, len(cells)))
+    mismatches = 0
+    for cell in sample:
+        lat, lon = h3.cell_to_latlng(cell)
+        want = ref.get(cell)
+        got = darksky._padus_h3_lookup(lat, lon, idx)
+        if got != want:
+            mismatches += 1
+            if mismatches <= 5:
+                print(f"  MISMATCH cell={cell} want={want} got={got}")
+    # Also the explicit sample points.
+    for lat, lon, label in SAMPLE_PTS:
+        cell = h3.latlng_to_cell(lat, lon, 7)
+        if darksky._padus_h3_lookup(lat, lon, idx) != ref.get(cell):
+            mismatches += 1
+            print(f"  MISMATCH {label}")
+    print(f"[verify] {len(sample)} sampled cells + {len(SAMPLE_PTS)} points: "
+          f"{mismatches} mismatches")
+    return mismatches
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--iters", type=int, default=5)
+    ap.add_argument("--verify-against", type=str, default=None)
+    args = ap.parse_args()
+
+    random.seed(42)
+    idx, load_times = bench_load(args.iters)
+    if idx is None:
+        print("PAD-US index unavailable (None) — check the parquet path.")
+        return
+    print(f"PAD-US index load ({args.iters} cold iterations):")
+    print(f"  min={min(load_times):8.1f} ms  median={statistics.median(load_times):8.1f} ms  "
+          f"max={max(load_times):8.1f} ms")
+    print("  sample lookups:")
+    n, hits, dt = bench_lookup(idx)
+    print(f"  lookup: {n} random pts in {dt*1000:.1f} ms "
+          f"({dt/n*1e6:.2f} us/pt, {hits} hits)")
+
+    if args.verify_against:
+        m = verify_against(args.verify_against, idx)
+        print("VERIFY:", "PASS ✅" if m == 0 else f"FAIL ❌ ({m} mismatches)")
+        sys.exit(0 if m == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_padus_index.py
+++ b/scripts/build_padus_index.py
@@ -149,9 +149,16 @@ def build_index() -> None:
     print(f"  {len(df):,} unique H3 cells after deduplication")
     print(f"  Blacklisted cells: {int(df['is_blacklisted'].sum()):,}  |  Viable: {int((~df['is_blacklisted']).sum()):,}")
 
+    # --- Encode H3 cells as sorted uint64 ---
+    # The runtime loader (darksky._load_padus_h3_index) reads h3_cell as a numpy
+    # uint64 array and binary-searches it, so store cells as uint64 sorted ascending
+    # — avoids a ~1.4M-object Python dict build on every Lambda cold start.
+    df["h3_cell"] = df["h3_cell"].map(h3.str_to_int).astype("uint64")
+    df = df.sort_values("h3_cell").reset_index(drop=True)
+
     # --- Write output ---
     os.makedirs(OUT_DIR, exist_ok=True)
-    df.to_parquet(OUT_FILE, engine="pyarrow", compression="snappy", index=False)
+    df.to_parquet(OUT_FILE, engine="pyarrow", compression="zstd", index=False)
     size_mb = os.path.getsize(OUT_FILE) / (1024 * 1024)
     print(f"\n  Saved → {OUT_FILE}  ({size_mb:.1f} MB)")
     print(f"  Columns: {df.columns.tolist()}")

--- a/scripts/migrate_padus_uint64.py
+++ b/scripts/migrate_padus_uint64.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""One-off: convert the PAD-US H3 parquet from string cells to sorted uint64 cells.
+
+The runtime loader (_load_padus_h3_index) reads h3_cell as a numpy uint64 array and
+binary-searches it, avoiding the ~1.4M-object Python dict build. This rebuilds the
+committed parquet in that format from an existing string-keyed parquet.
+
+    python scripts/migrate_padus_uint64.py <in_string.parquet> <out.parquet>
+"""
+import sys
+
+import h3
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def main():
+    src, dst = sys.argv[1], sys.argv[2]
+    tbl = pq.read_table(src)
+    print(f"read {tbl.num_rows:,} rows from {src}; columns={tbl.column_names}")
+
+    cells_str = tbl.column("h3_cell").to_pylist()
+    cells_u64 = [h3.str_to_int(c) for c in cells_str]      # exact, lossless
+
+    cols = {"h3_cell": pa.array(cells_u64, type=pa.uint64())}
+    for name in ("Unit_Nm", "Mang_Name", "is_blacklisted"):
+        if name in tbl.column_names:
+            cols[name] = tbl.column(name)
+    out = pa.table(cols)
+
+    # Sort ascending by cell so the loader can np.searchsorted without re-sorting.
+    out = out.sort_by([("h3_cell", "ascending")])
+    pq.write_table(out, dst, compression="zstd")
+    print(f"wrote {out.num_rows:,} rows to {dst}; h3_cell dtype={out.schema.field('h3_cell').type}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tier 1 · Item 2 of the find_nearby perf work. Confirmed in-region before shipping.

The PAD-US H3 index built a **~1.37M-entry Python dict** on every cold container — the dominant `find_nearby` cold-start cost once parallel geocode landed (~1.8 s laptop, **15–24 s on the worker**).

### Change (one variable)
- Columnar `_PadusIndex`: sorted `uint64` cell array + parallel name/blacklist arrays, looked up via `np.searchsorted`. Names stay in Arrow, materialised only on a hit.
- Parquet regenerated to uint64-sorted (`build_padus_index.py` updated; one-off `scripts/migrate_padus_uint64.py`); **10.6 → 3.5 MB**.

### Benchmarks
| Metric | Before | After |
|---|---:|---:|
| Local load (median) | 1787 ms | 54 ms (~33×) |
| **In-region cold load (2 GB worker)** | **15–24 s** | **~0.45 s (~35×)** |
| Lookup | 0.85 µs/pt | 2.54 µs/pt (~0.3 ms/search) |
| Correctness | — | 0 mismatches / 50,006 checks ✅ |

In-region confirmed on a throwaway worker (same 2 GB as baseline), then torn down. First container after a fresh image deploy still pays a one-time ~17 s Lambda image lazy-load tax (independent of this change). Tests: 390 passed. Likely makes Tier 2's regional-subset idea unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)