### PR TITLE
Fast-first-poll + backoff for /nearby (halve warm perceived latency)

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -32,7 +32,11 @@ function buildQuery(q: NightQuery): string {
   return p.toString()
 }
 
-const NEARBY_POLL_MS    = 3_000
+// Adaptive poll backoff: a warm job finishes in ~1.3s, so probe early and often
+// at first, then ease off. Each entry is the wait BEFORE that poll; the last value
+// repeats until the timeout. Catches a warm result near ~1.5s instead of the old
+// fixed 3s tick (no compute change — purely perceived latency).
+const NEARBY_POLL_BACKOFF_MS = [500, 1_000, 2_000, 3_000]
 const NEARBY_TIMEOUT_MS = 120_000
 
 /**
@@ -58,8 +62,9 @@ export async function fetchNearby(lat: number, lon: number, radius = 60): Promis
   const { job_id } = (await res.json()) as { job_id: string }
 
   const deadline = Date.now() + NEARBY_TIMEOUT_MS
-  while (Date.now() < deadline) {
-    await new Promise(r => setTimeout(r, NEARBY_POLL_MS))
+  for (let attempt = 0; Date.now() < deadline; attempt++) {
+    const wait = NEARBY_POLL_BACKOFF_MS[Math.min(attempt, NEARBY_POLL_BACKOFF_MS.length - 1)]
+    await new Promise(r => setTimeout(r, wait))
     let poll: Response
     try {
       poll = await fetch(`/jobs/${job_id}`)


### PR DESCRIPTION
## What

The `/nearby` UI polling slept a fixed **3s before its first poll** of `/jobs/{id}` ([apps/web/src/api.ts](apps/web/src/api.ts)). A warm job finishes in ~1.3s, so the user always waited for the next 3s tick → real feel ~3–4s.

Replaces the fixed interval with an **adaptive backoff** `[500, 1000, 2000, 3000]ms` (wait-before-each-poll; last value repeats until timeout). A warm result is now caught near **~1.5s instead of 3s** — roughly halving perceived latency.

## Why this lever

Per `memory/find_nearby_perf.md`, the poll interval is the #1 cheap lever on the ~2.5s warm load: **zero compute change**, no worker/API touch. It caps at the old 3s cadence so slow/cold jobs don't get hammered, and the 120s timeout is unchanged.

## Verification

- `tsc -b` clean, `eslint src/api.ts` clean.
- Loop is fully encapsulated in `fetchNearby`; sole consumer (`ReportCard.tsx`) just awaits it — no signature change.
- Skipped browser preview: this is a timing change against the SQS worker path, which a local preview can't exercise.

## Follow-ups (not in this PR)

- Enqueue ~1.1s TTFB to 202 — check if `/nearby` geocodes/validates synchronously before enqueue.
- Worker compute ~1.3s warm — S3 grid reads + dome detection + geocoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)