### PR TITLE
UI: drive-time sort, road distance, directions links

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -623,29 +623,38 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
     Uses Amazon Location GeoRoutes CalculateRouteMatrix (the modern, resource-less API)
     with DepartNow=True for traffic-aware ETAs.
 
+    Annotates drive_minutes (int | None) and drive_miles (road distance, int | None).
+
     Routes ONLY is_poi candidates: raw backcountry fallbacks have no established road
     access, so routing them wastes the API on an unreachable point. They get
-    drive_minutes=None (the frontend hides drive-time + offers a raw-coordinate map link).
+    drive_minutes=drive_miles=None (the frontend then hides the drive-time UI).
     """
     if not clusters:
         return
     # 1. Serve cached legs from a single batched route-matrix call's worth of history;
-    #    collect the misses. A cached _DRIVE_NO_ROUTE means "computed, no route" (≠ miss).
+    #    collect the misses. The cached value is {"m":min,"mi":road_miles} or the
+    #    _DRIVE_NO_ROUTE sentinel ("computed, no route" ≠ miss). Legacy int = minutes only.
     misses = []
     for c in clusters:
         if not c.get("is_poi"):
             c["drive_minutes"] = None      # never route a non-routable fallback pixel
+            c["drive_miles"] = None
             continue
         cached = cache.get(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]))
         if cached is not None:
-            c["drive_minutes"] = None if cached == _DRIVE_NO_ROUTE else cached
+            if cached == _DRIVE_NO_ROUTE:
+                c["drive_minutes"], c["drive_miles"] = None, None
+            elif isinstance(cached, dict):
+                c["drive_minutes"], c["drive_miles"] = cached.get("m"), cached.get("mi")
+            else:                          # legacy int cache entry: minutes only
+                c["drive_minutes"], c["drive_miles"] = cached, None
         else:
-            c["drive_minutes"] = None      # default until filled by the API below
+            c["drive_minutes"], c["drive_miles"] = None, None   # default until filled below
             misses.append(c)
     if not misses:
         return
     # 2. One GeoRoutes matrix call for just the uncached legs; cache each result. On
-    #    failure leave drive_minutes=None and DON'T cache, so a transient error isn't sticky.
+    #    failure leave the fields None and DON'T cache, so a transient error isn't sticky.
     try:
         client = _georoutes()
         resp = client.calculate_route_matrix(
@@ -657,12 +666,14 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
         )
         row = resp.get("RouteMatrix", [[]])[0]
         for i, c in enumerate(misses):
-            entry = row[i] if i < len(row) else {}
-            secs  = entry.get("Duration") if entry else None   # GeoRoutes: seconds
+            entry  = row[i] if i < len(row) else {}
+            secs   = entry.get("Duration") if entry else None   # GeoRoutes: seconds
+            meters = entry.get("Distance") if entry else None    # GeoRoutes: metres
             mins  = round(secs / 60) if secs is not None else None
-            c["drive_minutes"] = mins
+            miles = round(meters / 1609.34) if meters is not None else None
+            c["drive_minutes"], c["drive_miles"] = mins, miles
             cache.set(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]),
-                      mins if mins is not None else _DRIVE_NO_ROUTE,
+                      {"m": mins, "mi": miles} if mins is not None else _DRIVE_NO_ROUTE,
                       ttl_seconds=_DRIVE_CACHE_TTL)
     except Exception as e:
         log.debug("GeoRoutes route matrix failed: %s", e)
@@ -2197,6 +2208,7 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
             # Keep existing distance-based sort for local backend
             for c in needs_drive:
                 c["drive_minutes"] = None
+                c["drive_miles"] = None
 
     _funnel["results_final"] = len(dark_clusters)
     _funnel["best_available"] = best_available is not None

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -685,12 +685,22 @@ function nearbyBortleClass(bortleClass: number | null): string {
   return `nearby-bortle ${colorClass}`
 }
 
-function NearbyResults({ data, imperial }: { data: NearbyResult; imperial: boolean }) {
+function NearbyResults(
+  { data, imperial, originLat, originLon }:
+  { data: NearbyResult; imperial: boolean; originLat: number; originLon: number },
+) {
   const { origin_bortle, origin_sqm, radius_miles, results, light_domes, best_available } = data
   const sqmStr = origin_sqm != null ? ` (SQM ${origin_sqm.toFixed(1)})` : ''
 
   // Convert stored miles to the active unit system
   const fmtMi = (mi: number) => fmtDist(mi * 1.60934, imperial)
+  // Prefer actual road distance from the routing API; fall back to straight-line when a
+  // candidate wasn't routed (raw "Remote" fallbacks).
+  const distOf = (p: NearbyPlace) => fmtMi(p.drive_miles ?? p.distance_miles)
+  // Google Maps driving directions, origin → location (falls back to a place pin).
+  const dirLink = (p: NearbyPlace) =>
+    `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLon}` +
+    `&destination=${p.lat},${p.lon}&travelmode=driving`
 
   const placeStr = (p: NearbyPlace) =>
     p.name ?? `${p.lat.toFixed(2)}°, ${p.lon.toFixed(2)}°`
@@ -708,28 +718,17 @@ function NearbyResults({ data, imperial }: { data: NearbyResult; imperial: boole
     summer_camp: 'Summer camp', firepit: 'Fire pit', beach_resort: 'Beach resort',
     historic: 'Historic site',
   }
-  const mapsLink = (p: NearbyPlace) => `https://www.google.com/maps?q=${p.lat},${p.lon}`
-  // Render a place name with its reachability affordance: a category badge for routable
-  // POIs, or a "Remote" tag + raw-coordinate map link for off-road backcountry fallbacks.
-  const placeNode = (p: NearbyPlace) => {
-    if (p.is_poi) {
-      return (
-        <>
-          {placeStr(p)}
-          {p.poi_type && (
-            <span className="poi-badge">{POI_TYPE_LABEL[p.poi_type] ?? p.poi_type}</span>
-          )}
-        </>
-      )
-    }
-    return (
-      <>
-        {placeStr(p)}
-        <span className="poi-remote">Remote</span>
-        <a className="poi-maplink" href={mapsLink(p)} target="_blank" rel="noopener noreferrer">Map ↗</a>
-      </>
-    )
-  }
+  // Render a place name with a category badge (routable POIs) or a "Remote" tag (off-road
+  // fallbacks), plus a Google Maps driving-directions link on every result.
+  const placeNode = (p: NearbyPlace) => (
+    <>
+      {placeStr(p)}
+      {p.is_poi
+        ? (p.poi_type && <span className="poi-badge">{POI_TYPE_LABEL[p.poi_type] ?? p.poi_type}</span>)
+        : <span className="poi-remote">Remote</span>}
+      <a className="poi-maplink" href={dirLink(p)} target="_blank" rel="noopener noreferrer">Directions ↗</a>
+    </>
+  )
 
   return (
     <>
@@ -752,7 +751,7 @@ function NearbyResults({ data, imperial }: { data: NearbyResult; imperial: boole
             : `No significantly darker sky found within ${fmtMi(radius_miles)}.`
           }
           {best_available && origin_bortle > 1 && (
-            <> Closest darker spot: <span className={nearbyBortleClass(best_available.bortle_class)}>Bortle {best_available.bortle_class}</span>, {fmtMi(best_available.distance_miles)} {best_available.direction}{formatDriveTime(best_available.drive_minutes) ? ` · ${formatDriveTime(best_available.drive_minutes)} drive` : ''}  ({placeNode(best_available)})</>
+            <> Closest darker spot: <span className={nearbyBortleClass(best_available.bortle_class)}>Bortle {best_available.bortle_class}</span>, {distOf(best_available)} {best_available.direction}{formatDriveTime(best_available.drive_minutes) ? ` · ${formatDriveTime(best_available.drive_minutes)} drive` : ''}  ({placeNode(best_available)})</>
           )}
         </p>
       )}
@@ -802,12 +801,12 @@ function NearbyResults({ data, imperial }: { data: NearbyResult; imperial: boole
             <div className="nearby-highlights">
               <div className="nearby-highlight-row">
                 <span className="nearby-highlight-label">Nearest</span>
-                <span><span className={nearbyBortleClass(nearest.bortle_class)}>Bortle {nearest.bortle_class}</span>  ·  {fmtMi(nearest.distance_miles)} {nearest.direction}{formatDriveTime(nearest.drive_minutes) ? `  ·  ${formatDriveTime(nearest.drive_minutes)} drive` : ''}  ({placeNode(nearest)})</span>
+                <span><span className={nearbyBortleClass(nearest.bortle_class)}>Bortle {nearest.bortle_class}</span>  ·  {distOf(nearest)} {nearest.direction}{formatDriveTime(nearest.drive_minutes) ? `  ·  ${formatDriveTime(nearest.drive_minutes)} drive` : ''}  ({placeNode(nearest)})</span>
               </div>
               {showDarkest && (
                 <div className="nearby-highlight-row">
                   <span className="nearby-highlight-label">Darkest</span>
-                  <span><span className={nearbyBortleClass(darkest.bortle_class)}>Bortle {darkest.bortle_class}</span>  ·  {fmtMi(darkest.distance_miles)} {darkest.direction}{formatDriveTime(darkest.drive_minutes) ? `  ·  ${formatDriveTime(darkest.drive_minutes)} drive` : ''}  ({placeNode(darkest)})</span>
+                  <span><span className={nearbyBortleClass(darkest.bortle_class)}>Bortle {darkest.bortle_class}</span>  ·  {distOf(darkest)} {darkest.direction}{formatDriveTime(darkest.drive_minutes) ? `  ·  ${formatDriveTime(darkest.drive_minutes)} drive` : ''}  ({placeNode(darkest)})</span>
                 </div>
               )}
             </div>
@@ -825,13 +824,20 @@ function NearbyResults({ data, imperial }: { data: NearbyResult; imperial: boole
                 </thead>
                 <tbody>
                   {[...results]
-                    .sort((a, b) => a.distance_miles - b.distance_miles)
+                    // Order by drive time, lowest first; unrouted (no ETA) last, then by distance.
+                    .sort((a, b) => {
+                      const ad = a.drive_minutes, bd = b.drive_minutes
+                      if (ad == null && bd == null) return a.distance_miles - b.distance_miles
+                      if (ad == null) return 1
+                      if (bd == null) return -1
+                      return ad - bd || a.bortle_class - b.bortle_class
+                    })
                     .map((p, i) => (
                       <tr key={i}>
                         <td className={nearbyBortleClass(p.bortle_class)}>{placeNode(p)}</td>
                         <td className={`wx-num ${nearbyBortleClass(p.bortle_class)}`}>{p.bortle_class}</td>
                         <td className="wx-num">{p.sqm != null ? p.sqm.toFixed(1) : '—'}</td>
-                        <td className="wx-num">{fmtMi(p.distance_miles)}</td>
+                        <td className="wx-num">{distOf(p)}</td>
                         {hasDrive && <td className="wx-num">{formatDriveTime(p.drive_minutes) ?? '—'}</td>}
                         <td className="wx-num">{p.direction}</td>
                       </tr>
@@ -1012,7 +1018,7 @@ export default function ReportCard({
             <p className="sat-notice">{nearbyState.message}</p>
           )}
           {nearbyState.phase === 'done' && (
-            <NearbyResults data={nearbyState.data} imperial={imperial} />
+            <NearbyResults data={nearbyState.data} imperial={imperial} originLat={report.lat} originLon={report.lon} />
           )}
         </div>
       </details>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -206,6 +206,8 @@ export interface NearbyPlace {
   lat: number
   lon: number
   drive_minutes: number | null
+  // Road distance (miles) from the routing API; null when not routed (raw fallback).
+  drive_miles?: number | null
   // POI-first reachability: true = a routable, pre-named OSM POI (show drive time + badge);
   // false/undefined = a raw backcountry pixel with no road access (hide drive time, offer a
   // map link to the raw coordinate). poi_type is the OSM category when is_poi is true.

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -328,9 +328,13 @@ class TestAwsDriveTimes:
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert [c["drive_minutes"] for c in clusters] == [56, 88]
+        # road distance (GeoRoutes Distance) is captured too: _matrix sets m*1000 metres
+        assert [c["drive_miles"] for c in clusters] == [round(56000 / 1609.34),
+                                                        round(88000 / 1609.34)]
         client.calculate_route_matrix.assert_called_once()
-        # both legs now cached
-        assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == 56
+        # both legs now cached as {minutes, road-miles}
+        assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == \
+            {"m": 56, "mi": round(56000 / 1609.34)}
 
     def test_full_cache_hit_skips_api(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds


### PR DESCRIPTION
Three nearby-results UI changes (one needs a small backend bit since GeoRoutes already returns road distance):

1. **Order by drive time, lowest first.** Table now sorts by `drive_minutes` ascending; unrouted "Remote" fallbacks sort last (then by straight-line distance).
2. **Road distance instead of crow-flies.** `_aws_drive_times` now captures each leg's `Distance` from the GeoRoutes matrix → `drive_miles` (cached alongside the ETA as `{"m":min,"mi":miles}`; legacy int entries still read). The table + highlights show road distance, falling back to great-circle only for unrouted candidates.
3. **Directions link on every result.** Google Maps **driving directions** origin → location (`/maps/dir/?api=1&origin=…&destination=…&travelmode=driving`), replacing the location-only pin. `NearbyResults` now receives `originLat/originLon`.

### Verified
- Backend: 423 tests pass (incl. updated drive-time cache shape).
- Frontend: `tsc --noEmit` + `vite build` clean.
- Browser check deferred to the live site post-deploy (road distance needs the worker deploy; edge WAF blocks proxying to prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)