### PR TITLE
Ship the OSM POI index in the worker bundle

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -28,6 +28,7 @@ RUN pip install -r requirements-worker.txt
 COPY PyNightSkyPredictor/ ./PyNightSkyPredictor/
 COPY apps/ ./apps/
 COPY cache/darkhours_padus_h3.npz ./cache/darkhours_padus_h3.npz
+COPY cache/osm_pois.npz ./cache/osm_pois.npz
 
 # Drop root (Lambda fs is read-only except /tmp, for any user).
 ENV HOME=/tmp

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -55,7 +55,8 @@ def _stage_worker_src() -> str:
     as raw-binary grids with numpy+boto3; the PAD-US index is a numpy .npz), so the
     worker fits a zip Lambda (~169 MB unzipped < 250 MB). We ship the engine source,
     apps (minus the web SPA), the de421.bsp ephemeris (inside PyNightSkyPredictor/),
-    the PAD-US .npz, and requirements.txt; bundling pip-installs the deps on top.
+    the PAD-US + OSM-POI .npz indexes, and requirements.txt; bundling pip-installs the
+    deps on top.
     """
     stage = _REPO / "cdk" / ".worker_build"
     if stage.exists():
@@ -65,7 +66,8 @@ def _stage_worker_src() -> str:
     shutil.copytree(_REPO / "PyNightSkyPredictor", stage / "PyNightSkyPredictor", ignore=ig)
     shutil.copytree(_REPO / "apps", stage / "apps", ignore=ig)
     (stage / "cache").mkdir()
-    shutil.copy(_REPO / "cache" / "darkhours_padus_h3.npz", stage / "cache" / "darkhours_padus_h3.npz")
+    for _npz in ("darkhours_padus_h3.npz", "osm_pois.npz"):
+        shutil.copy(_REPO / "cache" / _npz, stage / "cache" / _npz)
     shutil.copy(_REPO / "requirements.txt", stage / "requirements.txt")
     return str(stage)
 


### PR DESCRIPTION
The POI-first `find_nearby` code shipped in #30/#31, but the worker zip bundling (`cdk/lambda_api_stack._worker_asset`) copied only `cache/darkhours_padus_h3.npz` — never `cache/osm_pois.npz`. So `_load_poi_h3_index()` returned `None` and the worker silently ran **pixel-first**. This copies both indexes into the bundle (and updates the stale `Dockerfile.worker` for consistency).

Confirmed via in-region throwaway worker (PROFILE=1): with the index present, results are `is_poi`, the `jit geocode candidates` phase collapses ~162ms→~0.5ms, and drive times populate. Without it (current prod), it's pixel-first with no drive times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)