### PR TITLE
Drop wasted reverse-geocode/tz from the /nearby enqueue

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -68,6 +68,10 @@ async def lifespan(app: FastAPI):
                 _p.get_backend().cache.get("__warmup__")   # open DynamoDB connection pool
             except Exception as _e:
                 logging.getLogger(__name__).debug("Cache pre-warm failed: %s", _e)
+            try:
+                jobs._sqs()   # build the boto3 SQS client off the first enqueue's path
+            except Exception as _e:
+                logging.getLogger(__name__).debug("SQS pre-warm failed: %s", _e)
 
         threading.Thread(target=_prewarm, daemon=True).start()
     yield
@@ -337,7 +341,16 @@ def nearby(
                         description="Search radius in miles (5–150)"),
 ):
     """Submit a nearby dark-sky search → 202 + job_id (poll /jobs/{id})."""
-    la, lo, _disp, _tz = _resolve(location, lat, lon)
+    # Only resolve what the job actually uses (lat/lon). The display name and
+    # timezone that _resolve() also computes are discarded here, and the worker
+    # reverse-geocodes the origin itself — so for raw coordinates (the web UI's
+    # path) we skip the wasted timezone lookup + networked reverse-geocode.
+    if location:
+        la, lo, _disp, _tz = _resolve(location, None, None)   # name → coords (still needed)
+    elif lat is not None and lon is not None:
+        la, lo = lat, lon
+    else:
+        raise HTTPException(400, "Provide 'location' or both 'lat' and 'lon'.")
     job_id = jobs.submit({"type": "nearby", "lat": la, "lon": lo, "radius_miles": radius})
     return _accepted(job_id)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -165,6 +165,19 @@ def test_nearby_requires_location_or_coords():
     assert client.get("/nearby", params={"radius": 60}).status_code == 400
 
 
+def test_nearby_raw_coords_skip_geocoding(monkeypatch, _nearby_mocks):
+    """Raw-coord /nearby must NOT reverse-geocode or look up a timezone — the job
+    only needs lat/lon and the worker names the origin itself. Both are wasted
+    enqueue latency, so we assert the handler never touches them."""
+    def _boom(*a, **kw):
+        raise AssertionError("raw-coord /nearby should not resolve a place")
+    monkeypatch.setattr(main_mod._loc, "reverse_geocode", _boom)
+    monkeypatch.setattr(main_mod._loc, "timezone_for", _boom)
+    r = TestClient(app).get("/nearby", params={"lat": 35.2, "lon": -111.6, "radius": 60})
+    assert r.status_code == 202
+    assert "job_id" in r.json()
+
+
 @pytest.mark.eph
 @requires_rasters
 def test_night_by_coords_matches_baseline():


### PR DESCRIPTION
## What

The `/nearby` handler called `_resolve()` — an in-process timezone lookup **plus a networked reverse-geocode** — then **discarded both results** (`_disp`/`_tz`). The job params only carry `lat/lon/radius`, and the worker's `find_nearby` reverse-geocodes the origin itself. So for the web UI's raw-coordinate path (`ReportCard.tsx` → `fetchNearby(report.lat, report.lon, radius)`), this was pure wasted enqueue latency.

This change resolves only what the job uses:
- **Raw coords** (the UI path): skip geocoding + timezone entirely — pass `lat/lon` straight to `jobs.submit`.
- **`location` name**: still resolve name→coords (unavoidable).
- Plus: **prewarm the SQS client** in the lifespan daemon thread so the first enqueue after a cold start doesn't pay the ~200–500ms boto3 client build.

## Why

Next lever from `memory/find_nearby_perf.md` after the poll-interval fix ([#26](https://github.com/mbeher2200/PyNightSkyPredictor/pull/26)). Removes ~60–530ms on AWS (warm hit → miss), and a full **1.1s** Nominatim rate-limit sleep on the local backend. Expected warm enqueue: ~1.1s → ~0.2–0.5s (just `_cache.set` pending + `send_message`).

## Correctness

- **Output unchanged** — `_disp`/`_tz` were already discarded; the worker names the origin.
- Only behavior change: raw-coord `/nearby` no longer returns `400` for a timezone-less point (e.g. mid-ocean). Not reachable from the UI, which always passes coords from an already-resolved report; such a search just returns no sites.

## Tests

- `408 passed, 7 skipped` (full suite, offline).
- New `test_nearby_raw_coords_skip_geocoding` monkeypatches `reverse_geocode`/`timezone_for` to raise and asserts a raw-coord `/nearby` still returns 202 — proving neither is called. This also removes a hidden Nominatim network/sleep dependency the `/nearby` tests previously had.

## Follow-up

In-region warm-enqueue TTFB measurement (before/after) per CLAUDE.md once deployed; will log the numbers in `docs/PERF_FINDNEARBY.md` + the memory note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)