### PR TITLE
perf(worker): non-blocking cold-start prewarm (init 10s-timeout -> ~4.5s)

### DIFF
--- a/apps/worker/handler.py
+++ b/apps/worker/handler.py
@@ -29,11 +29,15 @@ if "LAMBDA_TASK_ROOT" in os.environ:
     except ImportError:
         pass
 
-    # Pre-warm both S3 COGs during Lambda init so the first job doesn't pay for
-    # cold GDAL VSI_CACHE misses (header reads + overview structure = ~10-15s on
-    # a fresh container). Opening + sampling one pixel caches the COG index and
-    # at least one tile, cutting the first real job's raster I/O to near-zero.
-    def _prewarm_rasters() -> None:
+    # Pre-warm the first-job cost centres in a BACKGROUND DAEMON THREAD (mirrors the
+    # API's lifespan prewarm in apps/api/main.py). Doing this synchronously at module
+    # init blew Lambda's 10 s init budget (INIT_REPORT Status: timeout), so the wasted
+    # init re-ran into the first invoke. Threaded, module init returns immediately and
+    # the warming proceeds in the background, benefiting subsequent jobs on the same
+    # container. Each step is independently guarded so one failure can't wedge the rest.
+    def _prewarm() -> None:
+        # S3 COGs: open + sample one pixel to prime GDAL's VSI_CACHE (header + a tile),
+        # cutting cold raster I/O on the first real job.
         try:
             import rasterio
             from PyNightSkyPredictor import ports as _p
@@ -41,11 +45,30 @@ if "LAMBDA_TASK_ROOT" in os.environ:
             for dataset in ("viirs", "falchi"):
                 path = src.path_for(dataset, show_progress=False)
                 with rasterio.open(path) as ds:
-                    list(ds.sample([(0.0, 0.0)]))   # one pixel primes the file header + tile
+                    list(ds.sample([(0.0, 0.0)]))
         except Exception as _e:
             log.debug("Raster pre-warm failed: %s", _e)
+        # PAD-US H3 index (columnar load) used by find_nearby Tier 1.
+        try:
+            from PyNightSkyPredictor import darksky as _ds
+            _ds._load_padus_h3_index()
+        except Exception as _e:
+            log.debug("PAD-US pre-warm failed: %s", _e)
+        # DynamoDB connection pool (same warmup call the API uses).
+        try:
+            from PyNightSkyPredictor import ports as _p
+            _p.get_backend().cache.get("__warmup__")
+        except Exception as _e:
+            log.debug("Cache pre-warm failed: %s", _e)
+        # Ephemeris (mmap de421.bsp) — needed by trip/calendar jobs.
+        try:
+            from PyNightSkyPredictor import sky_events as _se
+            _se._ephemeris()
+        except Exception as _e:
+            log.debug("Ephemeris pre-warm failed: %s", _e)
 
-    _prewarm_rasters()
+    import threading
+    threading.Thread(target=_prewarm, daemon=True).start()
 
 
 def handler(event, context=None):

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -194,6 +194,30 @@ In-region confirmation (throwaway 2 GB worker, uncached):
 
 Both output-preserving; 390 tests pass.
 
+### Worker cold start · non-blocking prewarm + memory A/B (2026-06-10)
+
+The worker ran `_prewarm_rasters()` **synchronously at module init**, blowing Lambda's 10 s
+init budget (`INIT_REPORT … Status: timeout`) — wasted init that re-ran into the first
+invoke. Moved the warm-up to a **daemon thread** (mirrors the API's lifespan prewarm) and
+extended it to warm rasters + PAD-US index + DynamoDB pool + ephemeris in the background.
+
+In-region (throwaway 2 GB worker, cold containers):
+- **`INIT` no longer times out: 10 s timeout → ~4.4–5.8 s.**
+- **PAD-US load in-job → 0 ms** (background-prewarmed; was 0.45 s columnar / 5–24 s as the old dict).
+- First cold-job `[profile] TOTAL` ~3.1–3.5 s (was dominated by the wasted init + cold PAD-US).
+
+**Memory A/B (2 GB vs 3 GB; account caps Lambda at 3008 MB so 4 GB N/A):**
+
+| cold sample | init | first-job TOTAL | billed GB-s |
+|---|--:|--:|--:|
+| 2 GB | ~4.4 s | 3481 ms | 16.0 |
+| 3 GB (max) | ~4.6 s | 3117 ms | 23.5 |
+
+3 GB shaved ~0.3 s off the invoke but **init was flat** (the cold-start dominator) at ~47%
+more GB-s/invoke. **Decision: keep 2 GB — memory bump is a no-op.** Shipped the prewarm fix
+only. (Out of scope per decision: keep-warm ping, provisioned concurrency — the one-time
+~17 s first-container image lazy-load tax remains, only addressable by provisioned concurrency.)
+
 ## Reproduce
 
 - `scripts/bench_padus_load.py` — PAD-US load + lookup benchmark (`--verify-against` for correctness).


### PR DESCRIPTION
Worker cold-start fix (free; no recurring cost). Confirmed in-region.

The worker ran `_prewarm_rasters()` **synchronously at module init**, blowing Lambda's 10 s init budget (`INIT_REPORT … Status: timeout`) — the wasted init re-ran into the first invoke. The API already prewarms in a daemon thread; the worker didn't.

### Change
Move the warm-up to a **background daemon thread** (mirrors `apps/api/main.py` lifespan) and extend it to prime the other first-job cost centres, each independently guarded: rasters (existing), **PAD-US H3 index**, the **DynamoDB pool**, and the **ephemeris**.

### In-region confirmation (throwaway 2 GB worker, cold)
- **`INIT` no longer times out: 10 s → ~4.4–5.8 s.**
- **PAD-US load in-job → 0 ms** (background-prewarmed).
- First cold-job `[profile] TOTAL` ~3.1–3.5 s.

### Memory A/B (out of an abundance of caution)
2 GB vs 3 GB (account caps Lambda at 3008 MB, so 4 GB N/A): **init flat ~4.5 s**; 3 GB only ~0.3 s faster invoke at ~47% more GB-s. **Decision: keep 2 GB — memory bump is a no-op.** No CDK change.

Out of scope (per decision): keep-warm ping, provisioned concurrency (the one-time ~17 s first-container image lazy-load tax remains). 390 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)