### PR TITLE
Fix deploy gate: lazy osmium import in osm_poi_builder

### DIFF
--- a/scripts/osm_poi_builder.py
+++ b/scripts/osm_poi_builder.py
@@ -50,7 +50,14 @@ from pathlib import Path
 
 import h3
 import numpy as np
-import osmium
+
+# osmium (pyosmium) is a BUILD-only dependency (requirements-build.txt), not installed in
+# the test/runtime envs. Import it lazily so this module is still importable for its pure
+# helpers (encode_poi_npz, POI_TYPE_LABELS, _classify) — e.g. from tests/test_poi_index.py.
+try:
+    import osmium
+except ImportError:
+    osmium = None
 
 RESOLUTION = 7   # ~5 km hex — matches the PAD-US index; used for build-time dedup
 OUT_DIR    = "cache"
@@ -278,6 +285,9 @@ def _filter_to_small_pbf(pbf_path: str, small_path: str) -> int:
 
 
 def build_index(pbf_path: str) -> None:
+    if osmium is None:
+        sys.exit("osmium (pyosmium) is required to build the index — "
+                 "pip install -r requirements-build.txt")
     small_path = os.path.join("Temp", "osm_pois_filtered.osm.pbf")
     os.makedirs("Temp", exist_ok=True)
     print(f"Pass 1: filtering POIs from {pbf_path} → {small_path} …", flush=True)


### PR DESCRIPTION
PR #30's deploy failed at the pytest gate: `tests/test_poi_index.py` imports `scripts/osm_poi_builder.py` for its pure helpers (`encode_poi_npz`, `POI_TYPE_LABELS`), but that module did `import osmium` at the top. `osmium` (pyosmium) is a **build-only** dep (`requirements-build.txt`), not installed in the CI test/runtime env → `ModuleNotFoundError` during collection → deploy gate failed (prod untouched, still on #29).

Fix: import `osmium` lazily (`None` if absent) so the module is importable for its pure helpers; `build_index` now guards with a clear error if run without it. Verified by simulating CI (blocking the osmium import) — module imports, `encode_poi_npz` works, `build_index` exits cleanly; full suite still 422 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)