### PR TITLE
Cache the AWS drive-time route matrix per leg

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -495,6 +495,7 @@ _OVERPASS_URL    = "https://overpass-api.de/api/interpreter"
 _NOMINATIM_URL   = "https://nominatim.openstreetmap.org/reverse"
 _OVER_WATER      = "__water__"   # sentinel: Nominatim found no state/county — ocean or large water body
 _GEO_CACHE_TTL   = 90 * 24 * 3600   # 90 days
+_DRIVE_NO_ROUTE  = -1            # sentinel: route matrix returned no duration for this leg
 
 # PAD-US H3 spatial index — module-level lazy-load cache
 _PADUS_H3_FILENAME = "darkhours_padus_h3.npz"
@@ -562,32 +563,58 @@ def _reset_location_client() -> None:
     _location_client = None
 
 
+def _drive_cache_key(olat: float, olon: float, dlat: float, dlon: float) -> str:
+    """Per-leg drive-time cache key (origin→destination, rounded to ~111 m)."""
+    return f"route_drive|{olat:.3f}|{olon:.3f}|{dlat:.3f}|{dlon:.3f}"
+
+
 def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> None:
     """Annotate each cluster dict with drive_minutes (int | None) via AWS Location route matrix.
 
     AWS-backend only. Mutates in-place. Silently sets None on any API failure so the
     caller always has the field, just without a value.
+
+    Per-leg cached (origin→destination, rounded, 90-day TTL): dark-sky sites for a given
+    area are stable, so repeat searches skip the route-matrix call entirely; only the
+    cache-missing legs are sent to AWS. The matrix phase was ~2 s and previously uncached —
+    the dominant warm cost (see docs/PERF_FINDNEARBY.md).
     """
     if not clusters:
         return
+    # 1. Serve cached legs from a single batched route-matrix call's worth of history;
+    #    collect the misses. A cached _DRIVE_NO_ROUTE means "computed, no route" (≠ miss).
+    misses = []
+    for c in clusters:
+        cached = cache.get(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]))
+        if cached is not None:
+            c["drive_minutes"] = None if cached == _DRIVE_NO_ROUTE else cached
+        else:
+            c["drive_minutes"] = None      # default until filled by the API below
+            misses.append(c)
+    if not misses:
+        return
+    # 2. One route-matrix call for just the uncached legs; cache each result. On failure
+    #    leave drive_minutes=None and DON'T cache, so a transient error isn't sticky.
     calc_name = os.environ.get("PYNIGHTSKY_ROUTE_CALCULATOR", "pynightsky-route-calculator")
     try:
         client = _location()
         resp = client.calculate_route_matrix(
             CalculatorName=calc_name,
             DeparturePositions=[[origin_lon, origin_lat]],
-            DestinationPositions=[[c["lon"], c["lat"]] for c in clusters],
+            DestinationPositions=[[c["lon"], c["lat"]] for c in misses],
             TravelMode="Car",
         )
         row = resp.get("RouteMatrix", [[]])[0]
-        for i, c in enumerate(clusters):
+        for i, c in enumerate(misses):
             entry = row[i] if i < len(row) else {}
             secs  = entry.get("DurationSeconds") if entry else None
-            c["drive_minutes"] = round(secs / 60) if secs is not None else None
+            mins  = round(secs / 60) if secs is not None else None
+            c["drive_minutes"] = mins
+            cache.set(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]),
+                      mins if mins is not None else _DRIVE_NO_ROUTE,
+                      ttl_seconds=_GEO_CACHE_TTL)
     except Exception as e:
         log.debug("AWS route matrix failed: %s", e)
-        for c in clusters:
-            c["drive_minutes"] = None
 
 
 def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -252,3 +252,37 @@ and has a better tail. Cold open is equal/better. Correctness: all 10 test citie
 Image: worker **1.28 GB** (rasterio/GDAL absent). Harness: `out/profile_baseline.py` (host
 old-vs-new A/B), `out/city_probe.py` (profiled 10-city probe; run in-container with
 `PYNIGHTSKY_BACKEND=aws`).
+
+## 2026-06-16 — Lifecycle profile + worker keep-warm + drive-time caching
+
+End-to-end `/nearby` is **worker-bound**. API enqueue + polls are warm 2–15 ms (kept warm by
+the existing `/warmup` rule); the SQS worker was **not** kept warm and dominates latency.
+
+**In-region warm profile** (throwaway worker cloned from the deployed artifact, `PROFILE=1`,
+3 synthetic invokes, torn down). Per-phase ms `[cold+cachecold | warm+cachecold | warm+cachewarm]`:
+
+| phase | cold+cold | warm+cold | warm+warm |
+|---|--:|--:|--:|
+| **drive times (aws)** *(uncached)* | 1961 | 934 | **1978** |
+| viirs window read (S3) | 562 | 928 | 347 |
+| falchi window read (S3) | 378 | 371 | 200 |
+| extract+cluster+dome-detect (CPU) | 656 | 558 | 543 |
+| jit geocode | 82 | 826 | 5 |
+| dome naming | 459 | 323 | 62 |
+| origin settlement+lookup | 1385 | 377 | 9 |
+| **TOTAL handler** | **5499** (+Init 4454) | **4340** | **3158** |
+
+**Headline:** even fully cache-warm the worker is 3.16 s, and `drive times` ≈ 1.98 s (~63%)
+— the dominant phase, and uncached. (A laptop-harness run had shown drive-times at only
+~303 ms — misleading; the in-region throwaway is authoritative.)
+
+**Shipped:**
+- **Worker keep-warm** (PR #28): `WorkerWarmupRule` (EventBridge rate(4 min) → worker with
+  `{"warmup":true}`); handler runs prewarm synchronously on a Record-less event. Verified:
+  cold ping Init 4.93 s + 1.56 s prewarm off the user path; next ping warm 4.8 ms. Real jobs
+  skip the ~4.6 s cold Init.
+- **Drive-time per-leg cache**: `_aws_drive_times` now caches each origin→dest leg
+  (`route_drive|{olat:.3f}|{olon:.3f}|{dlat:.3f}|{dlon:.3f}`, 90-day TTL); only cache-missing
+  legs hit `calculate_route_matrix`; failures aren't cached. The call was already a single
+  batched matrix request (server-parallel), so the win is from skipping it on repeat areas,
+  not from parallelising. Projected warm-warm 3.16 s → ~1.2 s.

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -294,3 +294,72 @@ class TestSettlementDispatch:
         mock_nom.assert_called_once_with(39.7392, -104.9903)
         mock_aws.assert_not_called()
         assert result == "Denver, CO"
+
+
+# ── Drive-time route matrix + per-leg caching (_aws_drive_times) ──────────────
+
+class TestAwsDriveTimes:
+    """The route-matrix call is the dominant warm find_nearby phase (~2 s) and was
+    previously uncached. These cover the per-leg cache: hits skip the API, misses hit
+    it once for just the missing legs, and failures stay un-cached."""
+
+    @pytest.fixture
+    def _mem_cache(self, monkeypatch):
+        store: dict = {}
+        monkeypatch.setattr("PyNightSkyPredictor.darksky.cache.get", lambda k: store.get(k))
+        monkeypatch.setattr("PyNightSkyPredictor.darksky.cache.set",
+                            lambda k, v, ttl_seconds=None: store.__setitem__(k, v))
+        return store
+
+    @staticmethod
+    def _matrix(*minutes):
+        """A calculate_route_matrix response with one row of DurationSeconds (None = gap)."""
+        return {"RouteMatrix": [[
+            ({"DurationSeconds": m * 60} if m is not None else {}) for m in minutes
+        ]]}
+
+    def test_miss_calls_matrix_once_and_caches(self, monkeypatch, _mem_cache):
+        import PyNightSkyPredictor.darksky as ds
+        client = MagicMock()
+        client.calculate_route_matrix.return_value = self._matrix(56, 88)
+        monkeypatch.setattr(ds, "_location", lambda: client)
+        clusters = [{"lat": 35.41, "lon": -111.46}, {"lat": 35.23, "lon": -111.07}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert [c["drive_minutes"] for c in clusters] == [56, 88]
+        client.calculate_route_matrix.assert_called_once()
+        # both legs now cached
+        assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == 56
+
+    def test_full_cache_hit_skips_api(self, monkeypatch, _mem_cache):
+        import PyNightSkyPredictor.darksky as ds
+        _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] = 56
+        _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.23, -111.07)] = ds._DRIVE_NO_ROUTE
+        client = MagicMock()
+        monkeypatch.setattr(ds, "_location", lambda: client)
+        clusters = [{"lat": 35.41, "lon": -111.46}, {"lat": 35.23, "lon": -111.07}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert [c["drive_minutes"] for c in clusters] == [56, None]  # sentinel → None
+        client.calculate_route_matrix.assert_not_called()
+
+    def test_partial_miss_queries_only_uncached(self, monkeypatch, _mem_cache):
+        import PyNightSkyPredictor.darksky as ds
+        _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] = 56
+        client = MagicMock()
+        client.calculate_route_matrix.return_value = self._matrix(88)  # only the miss
+        monkeypatch.setattr(ds, "_location", lambda: client)
+        clusters = [{"lat": 35.41, "lon": -111.46}, {"lat": 35.23, "lon": -111.07}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert [c["drive_minutes"] for c in clusters] == [56, 88]
+        # only the single uncached destination was sent
+        _, kwargs = client.calculate_route_matrix.call_args
+        assert kwargs["DestinationPositions"] == [[-111.07, 35.23]]
+
+    def test_api_failure_leaves_none_and_uncached(self, monkeypatch, _mem_cache):
+        import PyNightSkyPredictor.darksky as ds
+        client = MagicMock()
+        client.calculate_route_matrix.side_effect = RuntimeError("throttled")
+        monkeypatch.setattr(ds, "_location", lambda: client)
+        clusters = [{"lat": 35.41, "lon": -111.46}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert clusters[0]["drive_minutes"] is None
+        assert _mem_cache == {}  # transient failure must not poison the cache


### PR DESCRIPTION
## What

Caches `_aws_drive_times` per origin→destination leg so repeat-area searches skip the route-matrix call entirely. Only cache-missing legs are sent to AWS.

## Why — in-region measurement

A throwaway worker (cloned from the deployed artifact, `PROFILE=1`, torn down after) profiled `find_nearby` in-region across three regimes:

| phase | cold+cachecold | warm+cachecold | **warm+cachewarm** |
|---|--:|--:|--:|
| **drive times (aws)** *(uncached)* | 1961 | 934 | **1978** |
| TOTAL handler | 5499 (+Init 4454) | 4340 | **3158** |

**Even fully cache-warm the worker is 3.16s, and drive-times is ~1.98s (~63%) of it** — the dominant phase, recomputed on *every* search including repeats. (A laptop harness had shown only ~303ms; the in-region number is authoritative — which is why we measured in-region.)

## How

- Per-leg key `route_drive|{olat:.3f}|{olon:.3f}|{dlat:.3f}|{dlon:.3f}` (~111m granularity, matches the reverse-geocode cache), 90-day TTL.
- `_DRIVE_NO_ROUTE = -1` sentinel distinguishes "computed, no route" from a cache miss.
- Cached legs served from cache; misses go in one `calculate_route_matrix` call; **transient failures are not cached** (so an error isn't sticky for 90 days).
- The matrix call was already a single batched request (AWS computes the matrix server-side), so the win is skipping it on cache hits — not parallelising N calls.

Projected warm-warm **3.16s → ~1.2s**.

## Tests

- `413 passed, 7 skipped`. New `TestAwsDriveTimes`: cache miss → one matrix call + caches; full hit → no API; partial → queries only the uncached legs; API failure → `None`, uncached.

## Verify after deploy

Re-run the throwaway-worker profile on the new artifact: invoke a fresh area (drive-times ~2s, populates cache) then the same area again (drive-times ~0). Confirms the in-region delta. Then tear down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)