### PR TITLE
docs: CLAUDE.md + PAD-US index reference (+ fix stale parquet comments)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ dev.sh
 Temp/
 
 # Generated spatial index artefacts (derived from PADUS; do not distribute)
-# darkhours_padus_h3.parquet (~10 MB) IS committed — Docker builds require it.
+# darkhours_padus_h3.parquet (~3.5 MB) IS committed — Docker builds require it.
 # Raw/intermediate files (GDB, full vector parquet, shapefiles) are excluded.
 cache/*
 !cache/darkhours_padus_h3.parquet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+Guidance for AI assistants working in this repo. Read this first, then the relevant
+`memory/` notes and `docs/` for the area you're touching.
+
+## What this is
+
+PyNightSkyPredictor: an astronomy/dark-sky planner. Predicts observing conditions
+(weather, moon, milky way, satellites, light pollution) and finds nearby dark-sky sites.
+
+- **CLI:** `pynightsky.py` (the parity oracle — behavior here is the reference).
+- **Web API:** `apps/api` (FastAPI). Long computes run async via SQS → `apps/worker`.
+- **Engine:** `PyNightSkyPredictor/` — `darksky.py` (light pollution + `find_nearby`),
+  `weather.py`, `moon_events.py`, `milky_way.py`, `satellites.py`, `tle_provider.py`,
+  `location.py`, `scoring.py`, `trip.py`.
+
+## Backends (ports & adapters)
+
+One backend is selected per process via `PYNIGHTSKY_BACKEND` (`local` default, or `aws`),
+through `ports.py`. The same engine runs against local files (CLI) or cloud services
+(prod). Don't bypass the seam:
+- cache → `LocalFileCache` | `DynamoCache`
+- geocode store → local json | DynamoDB
+- rasters → local GeoTIFF | S3 COG via GDAL `/vsis3`
+- reverse-geocode/routing → Nominatim+Overpass (local) | AWS Location (aws)
+
+## Ways of working (these produced the good results — keep them)
+
+- **Profile before optimizing.** Never guess a bottleneck. `PYNIGHTSKY_PROFILE=1` turns
+  on per-phase timing + cache hit/miss in `find_nearby`; `cache.stats` counts lookups.
+- **One variable at a time, and benchmark it.** Capture a baseline first, change one
+  thing, measure again, record the before/after. See `scripts/bench_*` / `profile_*`.
+- **Verify before shipping.** Tests must be green; for perf/infra claims, confirm on real
+  infra (see the test-worker recipe) — don't ship on a local number alone.
+- **Clean up experiments.** Tear down any throwaway AWS resources and temp files you create.
+- **Surface caveats, don't bury them.** "the bump won't help", "first-container image
+  tax", correctness gates — call these out explicitly.
+- **Persist context.** Update the relevant `memory/` note and `docs/` file as you go;
+  that's how the next session inherits this one.
+
+## Tests
+
+`python -m pytest -q`. Markers (see `pytest.ini`), all skipped by default:
+- `eph` — needs the de421.bsp ephemeris.
+- `aws` — hits real AWS; runs only with `PYNIGHTSKY_BACKEND=aws` + cache/raster env + creds.
+- `live` — hits real provider APIs; runs only with `PYNIGHTSKY_LIVE=1`
+  (`tests/test_provider_smoke.py` covers Open-Meteo, 7Timer, Celestrak, Nominatim, AWS Location).
+
+A default run stays offline and deterministic (currently 390 passed, ~7 skipped).
+
+## Ship flow (CI/CD)
+
+- **Branch → PR → squash-merge to `main` = deploy.** `.github/workflows/deploy.yml` fires
+  on push to `main`: test gate (`pytest -q`) → OIDC → build+push **both** `pynightsky-api`
+  and `pynightsky-worker` images (tagged `:<sha>`) → `cdk deploy ... -c imageTag=<sha>`.
+  Both the API and the worker (where `find_nearby` runs) get the new code.
+- **`security.yml`** runs on every branch/PR (scan-only, does not gate deploy): pytest +
+  Bandit, pip-audit, Semgrep, gitleaks, Trivy (image CVEs) via `scripts/security_scan.sh`.
+- We're on `main` by default — **branch before committing**. Commit trailer:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`; PR body trailer:
+  `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+### Security gate notes
+- Trivy image CVEs are gated HIGH/CRITICAL. Accepted, **time-boxed** suppressions live in
+  `.trivyignore` with a justification + removal trigger (currently 4 `libsolv` CVEs from
+  the AL2023 base — remove when AWS ships the patched package).
+- This is a **public repo**: never commit the S3 bucket name, DynamoDB table name, AWS
+  account id, or role ARNs. They're injected via env/secrets and discovered at runtime —
+  see below. `scripts/profile_aws.sh` reads them from the environment for this reason.
+
+## Running against real AWS (local)
+
+Needs an authenticated session and the resource names (kept out of source). Discover them
+rather than hardcoding:
+- Resource names: synthesized templates under `cdk/cdk.out/*.template.json`, or
+  `aws lambda list-functions` / `aws ecr describe-repositories`.
+- Then: `scripts/profile_aws.sh` (set `PYNIGHTSKY_RASTER_BUCKET` + `PYNIGHTSKY_CACHE_TABLE`
+  first) runs one `find_nearby` against the aws backend with profiling.
+
+### In-region perf validation (throwaway test worker)
+
+To measure a worker change on real infra without touching the deployed worker:
+1. `docker build -f Dockerfile.worker --platform linux/amd64 --provenance=false -t <repo>/pynightsky-worker:proftest .`
+   (single-platform manifest — Lambda rejects buildx attestation lists).
+2. ECR login, push the `:proftest` tag.
+3. `aws lambda create-function` a throwaway fn from that image, **reusing the existing
+   worker IAM role**, with the resource env vars + `PYNIGHTSKY_PROFILE=1`.
+4. Invoke with a synthetic SQS event:
+   `{"Records":[{"body":"{\"job_id\":\"x\",\"params\":{\"type\":\"nearby\",\"lat\":..,\"lon\":..,\"radius_miles\":60}}"}]}`
+   (use `AWS_MAX_ATTEMPTS=1 --cli-read-timeout 0` to avoid a double-invoke; force a cold
+   container between samples with a dummy env bump).
+5. Read `[profile]` lines from the function's CloudWatch log group; results in the cache
+   under `job|<job_id>`.
+6. **Tear down:** delete the function, the `:proftest` ECR image, and the log group.
+
+## Key docs & memory
+
+- `docs/PERF_FINDNEARBY.md` — `find_nearby` profiling results, fixes, and benchmark log.
+- `docs/PADUS_INDEX.md` — PAD-US H3 index: format, build, blacklist rules, regeneration.
+- `memory/` — running project notes (cloud migration, find_nearby perf, PAD-US, etc.).
+- `docs/PYNIGHTSKY.md`, `PRODUCT.md`, `README.md` — product/engine overview.

--- a/docs/PADUS_INDEX.md
+++ b/docs/PADUS_INDEX.md
@@ -1,0 +1,106 @@
+# PAD-US H3 Spatial Index
+
+A pre-built H3 index of US public lands used as **Tier 1** of `find_nearby`'s naming
+pipeline: a fast, offline, no-network first pass that either names a dark-sky candidate
+(public land) or eliminates it (restricted land) before any Overpass/Nominatim call.
+
+- **Source of truth:** USGS PAD-US 4.1 Geodatabase.
+- **Artifact:** `cache/darkhours_padus_h3.parquet` — **committed** (a `.gitignore`
+  exception; the Docker images copy it). ~3.5 MB, 1,374,391 cells.
+- **Builder:** `scripts/build_padus_index.py` (offline; needs `requirements-build.txt`).
+- **Runtime:** `darksky._load_padus_h3_index` / `_padus_h3_lookup`.
+
+## Why it exists
+
+Overpass is slow/unreliable and public Nominatim is rate-limited (1 req/s, no
+parallelism). For a US dark-sky candidate, the PAD-US cell answers two questions with
+zero network:
+- **Blacklisted cell** → discard the candidate (military/tribal/private/no-access).
+- **Non-blacklisted with a good `Unit_Nm`** → use that name; skip Overpass *and* the
+  reverse geocoder entirely.
+- **No cell hit** → fall through to Tier 2/3 (Overpass/geocoder).
+
+## File format (current — columnar uint64)
+
+| Column | Type | Notes |
+|---|---|---|
+| `h3_cell` | **uint64**, **sorted ascending** | H3 cell at resolution 7 (~5 km hex), as the native 64-bit id |
+| `Unit_Nm` | large_string | Park/unit name |
+| `Mang_Name` | large_string | Manager code (NPS, USFS, BLM, FWS, …) |
+| `is_blacklisted` | bool | True = restricted → eliminate the candidate |
+
+Counts: **1,374,391** unique cells — 1,297,603 viable, 76,788 blacklisted.
+
+> **Format invariant:** the runtime loader reads `h3_cell` as a numpy `uint64` array and
+> binary-searches it, so it **must be uint64 and sorted ascending**. The build and
+> migrate scripts produce exactly this; the loader also has a cheap sort-guard as a
+> safety net. (Older builds stored `h3_cell` as a *string* and the loader built a
+> ~1.4M-entry dict — that dominated Lambda cold starts; see
+> [PERF_FINDNEARBY.md](PERF_FINDNEARBY.md). Don't regress to strings.)
+
+## Runtime path (`PyNightSkyPredictor/darksky.py`)
+
+- `_load_padus_h3_index()` — lazy-loads once per process into a `_PadusIndex`
+  (sorted `uint64` cell array + parallel Arrow name array + bool blacklist array).
+  Cached in the `_padus_h3_cache` module global; returns `None` (cached) if h3/pyarrow
+  is missing or the file can't be read → callers degrade to Tier 2/3.
+- `_padus_h3_lookup(lat, lon, index)` — `np.searchsorted` on the cell array; returns
+  `(Unit_Nm, is_blacklisted)` or `None`. Names are materialised from Arrow only on a hit.
+- `_is_good_padus_name(unit_nm)` — rejects empty, `< 5` chars, and names containing
+  `unknown`/`unnamed`/`office`, and pure-numeric ids. A non-blacklisted cell with a junk
+  name still counts as "PAD-US-verified land" but falls to Tier 3 for naming.
+- File resolution order (`_padus_h3_path`): `PYNIGHTSKY_PADUS_H3_PATH` env override →
+  `<repo>/cache/darkhours_padus_h3.parquet` → `/app/cache/darkhours_padus_h3.parquet`
+  (the Lambda image path).
+
+## Blacklist rules (`_blacklisted` in the build script)
+
+A feature is blacklisted (→ `is_blacklisted=True`) if **any** of:
+- `Pub_Access == 'XA'` (no public access)
+- `Mang_Name` in: DOD, DOE, BIA, BOP, ARS, NASA, USCG, NGO, NRCS, UNK, UNKL
+- `Mang_Type` in: TRIB, PVT
+- `Des_Tp` in: "Conservation Easement", MIL, TRIBL, CONE
+
+`Pub_Access == 'UK'` (unknown) is deliberately **not** blacklisted (wide-net intent).
+On a cell with conflicting sources, **blacklisted wins** (dedup keeps the blacklisted row).
+
+## Rebuilding from source (full refresh, e.g. PAD-US 4.2)
+
+1. Download the **PAD-US Combined Feature Class Geodatabase** from USGS ScienceBase
+   (4.1: <https://www.sciencebase.gov/catalog/item/652d4fc5d34e44db0e2ee45e>, ~700 MB).
+2. Unzip into `Temp/` so the path is `Temp/PADUS4_1Geodatabase/PADUS4_1Geodatabase.gdb`
+   (the `Temp/` raw data is gitignored — do not commit it). Update `GDB_PATH`/`LAYER` in
+   the build script if the version/layer name changes.
+3. `pip install -r requirements-build.txt` (geopandas, pyarrow, fiona, h3).
+4. `python scripts/build_padus_index.py` → writes `cache/darkhours_padus_h3.parquet`
+   (uint64, sorted, zstd). Pipeline: read `PADUS4_1Fee` → flag blacklist → reproject to
+   EPSG:4326 → H3 polyfill at res 7 (`h3.geo_to_cells`, centroid fallback for sub-hex
+   polygons) → dedup (blacklist wins) → encode `h3_cell` to uint64 + sort → write.
+5. Verify + benchmark: `python scripts/bench_padus_load.py` (load time + sample lookups).
+6. Commit the regenerated parquet (it's a tracked `.gitignore` exception). Pre-commit
+   `check-added-large-files` allows up to 17 MB.
+
+## Migrating an existing string-keyed parquet (no source GDB needed)
+
+If you only have an old string-`h3_cell` parquet:
+
+```
+python scripts/migrate_padus_uint64.py <old_string.parquet> cache/darkhours_padus_h3.parquet
+```
+
+Converts cells via `h3.str_to_int`, sorts, and rewrites in the columnar format.
+
+## Verifying correctness after a change
+
+```
+python scripts/bench_padus_load.py --verify-against <reference_string.parquet>
+```
+
+Cross-checks every lookup against a reference dict built from the original parquet
+(used when the uint64 migration shipped: 0 mismatches over 50,006 checks).
+
+## Related
+
+- Cold-start performance impact and benchmarks: [PERF_FINDNEARBY.md](PERF_FINDNEARBY.md).
+- The index is one tier of `_jit_geocode_candidates` / `_offline_tier_name`; Tier 2 is
+  Overpass natural areas, Tier 3 is the reverse geocoder (Nominatim or AWS Location).

--- a/scripts/build_padus_index.py
+++ b/scripts/build_padus_index.py
@@ -1,7 +1,7 @@
 """
 Build a compact H3 spatial index of public lands from the USGS PAD-US 4.1 Geodatabase.
 
-The output (cache/darkhours_padus_h3.parquet, ~10 MB) is used by the DarkHours Lambda
+The output (cache/darkhours_padus_h3.parquet, ~3.5 MB) is used by the DarkHours Lambda
 as a fast pre-filter before calling Overpass: if a GPS coordinate falls inside a known
 public land cell the park name is returned directly; if it lands on a blacklisted cell
 (military, tribal, private, no-access) the candidate is eliminated without an API call.
@@ -28,15 +28,14 @@ public land cell the park name is returned directly; if it lands on a blackliste
 
     python scripts/build_padus_index.py
 
-Output is written to cache/darkhours_padus_h3.parquet (also gitignored).
+Output: cache/darkhours_padus_h3.parquet — committed via a .gitignore exception
+(the Docker images copy it). h3_cell is stored as sorted uint64 so the runtime loader
+binary-searches it instead of building a ~1.4M-entry dict; see docs/PADUS_INDEX.md.
 
---- LAMBDA QUERY PATTERN ---
+--- RUNTIME LOOKUP ---
 
-    cell = h3.latlng_to_cell(lat, lng, 7)
-    row  = index.get(cell)
-    if row is None:              proceed_to_overpass()          # not in PADUS
-    elif row["is_blacklisted"]:  eliminate_candidate()          # restricted land
-    else:                        use_park_name(row["Unit_Nm"])  # skip Overpass
+    Loaded once per process and queried via darksky._load_padus_h3_index /
+    _padus_h3_lookup (columnar np.searchsorted). See docs/PADUS_INDEX.md.
 """
 
 import os


### PR DESCRIPTION
Documentation only — no runtime change (the Dockerfiles don't copy `docs/`, `CLAUDE.md`, or `scripts/`).

- **`CLAUDE.md`** (new): orientation for future sessions — ways of working (profile-first, one-variable benchmarking, verify-before-ship, keep memory/docs current), test markers, the deploy/security CI flow, public-repo secret hygiene, and the throwaway test-worker recipe.
- **`docs/PADUS_INDEX.md`** (new): canonical PAD-US H3 index reference — uint64 columnar format, schema, blacklist rules, full build pipeline, regeneration + migration + verification steps.
- Fix stale `~10 MB / gitignored / dict-lookup` comments in `build_padus_index.py` and `.gitignore` to match the committed ~3.5 MB uint64 parquet.

> Note: merging triggers a deploy (no-op image-wise). Fine to leave open and batch with the next code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)