### PR TITLE
Fix dark-threshold starving already-dark origins (Sterling Forest)

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -1697,6 +1697,21 @@ def _is_in_us(lat: float, lon: float) -> bool:
     return (18.0 <= lat <= 72.0) and (-180.0 <= lon <= -66.0)
 
 
+def _dark_threshold(origin_bortle: int) -> int:
+    """Bortle ceiling for 'darker than origin' candidates: one class darker, capped at 3.
+
+    Capped at Bortle 3 (the darkest we can reliably surface from a suburban origin) and
+    floored so a Bortle 2 origin still requires Bortle 1. A 2-class gap (origin-2) starved
+    already-dark origins — a Bortle 3 origin (e.g. Sterling Forest, NY) demanded Bortle 1,
+    which doesn't exist in the eastern US, dropping the reachable Bortle 2 Catskills sites.
+    One class darker surfaces them, ranked darkest-first; brighter origins (B5+) are
+    unchanged (still capped at 3). See docs/PERF_FINDNEARBY / the Sterling Forest case.
+    """
+    if origin_bortle <= 2:
+        return 1
+    return min(origin_bortle - 1, 3)
+
+
 def _offline_tier_name(
     c: dict,
     padus_index: "dict | None",
@@ -1941,11 +1956,7 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
     origin_bortle = origin_info.get("bortle_class") or 5
     origin_sqm    = origin_info.get("sqm")
 
-    # Dark threshold: need to be meaningfully darker than origin
-    if origin_bortle <= 2:
-        dark_threshold = 1   # Bortle 2 → require Bortle 1
-    else:
-        dark_threshold = min(origin_bortle - 2, 3) # Bortle 3 is the darkest we can reliably surface from a suburban origin (Bortle 5+)
+    dark_threshold = _dark_threshold(origin_bortle)
 
     # Force the bounding box out to 150 miles to catch distant megacities regardless
     # of the user's requested driving radius.  Both dark-sky and dome detection read

--- a/tests/test_poi_index.py
+++ b/tests/test_poi_index.py
@@ -183,6 +183,18 @@ def test_aws_drive_times_skips_non_poi():
     assert kwargs["RoutingBoundary"] == {"Unbounded": True}
 
 
+def test_dark_threshold_relaxes_for_dark_origins():
+    """One class darker, capped at 3 — dark origins no longer demand near-impossible Bortle 1."""
+    # (origin_bortle, expected dark_threshold)
+    assert ds._dark_threshold(1) == 1
+    assert ds._dark_threshold(2) == 1
+    assert ds._dark_threshold(3) == 2   # was 1 — the Sterling Forest fix (surfaces Bortle 2)
+    assert ds._dark_threshold(4) == 3   # was 2
+    assert ds._dark_threshold(5) == 3   # unchanged (brighter origins capped at 3)
+    assert ds._dark_threshold(8) == 3
+    assert ds._dark_threshold(9) == 3
+
+
 def test_offline_tier_name_poi_shortcircuits():
     """is_poi candidate → named offline (no Overpass/_settlement), unless blacklisted."""
     poi = {"lat": 38.5, "lon": -120.1, "name": "Shriner Lake Campground", "is_poi": True}


### PR DESCRIPTION
## Problem
`find_nearby` required sky **2 classes darker** than the origin (`min(origin-2, 3)`). For a **Bortle 3** origin like **Sterling Forest, NY** that demanded **Bortle 1** — which essentially doesn't exist in the eastern US (even Cherry Springs is Bortle 2). Result: **0 results**, even though reachable **Bortle 2 Catskills** sites (Slide Mountain, Frost Valley, Mongaup Pond, an observatory) were ~57 mi away. Diagnosed from a histogram: 0 Bortle-1 pixels but 37k Bortle-2 within 150 mi.

## Fix
Relax to **one class darker, capped at Bortle 3** (extracted to a testable `_dark_threshold`):

| origin | before | after |
|---|---|---|
| B3 (Sterling Forest) | 1 (→ 0 results) | **2** (→ Catskills B2 sites) |
| B4 | 2 | 3 |
| B5–B9 | 3 | 3 (unchanged) |

Darker sites are still ranked darkest-first, so Bortle 1 still surfaces *where it exists* (e.g. Phoenix → Mogollon Rim B1 sites, unchanged).

## Verified
- Sterling Forest: **0 → 10** Bortle-2 POIs.
- NYC (B9) and Phoenix (B9): unchanged.
- New unit test `test_dark_threshold_relaxes_for_dark_origins`; full suite **423 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)