### PR TITLE
Keep the SQS worker warm to kill the ~4.6s cold Init

### DIFF
--- a/apps/worker/handler.py
+++ b/apps/worker/handler.py
@@ -20,6 +20,47 @@ from apps import jobs
 
 log = logging.getLogger()
 
+_warmed = False
+
+
+# Pre-warm the first-job cost centres (mirrors the API's lifespan prewarm in
+# apps/api/main.py). Idempotent + cheap to re-run; guarded by `_warmed` so the
+# recurring warmup ping only does the real work once per container. Each step is
+# independently guarded so one failure can't wedge the rest.
+def _prewarm() -> None:
+    global _warmed
+    if _warmed:
+        return
+    # S3 grids: open (fetch the tiny .json) + sample one pixel (a few-byte ranged
+    # GET) to prime each dataset's GridArray, cutting cold raster I/O on the first job.
+    try:
+        from PyNightSkyPredictor import ports as _p
+        src = _p.get_backend().raster_source
+        for dataset in ("viirs", "falchi"):
+            src.sample(dataset, 0.0, 0.0)
+    except Exception as _e:
+        log.debug("Raster pre-warm failed: %s", _e)
+    # PAD-US H3 index (columnar load) used by find_nearby Tier 1.
+    try:
+        from PyNightSkyPredictor import darksky as _ds
+        _ds._load_padus_h3_index()
+    except Exception as _e:
+        log.debug("PAD-US pre-warm failed: %s", _e)
+    # DynamoDB connection pool (same warmup call the API uses).
+    try:
+        from PyNightSkyPredictor import ports as _p
+        _p.get_backend().cache.get("__warmup__")
+    except Exception as _e:
+        log.debug("Cache pre-warm failed: %s", _e)
+    # Ephemeris (mmap de421.bsp) — needed by trip/calendar jobs.
+    try:
+        from PyNightSkyPredictor import sky_events as _se
+        _se._ephemeris()
+    except Exception as _e:
+        log.debug("Ephemeris pre-warm failed: %s", _e)
+    _warmed = True
+
+
 if "LAMBDA_TASK_ROOT" in os.environ:
     try:
         from aws_xray_sdk.core import patch_all as _xray_patch_all
@@ -29,47 +70,24 @@ if "LAMBDA_TASK_ROOT" in os.environ:
     except ImportError:
         pass
 
-    # Pre-warm the first-job cost centres in a BACKGROUND DAEMON THREAD (mirrors the
-    # API's lifespan prewarm in apps/api/main.py). Doing this synchronously at module
-    # init blew Lambda's 10 s init budget (INIT_REPORT Status: timeout), so the wasted
-    # init re-ran into the first invoke. Threaded, module init returns immediately and
-    # the warming proceeds in the background, benefiting subsequent jobs on the same
-    # container. Each step is independently guarded so one failure can't wedge the rest.
-    def _prewarm() -> None:
-        # S3 grids: open (fetch the tiny .json) + sample one pixel (a few-byte ranged
-        # GET) to prime each dataset's GridArray, cutting cold raster I/O on the first job.
-        try:
-            from PyNightSkyPredictor import ports as _p
-            src = _p.get_backend().raster_source
-            for dataset in ("viirs", "falchi"):
-                src.sample(dataset, 0.0, 0.0)
-        except Exception as _e:
-            log.debug("Raster pre-warm failed: %s", _e)
-        # PAD-US H3 index (columnar load) used by find_nearby Tier 1.
-        try:
-            from PyNightSkyPredictor import darksky as _ds
-            _ds._load_padus_h3_index()
-        except Exception as _e:
-            log.debug("PAD-US pre-warm failed: %s", _e)
-        # DynamoDB connection pool (same warmup call the API uses).
-        try:
-            from PyNightSkyPredictor import ports as _p
-            _p.get_backend().cache.get("__warmup__")
-        except Exception as _e:
-            log.debug("Cache pre-warm failed: %s", _e)
-        # Ephemeris (mmap de421.bsp) — needed by trip/calendar jobs.
-        try:
-            from PyNightSkyPredictor import sky_events as _se
-            _se._ephemeris()
-        except Exception as _e:
-            log.debug("Ephemeris pre-warm failed: %s", _e)
-
+    # Best-effort prewarm in a BACKGROUND DAEMON THREAD at module init: doing it
+    # synchronously here blew Lambda's init budget (INIT_REPORT timeout). This covers
+    # the case where the first event on a cold container is a real job. The scheduled
+    # warmup ping (see handler) is the primary path and finishes the prewarm off the
+    # user path; this thread is suspended when the handler returns, so it may not.
     import threading
     threading.Thread(target=_prewarm, daemon=True).start()
 
 
 def handler(event, context=None):
     records = event.get("Records", []) if isinstance(event, dict) else []
+    if not records:
+        # Scheduled warmup ping (EventBridge, no SQS Records): keep this container
+        # alive AND fully primed so the next real job skips the ~4.6s cold init and
+        # the cold raster/PAD-US reads. Run prewarm synchronously (off the user path)
+        # rather than relying on the init daemon, which Lambda freezes on return.
+        _prewarm()
+        return {"warmed": True}
     for record in records:
         msg = json.loads(record["body"])
         job_id = msg["job_id"]

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -227,6 +227,22 @@ class LambdaApiStack(Stack):
         worker.add_environment("PYNIGHTSKY_ROUTE_CALCULATOR", route_calc.calculator_name)
         worker.add_event_source(lambda_events.SqsEventSource(jobs_queue, batch_size=1))
 
+        # --- Scheduled worker warmup ping — keeps one worker container alive + primed ---
+        # The worker is only invoked by SQS, so at sparse traffic nearly every job pays the
+        # ~4.6s cold Init. EventBridge invokes the worker directly every 4 min with a
+        # non-SQS event (no Records); the handler treats that as a warmup, runs the prewarm
+        # synchronously, and returns. Cost: ~10,800 tiny invocations/month (free tier).
+        worker_warmup_rule = events.Rule(
+            self, "WorkerWarmupRule",
+            schedule=events.Schedule.rate(Duration.minutes(4)),
+        )
+        worker_warmup_rule.add_target(
+            targets.LambdaFunction(
+                worker,
+                event=events.RuleTargetInput.from_object({"warmup": True}),
+            )
+        )
+
         # The API can enqueue jobs and knows the queue URL (its presence flips the
         # endpoints from inline to async).
         jobs_queue.grant_send_messages(fn)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -63,6 +63,16 @@ def test_worker_handler_processes_records(monkeypatch, mem_cache):
     assert jobs.get("abc") == {"status": "done", "result": {"ok": True}}
 
 
+def test_worker_handler_warmup_ping(monkeypatch):
+    """A non-SQS event (no Records) is a scheduled warmup: it runs prewarm and
+    returns without touching the job pipeline."""
+    calls = {"prewarm": 0, "process": 0}
+    monkeypatch.setattr(worker_handler, "_prewarm", lambda: calls.__setitem__("prewarm", calls["prewarm"] + 1))
+    monkeypatch.setattr(jobs, "process", lambda *a, **kw: calls.__setitem__("process", calls["process"] + 1))
+    assert worker_handler.handler({"warmup": True}, None) == {"warmed": True}
+    assert calls == {"prewarm": 1, "process": 0}
+
+
 def test_trip_endpoint_returns_202_then_done(monkeypatch, mem_cache):
     monkeypatch.setattr(main_mod._loc, "resolve",
                         lambda name: (40.0, -105.0, "Boulder", "America/Denver"))


### PR DESCRIPTION
## What

Adds an EventBridge rule that pings the SQS worker Lambda every 4 minutes with a non-SQS event (`{"warmup": true}`, no `Records`). The handler treats a Record-less event as a warmup: it runs the prewarm **synchronously** and returns `{"warmed": true}`.

## Why — in-region profiling reframe

CloudWatch profiling of the full `/nearby` lifecycle showed the **worker is ~100% of perceived latency**, and the prior "~1.3s warm" baseline was a best-case outlier:

| Leg | Reality |
|---|---|
| API enqueue + polls (`/pynightsky/api`) | warm **2–15ms**, kept warm by the existing `/warmup` rule — not the bottleneck |
| **Worker** (`/pynightsky/worker`) | only **~9 invokes/6h, NOT kept warm** → cold **Init 4.6s + 3–5s handler (~8s)**; even warm, **4–5s typical** |

Only the API had a keep-warm ping. The worker is SQS-triggered, so at sparse traffic nearly every search paid the **4.6s cold Init**. This is the single biggest, cheapest win.

## How

- **Handler** (`apps/worker/handler.py`): `_prewarm()` lifted to module scope, guarded by a `_warmed` flag (idempotent, runs the real work once per container). A Record-less event runs it synchronously and returns. **Synchronous on purpose** — Lambda freezes the container when the handler returns, which would suspend the init-time daemon prewarm; the ping both keeps one container alive *and* fully primes rasters/PAD-US/ephemeris off the user path.
- **CDK** (`cdk/lambda_api_stack.py`): `WorkerWarmupRule`, rate 4 min, target = worker with constant input `{"warmup": true}`. Mirrors the API `WarmupRule`. Cost ~10,800 tiny invokes/month (free tier).

## Tests

- `409 passed, 7 skipped`. New `test_worker_handler_warmup_ping` asserts a Record-less event runs prewarm once and never touches `jobs.process`.
- Existing `test_worker_handler_processes_records` still green (real SQS path unchanged).

## Verify after deploy

Confirm the rule fires (worker invoked every 4 min) and that real jobs land on a warm container (no `Init Duration` in `/pynightsky/worker` REPORT lines). Expect cold-start searches (~8s) to disappear; warm worker compute (~4–5s) is the next lever — to be profiled via the throwaway-worker recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)