### PR TITLE
Drive times: GeoRoutes CalculateRouteMatrix + DepartNow (traffic-aware)

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -496,6 +496,10 @@ _NOMINATIM_URL   = "https://nominatim.openstreetmap.org/reverse"
 _OVER_WATER      = "__water__"   # sentinel: Nominatim found no state/county — ocean or large water body
 _GEO_CACHE_TTL   = 90 * 24 * 3600   # 90 days
 _DRIVE_NO_ROUTE  = -1            # sentinel: route matrix returned no duration for this leg
+# Drive-time legs use DepartNow (live-traffic) ETAs, so they're cached only briefly —
+# a 90-day cache would freeze a rush-hour snapshot. Short enough to keep traffic fresh,
+# long enough that a user's repeat searches within a planning session still hit cache.
+_DRIVE_CACHE_TTL = 3600          # 1 hour
 
 # PAD-US H3 spatial index — module-level lazy-load cache
 _PADUS_H3_FILENAME = "darkhours_padus_h3.npz"
@@ -547,6 +551,8 @@ _GEOCODE_MAX_WORKERS = int(os.environ.get("PYNIGHTSKY_GEOCODE_WORKERS", "8"))
 # reverse-geocode fan-out. Double-checked locking guards the one-time construction.
 _location_client = None
 _location_client_lock = threading.Lock()
+_georoutes_client = None
+_georoutes_client_lock = threading.Lock()
 
 
 def _location():
@@ -571,10 +577,32 @@ def _location():
     return _location_client
 
 
+def _georoutes():
+    """Return the process-wide Amazon Location GeoRoutes client (drive-time matrix).
+
+    GeoRoutes is the modern, resource-less routing API (no route calculator to create);
+    it supports DepartNow traffic-aware ETAs. Separate from the legacy `location` client
+    (still used for place-index reverse-geocoding)."""
+    global _georoutes_client
+    if _georoutes_client is None:
+        with _georoutes_client_lock:
+            if _georoutes_client is None:
+                import boto3
+                from botocore.config import Config
+                region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+                _georoutes_client = boto3.client(
+                    "geo-routes",
+                    region_name=region,
+                    config=Config(retries={"max_attempts": 5, "mode": "adaptive"}),
+                )
+    return _georoutes_client
+
+
 def _reset_location_client() -> None:
-    """Drop the cached AWS Location client (used by tests, mirrors ports.reset_backend)."""
-    global _location_client
+    """Drop the cached AWS clients (used by tests, mirrors ports.reset_backend)."""
+    global _location_client, _georoutes_client
     _location_client = None
+    _georoutes_client = None
 
 
 def _drive_cache_key(olat: float, olon: float, dlat: float, dlon: float) -> str:
@@ -588,10 +616,12 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
     AWS-backend only. Mutates in-place. Silently sets None on any API failure so the
     caller always has the field, just without a value.
 
-    Per-leg cached (origin→destination, rounded, 90-day TTL): dark-sky sites for a given
-    area are stable, so repeat searches skip the route-matrix call entirely; only the
-    cache-missing legs are sent to AWS. The matrix phase was ~2 s and previously uncached —
-    the dominant warm cost (see docs/PERF_FINDNEARBY.md).
+    Per-leg cached (origin→destination, rounded, short TTL): repeat searches within a
+    planning session skip the route-matrix call; only the cache-missing legs are sent to
+    AWS. The cache is short (_DRIVE_CACHE_TTL) because the ETAs are DepartNow/live-traffic.
+
+    Uses Amazon Location GeoRoutes CalculateRouteMatrix (the modern, resource-less API)
+    with DepartNow=True for traffic-aware ETAs.
 
     Routes ONLY is_poi candidates: raw backcountry fallbacks have no established road
     access, so routing them wastes the API on an unreachable point. They get
@@ -614,28 +644,28 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
             misses.append(c)
     if not misses:
         return
-    # 2. One route-matrix call for just the uncached legs; cache each result. On failure
-    #    leave drive_minutes=None and DON'T cache, so a transient error isn't sticky.
-    calc_name = os.environ.get("PYNIGHTSKY_ROUTE_CALCULATOR", "pynightsky-route-calculator")
+    # 2. One GeoRoutes matrix call for just the uncached legs; cache each result. On
+    #    failure leave drive_minutes=None and DON'T cache, so a transient error isn't sticky.
     try:
-        client = _location()
+        client = _georoutes()
         resp = client.calculate_route_matrix(
-            CalculatorName=calc_name,
-            DeparturePositions=[[origin_lon, origin_lat]],
-            DestinationPositions=[[c["lon"], c["lat"]] for c in misses],
+            Origins=[{"Position": [origin_lon, origin_lat]}],
+            Destinations=[{"Position": [c["lon"], c["lat"]]} for c in misses],
+            RoutingBoundary={"Unbounded": True},
             TravelMode="Car",
+            DepartNow=True,                 # traffic-aware ETAs
         )
         row = resp.get("RouteMatrix", [[]])[0]
         for i, c in enumerate(misses):
             entry = row[i] if i < len(row) else {}
-            secs  = entry.get("DurationSeconds") if entry else None
+            secs  = entry.get("Duration") if entry else None   # GeoRoutes: seconds
             mins  = round(secs / 60) if secs is not None else None
             c["drive_minutes"] = mins
             cache.set(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]),
                       mins if mins is not None else _DRIVE_NO_ROUTE,
-                      ttl_seconds=_GEO_CACHE_TTL)
+                      ttl_seconds=_DRIVE_CACHE_TTL)
     except Exception as e:
-        log.debug("AWS route matrix failed: %s", e)
+        log.debug("GeoRoutes route matrix failed: %s", e)
 
 
 def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -157,22 +157,14 @@ class LambdaApiStack(Stack):
         fn.add_to_role_policy(geo_policy)
         fn.add_environment("PYNIGHTSKY_PLACE_INDEX", place_index.index_name)
 
-        route_calc = location.CfnRouteCalculator(
-            self, "RouteCalculator",
-            calculator_name="pynightsky-route-calculator",
-            data_source="Esri",
-            pricing_plan="RequestBasedUsage",
-        )
-        route_calc_arn = (
-            f"arn:aws:geo:{self.region}:{self.account}"
-            f":route-calculator/{route_calc.calculator_name}"
-        )
+        # Drive times use Amazon Location GeoRoutes (CalculateRouteMatrix) — the modern,
+        # resource-less routing API (no route calculator to create), with DepartNow
+        # traffic-aware ETAs. The action takes no resource ARN, so it's scoped to "*".
         route_policy = iam.PolicyStatement(
-            actions=["geo:CalculateRouteMatrix"],
-            resources=[route_calc_arn],
+            actions=["geo-routes:CalculateRouteMatrix"],
+            resources=["*"],
         )
         fn.add_to_role_policy(route_policy)
-        fn.add_environment("PYNIGHTSKY_ROUTE_CALCULATOR", route_calc.calculator_name)
 
         # --- async jobs: SQS queue + zip-Lambda worker (M6.3) ---
         # Long /calendar+/trip computes run off the request path. The API enqueues a
@@ -226,7 +218,6 @@ class LambdaApiStack(Stack):
         worker.add_to_role_policy(geo_policy)
         worker.add_environment("PYNIGHTSKY_PLACE_INDEX", place_index.index_name)
         worker.add_to_role_policy(route_policy)
-        worker.add_environment("PYNIGHTSKY_ROUTE_CALCULATOR", route_calc.calculator_name)
         worker.add_event_source(lambda_events.SqsEventSource(jobs_queue, batch_size=1))
 
         # --- Scheduled worker warmup ping — keeps one worker container alive + primed ---

--- a/scripts/profile_aws.sh
+++ b/scripts/profile_aws.sh
@@ -24,7 +24,7 @@ export PYNIGHTSKY_BACKEND=aws
 export PYNIGHTSKY_RASTER_BUCKET="${PYNIGHTSKY_RASTER_BUCKET:?set PYNIGHTSKY_RASTER_BUCKET to your raster bucket}"
 export PYNIGHTSKY_CACHE_TABLE="${PYNIGHTSKY_CACHE_TABLE:?set PYNIGHTSKY_CACHE_TABLE to your cache table}"
 export PYNIGHTSKY_PLACE_INDEX="${PYNIGHTSKY_PLACE_INDEX:-pynightsky-place-index}"
-export PYNIGHTSKY_ROUTE_CALCULATOR="${PYNIGHTSKY_ROUTE_CALCULATOR:-pynightsky-route-calculator}"
+# Drive times use the resource-less GeoRoutes API (no route-calculator name needed).
 export PYNIGHTSKY_PROFILE=1
 
 echo "Authenticated as: $(aws sts get-caller-identity --query Arn --output text)"

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -313,16 +313,17 @@ class TestAwsDriveTimes:
 
     @staticmethod
     def _matrix(*minutes):
-        """A calculate_route_matrix response with one row of DurationSeconds (None = gap)."""
+        """A GeoRoutes CalculateRouteMatrix response: one row of Duration (None = no route)."""
         return {"RouteMatrix": [[
-            ({"DurationSeconds": m * 60} if m is not None else {}) for m in minutes
+            ({"Duration": m * 60, "Distance": m * 1000} if m is not None
+             else {"Error": "NoRoute"}) for m in minutes
         ]]}
 
     def test_miss_calls_matrix_once_and_caches(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds
         client = MagicMock()
         client.calculate_route_matrix.return_value = self._matrix(56, 88)
-        monkeypatch.setattr(ds, "_location", lambda: client)
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True},
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
@@ -336,7 +337,7 @@ class TestAwsDriveTimes:
         _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] = 56
         _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.23, -111.07)] = ds._DRIVE_NO_ROUTE
         client = MagicMock()
-        monkeypatch.setattr(ds, "_location", lambda: client)
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True},
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
@@ -348,20 +349,20 @@ class TestAwsDriveTimes:
         _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] = 56
         client = MagicMock()
         client.calculate_route_matrix.return_value = self._matrix(88)  # only the miss
-        monkeypatch.setattr(ds, "_location", lambda: client)
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True},
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert [c["drive_minutes"] for c in clusters] == [56, 88]
         # only the single uncached destination was sent
         _, kwargs = client.calculate_route_matrix.call_args
-        assert kwargs["DestinationPositions"] == [[-111.07, 35.23]]
+        assert kwargs["Destinations"] == [{"Position": [-111.07, 35.23]}]
 
     def test_api_failure_leaves_none_and_uncached(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds
         client = MagicMock()
         client.calculate_route_matrix.side_effect = RuntimeError("throttled")
-        monkeypatch.setattr(ds, "_location", lambda: client)
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert clusters[0]["drive_minutes"] is None

--- a/tests/test_poi_index.py
+++ b/tests/test_poi_index.py
@@ -162,22 +162,25 @@ def test_extract_dark_sky_returns_pois_when_intersecting(tmp_path, monkeypatch):
 
 
 def test_aws_drive_times_skips_non_poi():
-    """Raw fallback candidates are never routed; POIs are."""
+    """Raw fallback candidates are never routed; POIs are (GeoRoutes, DepartNow)."""
     poi = {"lat": 38.5, "lon": -120.1, "is_poi": True}
     raw = {"lat": 38.6, "lon": -120.2, "is_poi": False}
     with patch.object(ds, "cache") as mock_cache, \
-         patch.object(ds, "_location") as mock_loc:
+         patch.object(ds, "_georoutes") as mock_gr:
         mock_cache.get.return_value = None
-        mock_loc.return_value.calculate_route_matrix.return_value = {
-            "RouteMatrix": [[{"DurationSeconds": 1800}]]
+        mock_gr.return_value.calculate_route_matrix.return_value = {
+            "RouteMatrix": [[{"Duration": 1800, "Distance": 40000}]]
         }
         ds._aws_drive_times(40.0, -121.0, [poi, raw])
 
     assert raw["drive_minutes"] is None
     assert poi["drive_minutes"] == 30
-    # Exactly one destination (the POI) was sent to the matrix.
-    sent = mock_loc.return_value.calculate_route_matrix.call_args.kwargs["DestinationPositions"]
-    assert sent == [[-120.1, 38.5]]
+    kwargs = mock_gr.return_value.calculate_route_matrix.call_args.kwargs
+    # Exactly one destination (the POI) was sent, traffic-aware, GeoRoutes shape.
+    assert kwargs["Destinations"] == [{"Position": [-120.1, 38.5]}]
+    assert kwargs["Origins"] == [{"Position": [-121.0, 40.0]}]
+    assert kwargs["DepartNow"] is True
+    assert kwargs["RoutingBoundary"] == {"Unbounded": True}
 
 
 def test_offline_tier_name_poi_shortcircuits():


### PR DESCRIPTION
Moves drive-time ETAs from the legacy AWS Location **route-calculator** API to the modern, resource-less **Amazon Location GeoRoutes** `CalculateRouteMatrix`, with **`DepartNow=True`** for live-traffic estimates.

### Code (`darksky.py`)
- New `_georoutes()` client (`geo-routes` service).
- `_aws_drive_times` now sends `Origins`/`Destinations` (`{Position:[lon,lat]}`), `RoutingBoundary={Unbounded:true}`, `TravelMode=Car`, `DepartNow=true`, and reads each cell's `Duration` (seconds).
- **Cache TTL for drive legs cut 90d → 1h** (`_DRIVE_CACHE_TTL`): a 90-day cache would freeze a rush-hour snapshot, defeating `DepartNow`. Geocode results stay at 90d. Repeat searches within a planning session still hit cache.

### Infra (`cdk/lambda_api_stack.py`)
- Drop the `CfnRouteCalculator` resource + `PYNIGHTSKY_ROUTE_CALCULATOR` env (GeoRoutes needs no calculator).
- Grant `geo-routes:CalculateRouteMatrix` (resource `*` — resource-less API).

### Tests
- `test_aws_location.py` / `test_poi_index.py` updated to the GeoRoutes request/response shape (`Destinations`, `RoutingBoundary`, `DepartNow`, `Duration`).

### Verification
- **Live** call against real GeoRoutes (DepartNow) through `_aws_drive_times`: traffic-aware ETAs returned, `is_poi=False` correctly skipped.
- Full suite **422 passed**.

> Note: this is a single atomic deploy — the IAM change (geo-routes permission) ships with the code via `cdk deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)