### PR TITLE
perf(domes): vectorise light-dome centroid extraction (~8-30x, output-identical)

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -57,6 +57,7 @@ except ImportError:
 try:
     from scipy.ndimage import label as _ndimage_label
     from scipy.ndimage import center_of_mass as _ndimage_center_of_mass
+    from scipy.ndimage import maximum as _ndimage_maximum
     _HAS_SCIPY = True
 except ImportError:
     log.warning(
@@ -770,30 +771,36 @@ def _find_light_domes_from_array(
         tier_mask, structure=np.ones((3, 3), dtype=np.int8)
     )
 
-    # ── Centroid extraction (radiance-weighted) ───────────────────────────────
-    # Pass viirs_array (not tier_mask) as the weighting array so the centroid
-    # gravitates toward the brightest core rather than the geometric centre.
-    # For a crescent-shaped metro area the geometric centroid can land in a bay
-    # or dark suburb; radiance weighting anchors it on the densest light core.
+    # ── Centroid extraction (radiance-weighted, vectorised) ───────────────────
+    # viirs_array (not tier_mask) is the weighting array so the centroid gravitates
+    # toward the brightest core rather than the geometric centre — for a crescent
+    # metro the geometric centroid can land in a bay or dark suburb.
+    #
+    # All per-blob work is batched: np.bincount for sizes and scipy's index= APIs
+    # for centroids/peaks compute every label in a few full-array passes. The prior
+    # per-blob Python loop did `labeled == i` + center_of_mass per blob — O(blobs ×
+    # pixels), which was ~98% of this function on a bright metro window (NY: ~2.3 s
+    # over 1326 blobs). Output is identical (same blobs, order, centroids, peaks).
+    sizes = np.bincount(labeled.ravel())          # pixel count per label (index 0 = bg)
+    keep = np.nonzero(sizes >= min_blob_pixels)[0]
+    keep = keep[keep != 0]
+    if keep.size == 0:
+        return []
+
+    centroids  = _ndimage_center_of_mass(viirs_array, labeled, index=keep)
+    max_bortle = np.atleast_1d(_ndimage_maximum(bortle_arr, labeled, index=keep))
+
     results = []
-    for i in range(1, n_features + 1):
-        blob_mask = labeled == i
-        if blob_mask.sum() < min_blob_pixels:
-            continue
-
-        row_f, col_f = _ndimage_center_of_mass(viirs_array, labeled, i)
-
-        # Guard: if blob pixels all become NaN after ocean masking the radiance
-        # sum is 0 and center_of_mass returns NaN — skip rather than crash.
+    for (row_f, col_f), mb in zip(centroids, max_bortle):
+        # A degenerate blob (zero total weight) yields a NaN centroid — skip it.
         if math.isnan(row_f) or math.isnan(col_f):
             continue
-
         row_i = min(int(round(row_f)), rows - 1)
         col_i = min(int(round(col_f)), cols - 1)
         results.append((
             float(lat_grid[row_i, col_i]),
             float(lon_grid[row_i, col_i]),
-            int(np.max(bortle_arr[blob_mask])),
+            int(mb),
         ))
 
     return results

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -145,6 +145,34 @@ concurrency. Tests: 390 passed. This likely makes Tier 2 item 3 (regional subset
 Not yet benchmarked: Item 1 (memory bump) — deferred (single-threaded load already has
 ≥1 vCPU at 2 GB, so it won't help this phase; revisit for Init + dome detection).
 
+### Tier 3 · scipy dome detection — vectorise the per-blob centroid loop (2026-06-09)
+
+Profiling `_find_light_domes_from_array` on real 150-mile VIIRS windows
+(`scripts/bench_dome_detection.py`) showed **97–98% of the time was the centroid loop**,
+not the land mask as assumed: it did `labeled == i` + `.sum()` + `center_of_mass(...)`
+per blob — O(blobs × pixels), ~500–1300 blobs over ~1.3M pixels. Replaced with batched
+ops: `np.bincount` for sizes + scipy `center_of_mass`/`maximum` with `index=` (each a
+few full-array passes). **Output-identical** to the per-blob loop.
+
+| Origin (≈1.3M-px window) | Before | After | Speedup |
+|---|---:|---:|---:|
+| Los Angeles (315 domes) | 928 ms | **79 ms** | ~12× |
+| New York (829 domes) | 2547 ms | **84 ms** | ~30× |
+
+Correctness: new vs original loop = identical dome lists on both windows; 390 tests pass
+(incl. `test_light_dome_array.py`). Structural win (removes a blobs×pixels factor), so the
+ratio holds on Lambda's slower vCPU too — laptop absolute 0.9–2.5 s → ~0.08 s.
+
+**In-region confirmation** (throwaway 2 GB worker, cold), `light dome detection` phase vs
+the OLD-code baselines on the same origins:
+
+| Origin | OLD (baseline) | NEW | Speedup |
+|---|---:|---:|---:|
+| Phoenix | ~1726 ms | 207 ms | ~8× |
+| Dallas | ~4516 ms | 185 ms | ~24× |
+
+`find_nearby` returned cleanly both times. Confirmed → shipped.
+
 ## Reproduce
 
 - `scripts/bench_padus_load.py` — PAD-US load + lookup benchmark (`--verify-against` for correctness).

--- a/scripts/bench_dome_detection.py
+++ b/scripts/bench_dome_detection.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Profile _find_light_domes_from_array sub-steps on a real 150-mile VIIRS window.
+
+Loads the same window find_nearby builds (dome_search_radius=150 mi) for a bright
+origin, times the whole function, then attributes time to each sub-step so we know
+which one variable to optimize. Local backend (uses the on-disk VIIRS TIF).
+"""
+import math
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from PyNightSkyPredictor import darksky  # noqa: E402
+
+ORIGINS = [
+    ("Los Angeles, CA", 34.0522, -118.2437),
+    ("New York, NY", 40.7128, -74.0060),
+]
+
+
+def _reference_domes(arr, min_lat, max_lat, min_lon, max_lon, tier_min_bortle=8,
+                     min_blob_pixels=4):
+    """The ORIGINAL per-blob-loop implementation, for correctness comparison."""
+    import numpy as np
+    from scipy.ndimage import label as ndlabel, center_of_mass as ndcom
+    rows, cols = arr.shape
+    lat_vals = np.linspace(max_lat, min_lat, rows)
+    lon_vals = np.linspace(min_lon, max_lon, cols)
+    lat_grid, lon_grid = np.meshgrid(lat_vals, lon_vals, indexing="ij")
+    masked = np.where(darksky._glm.is_land(lat_grid, lon_grid), arr, np.nan)
+    sqm = np.where(masked > 0, 21.7 - 2.5 * np.log10(masked + 0.6), np.nan)
+    bortle = darksky._sqm_to_bortle_array(sqm)
+    tier = (bortle >= tier_min_bortle) & (bortle != 0)
+    if not tier.any():
+        return []
+    labeled, n = ndlabel(tier, structure=np.ones((3, 3), dtype=np.int8))
+    out = []
+    for i in range(1, n + 1):
+        bm = labeled == i
+        if bm.sum() < min_blob_pixels:
+            continue
+        rf, cf = ndcom(arr, labeled, i)
+        if math.isnan(rf) or math.isnan(cf):
+            continue
+        ri = min(int(round(rf)), rows - 1)
+        ci = min(int(round(cf)), cols - 1)
+        out.append((float(lat_grid[ri, ci]), float(lon_grid[ri, ci]), int(np.max(bortle[bm]))))
+    return out
+
+
+def _window_for(lat, lon, radius=150):
+    dlat = radius / 69.0
+    dlon = radius / max(69.0 * math.cos(math.radians(lat)), 0.01)
+    return lat - dlat, lat + dlat, lon - dlon, lon + dlon
+
+
+def _step_profile(arr, min_lat, max_lat, min_lon, max_lon):
+    """Replicate the function's steps with per-step timing (same logic as source)."""
+    import numpy as np
+    from scipy.ndimage import label as ndlabel, center_of_mass as ndcom
+    t = {}
+
+    t0 = time.perf_counter()
+    rows, cols = arr.shape
+    lat_vals = np.linspace(max_lat, min_lat, rows)
+    lon_vals = np.linspace(min_lon, max_lon, cols)
+    lat_grid, lon_grid = np.meshgrid(lat_vals, lon_vals, indexing="ij")
+    t["meshgrid"] = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    masked = np.where(darksky._glm.is_land(lat_grid, lon_grid), arr, np.nan)
+    t["is_land mask"] = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    sqm = np.where(masked > 0, 21.7 - 2.5 * np.log10(masked + 0.6), np.nan)
+    bortle = darksky._sqm_to_bortle_array(sqm)
+    t["sqm+bortle"] = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    tier = (bortle >= 8) & (bortle != 0)
+    labeled, n = ndlabel(tier, structure=np.ones((3, 3), dtype=np.int8))
+    t["tier+label"] = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    nb = 0
+    for i in range(1, n + 1):
+        bm = labeled == i
+        if bm.sum() < 4:
+            continue
+        rf, cf = ndcom(arr, labeled, i)
+        if math.isnan(rf) or math.isnan(cf):
+            continue
+        nb += 1
+    t["centroid loop"] = time.perf_counter() - t0
+    return t, n, nb
+
+
+def main():
+    import numpy as np
+    for label, lat, lon in ORIGINS:
+        mnla, mxla, mnlo, mxlo = _window_for(lat, lon)
+        arr = darksky._load_raster_window("viirs", mnla, mxla, mnlo, mxlo)
+        if arr is None:
+            print(f"{label}: viirs window unavailable"); continue
+        print(f"\n{label}: array {arr.shape} = {arr.size:,} px")
+
+        # whole-function timing (3 runs)
+        times = []
+        for _ in range(3):
+            t0 = time.perf_counter()
+            domes = darksky._find_light_domes_from_array(arr, mnla, mxla, mnlo, mxlo, 8)
+            times.append((time.perf_counter() - t0) * 1000)
+        print(f"  _find_light_domes_from_array: median {statistics.median(times):.0f} ms "
+              f"(min {min(times):.0f})  -> {len(domes)} raw domes")
+
+        # correctness: new (vectorised) vs original per-blob loop
+        t0 = time.perf_counter()
+        ref = _reference_domes(arr, mnla, mxla, mnlo, mxlo, 8)
+        ref_ms = (time.perf_counter() - t0) * 1000
+        same = sorted(domes) == sorted(ref)
+        print(f"  reference (old loop): {ref_ms:.0f} ms, {len(ref)} domes  "
+              f"-> identical: {same}")
+        if not same:
+            sd, sr = set(domes), set(ref)
+            print(f"    only-new={len(sd-sr)}  only-ref={len(sr-sd)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tier 3 of the find_nearby perf work. Profiled, benchmarked, and **confirmed in-region** before shipping.

`_find_light_domes_from_array`'s centroid loop was **O(blobs × pixels)** — per blob: `labeled == i` + `.sum()` + `center_of_mass(...)`, each a full ~1.3M-pixel pass over 500–1300 blobs. Profiling showed it was **97–98%** of the function (the land mask, my prior suspect, was 1–2%).

### Change (output-identical)
Batched: `np.bincount` for blob sizes + scipy `center_of_mass`/`maximum` with `index=` (a few full-array passes total).

### Benchmarks
| | Before | After | Speedup |
|---|---:|---:|---:|
| LA (local, 1.3M px) | 928 ms | 79 ms | ~12× |
| NY (local, 1.4M px) | 2547 ms | 84 ms | ~30× |
| Phoenix (in-region phase) | ~1726 ms | 207 ms | ~8× |
| Dallas (in-region phase) | ~4516 ms | 185 ms | ~24× |

Output verified **identical** to the original per-blob loop on both real windows; `find_nearby` returned cleanly in-region. Tests: 390 passed (incl. `test_light_dome_array.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)