### PR TITLE
Place autocomplete + UI fixes (local date, az/alt order)

### DIFF
--- a/PyNightSkyPredictor/location.py
+++ b/PyNightSkyPredictor/location.py
@@ -171,6 +171,69 @@ def _geocode_via_aws(name: str, query: str) -> dict | None:
     }
 
 
+def _suggest_via_aws(query: str, max_results: int) -> list[str]:
+    """Typeahead suggestions via AWS Location SearchPlaceIndexForSuggestions."""
+    from . import darksky  # reuse the process-wide pooled 'location' client
+    index_name = os.environ.get("PYNIGHTSKY_PLACE_INDEX", "pynightsky-place-index")
+    try:
+        client = darksky._location()
+        resp = client.search_place_index_for_suggestions(
+            IndexName=index_name, Text=query, MaxResults=max_results,
+        )
+    except Exception as e:
+        log.error("AWS Location suggest error for %r: %s", query, e,
+                  extra={"service": "aws-location"})
+        raise RuntimeError(f"Suggestion error: {e}")
+    out: list[str] = []
+    for r in resp.get("Results", []):
+        txt = r.get("Text")
+        if txt and txt not in out:        # de-dup while preserving rank order
+            out.append(txt)
+    return out
+
+
+def _suggest_via_nominatim(query: str, max_results: int) -> list[str]:
+    """Typeahead suggestions via a Nominatim multi-result geocode (local backend).
+
+    Best-effort: a timeout/rate-limit returns no suggestions rather than raising,
+    so a slow geocoder never blocks typing.
+    """
+    try:
+        geolocator = Nominatim(user_agent=USER_AGENT)
+        results = geolocator.geocode(
+            _geocode_query(query), exactly_one=False, limit=max_results, timeout=10,
+        ) or []
+        _ph.record("nominatim", "ok")
+    except (GeocoderTimedOut, GeocoderServiceError, GeocoderRateLimited) as e:
+        log.debug("Nominatim suggest failed for %r: %s", query, e)
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for r in results:
+        if r.address and r.address not in seen:
+            seen.add(r.address)
+            out.append(r.address)
+    return out
+
+
+def suggest(query: str, max_results: int = 5) -> list[str]:
+    """Return typeahead place suggestions for an autocomplete box.
+
+    aws backend   → AWS Location SearchPlaceIndexForSuggestions.
+    local backend → Nominatim multi-result geocode (best-effort).
+
+    Returns a list of human-readable suggestion strings (possibly empty). The
+    chosen string is resolved to coordinates later through the normal resolve()
+    path, so no PlaceId bookkeeping is needed here.
+    """
+    query = query.strip()
+    if not query:
+        return []
+    if ports.get_backend()._name == "aws":
+        return _suggest_via_aws(query, max_results)
+    return _suggest_via_nominatim(query, max_results)
+
+
 def resolve(name: str) -> tuple:
     """
     Resolve a location name to (lat, lon, display_name, tz_name).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Every run produces a single-night report:
 
 `--satellites` adds a unified pass table for ISS, Hubble Telescope, Tiangong, and any currently raising Starlink trains. Each row shows rise, peak, and set times with altitude, azimuth, pass duration, and moon separation. Twilight passes are flagged `†`; passes ending in Earth's shadow are flagged `*`.
 
-`--show-nearby` adds a table of named darker sky areas and light domes within the search radius.
+`--show-nearby` adds a table of named darker sky areas and light domes within the search radius. The search is **POI-first**: when the routable OSM POI index is present (see [Offline Spatial Index (OSM POIs)](#offline-spatial-index-osm-pois)), it surfaces named, reachable destinations (trailhead parking, viewpoints, campsites, observatories, …) that sit on a dark pixel, rather than raw off-road coordinates; areas with no routable POI fall back to a plain coordinate, flagged as remote. It returns sky at least one Bortle class darker than the origin (capped at Bortle 3), so already-dark origins (e.g. a Bortle 3 site) still surface the reachable Bortle 2 areas nearby. Drive times and road distances are computed only on the cloud (AWS) deployment — see [Cloud Deployment](#cloud-deployment).
 
 `--all` is shorthand for `--weather --targets --satellites --show-nearby` in one flag.
 
@@ -340,7 +340,7 @@ External I/O — caching, the saved-location store, and the light-pollution rast
 | `PyNightSkyPredictor/targets.py` | Visible targets engine — K&S interference, photo window clipping |
 | `PyNightSkyPredictor/targets.json` | Curated target catalog |
 | `PyNightSkyPredictor/config.py` | Configuration loader — merges `PyNightSkyPredictor/config.json` over built-in defaults (see [Configuration](#configuration) below) |
-| `PyNightSkyPredictor/darksky.py` | Light pollution lookup (VIIRS + Falchi); `find_nearby()` dark-sky search; `LocalRasterSource` adapter |
+| `PyNightSkyPredictor/darksky.py` | Light pollution lookup (VIIRS + Falchi); POI-first `find_nearby()` dark-sky search (routable OSM POI index + drive times); `LocalRasterSource` adapter |
 | `PyNightSkyPredictor/weather.py` | Weather forecast — NOAA/NWS, Open-Meteo, 7Timer ASTRO |
 | `PyNightSkyPredictor/location.py` | Geocoding and timezone resolution; `LocalGeocodeStore` adapter |
 | `PyNightSkyPredictor/satellites.py` | Satellite pass prediction — Skyfield SGP4 propagation, Moon proximity |
@@ -423,6 +423,26 @@ python scripts/build_padus_index.py
 
 Output: `cache/darkhours_padus_h3.parquet` (~10 MB). Both `Temp/` and `cache/` are gitignored.
 
+### Offline Spatial Index (OSM POIs)
+
+`find_nearby()` is **POI-first**: dark-sky areas are surfaced as named, routable OpenStreetMap
+POIs (parking, viewpoints, campsites, rest areas, observatories, lighthouses, and more) rather
+than raw off-road pixels — so results are reachable, pre-named (no reverse-geocode), and carry a
+real coordinate to route to. This is driven by a compact H3 index, `cache/osm_pois.npz` (~0.7 MB,
+committed). To regenerate it:
+
+```bash
+pip install -r requirements-build.txt          # provides osmium (pyosmium) + h3
+scripts/update_pois.sh                          # download latest US extract, build, clean up
+# — or, against a .pbf you already have in Temp/:
+python scripts/osm_poi_builder.py Temp/us-260608.osm.pbf
+```
+
+The builder filters a Geofabrik US extract to named POIs of the indexed types, drops closed/junk
+entries, and keeps only those in dark (Bortle ≤ 4) areas so the index stays small. Source data is
+© OpenStreetMap contributors, licensed **ODbL** — keep that attribution visible wherever the data
+is used. Format and rules: [docs/OSM_POI_INDEX.md](docs/OSM_POI_INDEX.md).
+
 ### Configuration
 
 Drop a `PyNightSkyPredictor/config.json` to override the built-in defaults:
@@ -452,8 +472,9 @@ The repository includes an optional cloud-native deployment that exposes the eng
 **Stack:**
 - **Compute** — FastAPI on AWS Lambda (container image) fronted by CloudFront with WAFv2 rate limiting
 - **Storage** — DynamoDB for cache and geocode store; S3 for the VIIRS/Falchi rasters as Cloud-Optimized GeoTIFFs
-- **Frontend** — React/TypeScript SPA (Vite) served from S3 via CloudFront
-- **Resilience** — scheduled Lambda warmer for satellite TLEs; SQS + worker Lambda for async calendar/trip jobs
+- **Routing & geocoding** — Amazon Location **GeoRoutes** (`CalculateRouteMatrix`, traffic-aware via `DepartNow`) computes drive time + road distance to each reachable POI in `find_nearby`; AWS Location place index handles reverse-geocoding. Per-leg results are cached briefly (live-traffic ETAs)
+- **Frontend** — React/TypeScript SPA (Vite) served from S3 via CloudFront. The nearby-results view orders sites by drive time, shows road distance, and links Google Maps driving directions (origin → site) for each
+- **Resilience** — scheduled Lambda warmer for satellite TLEs; SQS + worker Lambda for async calendar/trip jobs (the worker also runs `find_nearby` and ships the PAD-US + OSM POI indexes)
 - **Observability** — structured JSON logs, X-Ray tracing, CloudWatch metric alarms
 
 **Repository layout:**
@@ -474,7 +495,7 @@ To run your own instance, deploy the CDK stacks against your own AWS account wit
 Requires the dev dependencies (`pip install -r requirements-dev.txt`).
 
 ```bash
-python -m pytest                  # Full suite — 304 tests
+python -m pytest                  # Full suite — 423 tests
 python -m pytest -m "not eph"     # Fast suite — no ephemeris file needed
 python -m pytest -v               # Verbose output
 ```
@@ -502,7 +523,8 @@ python -m pytest -v               # Verbose output
 |-----------|----------|
 | `test_adapters.py` | `LocalFileCache` vs `DynamoCache`, `LocalGeocodeStore` vs `DynamoGeocodeStore` contract parity (DynamoDB mocked via moto) |
 | `test_api.py` | HTTP API endpoints via FastAPI TestClient — healthz, error paths, `/night` success |
-| `test_aws_location.py` | AWS Location Service geocoding adapter — all boto3 calls mocked |
+| `test_aws_location.py` | AWS Location geocoding + GeoRoutes drive-time matrix (DepartNow, per-leg cache) — all boto3 calls mocked |
+| `test_poi_index.py` | POI-first `find_nearby` — OSM POI index loader/encoder round-trip, dark-mask intersection, naming/drive-time gates, dark-threshold |
 | `test_aws_smoke.py` | Opt-in integration smoke against real AWS (skipped unless `PYNIGHTSKY_BACKEND=aws` + credentials set) |
 | `test_warmer.py` | TLE warmer Lambda handler — `tle_provider` mocked, no network |
 | `test_jobs.py` | Async job lifecycle — in-memory cache, `run_job` and SQS mocked |

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -274,6 +274,20 @@ def night(
     return night_report_to_dict(report)
 
 
+@app.get("/suggest")
+def suggest(q: str = Query(..., min_length=1, max_length=_MAX_NAME_LEN)):
+    """Typeahead place suggestions for the search box (autocomplete).
+
+    Returns {"suggestions": [str, ...]} — display strings the client feeds back
+    to /night as `location=` when one is picked. Best-effort: an empty list is a
+    valid response when nothing matches.
+    """
+    try:
+        return {"suggestions": _loc.suggest(q)}
+    except RuntimeError as e:
+        raise HTTPException(502, str(e))   # geocoder unreachable
+
+
 def _accepted(job_id: str) -> JSONResponse:
     """202 with the job id + where to poll for the result."""
     return JSONResponse(

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect, type FormEvent } from 'react'
 import './App.css'
-import { LocateFixed, Cloud, Star, Satellite, ChevronLeft, ChevronRight, Clock, X } from 'lucide-react'
-import { ApiRequestError, fetchNight, type NightQuery } from './api'
-import { todayIso, defaultImperial } from './format'
+import { LocateFixed, Cloud, Star, Satellite, ChevronLeft, ChevronRight, Clock, MapPin, X } from 'lucide-react'
+import { ApiRequestError, fetchNight, fetchSuggestions, type NightQuery } from './api'
+import { todayIso, toIsoDate, defaultImperial } from './format'
 import ReportCard from './ReportCard'
 import DatePicker from './DatePicker'
 import type { NightReport } from './types'
@@ -67,8 +67,30 @@ export default function App() {
   const [searchHistory, setSearchHistory] = useState<HistoryEntry[]>(loadHistory)
   const [placeDropdown, setPlaceDropdown] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
+  const [suggestions, setSuggestions] = useState<string[]>([])
   const placeInputRef = useRef<HTMLInputElement>(null)
   const dropdownItemRefs = useRef<(HTMLButtonElement | null)[]>([])
+  // The label most recently picked from the dropdown — used to suppress the
+  // suggestion fetch that the resulting setPlace() would otherwise trigger.
+  const lastPickedRef = useRef<string | null>(null)
+
+  // Debounced autocomplete: fetch suggestions as the user types a place name.
+  // A 300ms debounce + 3-char minimum keeps the per-keystroke request count (and
+  // the AWS Location bill) low; each in-flight request is aborted when superseded.
+  useEffect(() => {
+    const q = place.trim()
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => {
+      if (mode !== 'place' || q.length < 3 || q === lastPickedRef.current) {
+        setSuggestions([])
+        return
+      }
+      fetchSuggestions(q, ctrl.signal)
+        .then(setSuggestions)
+        .catch(() => { /* aborted or failed — leave existing suggestions */ })
+    }, 300)
+    return () => { clearTimeout(timer); ctrl.abort() }
+  }, [place, mode])
 
   function toggleUnits(imp: boolean) {
     setImperial(imp)
@@ -190,7 +212,7 @@ export default function App() {
   function shiftDay(delta: number) {
     const d = new Date(date + 'T00:00:00')
     d.setDate(d.getDate() + delta)
-    setDate(d.toISOString().slice(0, 10))
+    setDate(toIsoDate(d))
   }
 
   function quickSearch(location: string) {
@@ -272,10 +294,43 @@ export default function App() {
         </div>
 
         {mode === 'place' ? (() => {
-          const filteredHistory = searchHistory.filter(h =>
-            !place.trim() || h.label.toLowerCase().includes(place.toLowerCase().trim())
-          )
-          const showDropdown = placeDropdown && filteredHistory.length > 0
+          const q = place.trim()
+          // While actively typing (≥3 chars) show live geocoder suggestions;
+          // otherwise fall back to filtered recent searches.
+          const useSuggest = q.length >= 3 && suggestions.length > 0
+          type Item =
+            | { kind: 'suggestion'; label: string }
+            | { kind: 'history'; label: string; entry: HistoryEntry }
+          const items: Item[] = useSuggest
+            ? suggestions.map(s => ({ kind: 'suggestion' as const, label: s }))
+            : searchHistory
+                .filter(h => !q || h.label.toLowerCase().includes(q.toLowerCase()))
+                .map(h => ({ kind: 'history' as const, label: h.label, entry: h }))
+          const showDropdown = placeDropdown && items.length > 0
+
+          const selectItem = (item: Item) => {
+            setPlaceDropdown(false)
+            setActiveIndex(-1)
+            const { wxUnavail, satUnavail } = availabilityFor(date)
+            if (item.kind === 'suggestion') {
+              lastPickedRef.current = item.label   // suppress the refetch from setPlace
+              setSuggestions([])
+              setMode('place')
+              setPlace(item.label)
+              runQuery({ location: item.label, date, weather: !wxUnavail, targets: true, satellites: !satUnavail })
+              return
+            }
+            const h = item.entry
+            setMode(h.mode)
+            if (h.mode === 'place') {
+              setPlace(h.location!)
+              runQuery({ location: h.location!, date, weather: !wxUnavail, targets: true, satellites: !satUnavail })
+            } else {
+              setLat(h.lat!)
+              setLon(h.lon!)
+              runQuery({ lat: Number(h.lat), lon: Number(h.lon), date, weather: !wxUnavail, targets: true, satellites: !satUnavail })
+            }
+          }
           return (
           <div
             className="field place-field-wrap"
@@ -294,7 +349,7 @@ export default function App() {
                 type="text"
                 placeholder="e.g. Cherry Springs State Park"
                 value={place}
-                onChange={(e) => { setPlace(e.target.value); setActiveIndex(-1) }}
+                onChange={(e) => { setPlace(e.target.value); setActiveIndex(-1); setPlaceDropdown(true) }}
                 onFocus={() => setPlaceDropdown(true)}
                 onKeyDown={(e) => {
                   if (e.key === 'ArrowDown' && showDropdown) {
@@ -311,7 +366,7 @@ export default function App() {
                 role="combobox"
                 aria-expanded={showDropdown}
                 aria-haspopup="listbox"
-                aria-controls="place-history-listbox"
+                aria-controls="place-listbox"
                 aria-autocomplete="list"
                 aria-activedescendant={activeIndex >= 0 ? `place-item-${activeIndex}` : undefined}
                 className={place ? 'has-clear' : ''}
@@ -335,14 +390,14 @@ export default function App() {
             </div>
             {showDropdown && (
               <div
-                id="place-history-listbox"
+                id="place-listbox"
                 className="place-dropdown"
                 role="listbox"
-                aria-label="Recent searches"
+                aria-label={useSuggest ? 'Place suggestions' : 'Recent searches'}
               >
-                {filteredHistory.map((h, i) => (
+                {items.map((item, i) => (
                   <button
-                    key={i}
+                    key={`${item.kind}-${i}`}
                     id={`place-item-${i}`}
                     ref={(el) => { dropdownItemRefs.current[i] = el }}
                     type="button"
@@ -350,26 +405,12 @@ export default function App() {
                     role="option"
                     aria-selected={activeIndex === i}
                     onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => {
-                      setPlaceDropdown(false)
-                      setActiveIndex(-1)
-                      setMode(h.mode)
-                      if (h.mode === 'place') {
-                        setPlace(h.location!)
-                        const { wxUnavail, satUnavail } = availabilityFor(date)
-                        runQuery({ location: h.location!, date, weather: !wxUnavail, targets: true, satellites: !satUnavail })
-                      } else {
-                        setLat(h.lat!)
-                        setLon(h.lon!)
-                        const { wxUnavail, satUnavail } = availabilityFor(date)
-                        runQuery({ lat: Number(h.lat), lon: Number(h.lon), date, weather: !wxUnavail, targets: true, satellites: !satUnavail })
-                      }
-                    }}
+                    onClick={() => selectItem(item)}
                     onKeyDown={(e) => {
                       if (e.key === 'ArrowDown') {
                         e.preventDefault()
                         const next = i + 1
-                        if (next < filteredHistory.length) {
+                        if (next < items.length) {
                           setActiveIndex(next)
                           dropdownItemRefs.current[next]?.focus()
                         }
@@ -386,11 +427,16 @@ export default function App() {
                         setPlaceDropdown(false)
                         setActiveIndex(-1)
                         placeInputRef.current?.focus()
+                      } else if (e.key === 'Enter') {
+                        e.preventDefault()
+                        selectItem(item)
                       }
                     }}
                   >
-                    <Clock size={12} strokeWidth={2} className="place-dropdown-icon" />
-                    <span className="place-dropdown-label">{h.label}</span>
+                    {item.kind === 'suggestion'
+                      ? <MapPin size={12} strokeWidth={2} className="place-dropdown-icon" />
+                      : <Clock size={12} strokeWidth={2} className="place-dropdown-icon" />}
+                    <span className="place-dropdown-label">{item.label}</span>
                   </button>
                 ))}
               </div>

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -35,9 +35,10 @@ function WmoIcon({ code, size = 19 }: { code: number | null; size?: number }) {
   return <Icon size={size} strokeWidth={1.5} style={{ flexShrink: 0 }} />
 }
 
-// Alt/Az in standard format: "42° alt · 195° (S)"
+// Horizontal coordinates in the conventional order: azimuth (with compass point)
+// first, then altitude — e.g. "Az 195° S · Alt 42°".
 function fmtPos(altDeg: number, azDeg: number): string {
-  return `${Math.round(altDeg)}° alt · ${Math.round(azDeg)}° (${cardinal(azDeg)})`
+  return `Az ${Math.round(azDeg)}° ${cardinal(azDeg)} · Alt ${Math.round(altDeg)}°`
 }
 
 // ── Moon phase image (NASA SVS) ──────────────────────────────────────────────
@@ -204,7 +205,7 @@ function SatellitePasses({ report }: { report: NightReport }) {
     )
   }
 
-  const az = (deg: number) => `${deg.toFixed(0)}°(${cardinal(deg)})`
+  const az = (deg: number) => `${deg.toFixed(0)}° ${cardinal(deg)}`
 
   return (
     <>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -80,6 +80,31 @@ export async function fetchNearby(lat: number, lon: number, radius = 60): Promis
 }
 
 /**
+ * Typeahead place suggestions for the search box (autocomplete).
+ *
+ * Best-effort: any failure (network, non-2xx) resolves to an empty list so a
+ * flaky geocoder never disrupts typing. An aborted request (superseded by a
+ * newer keystroke) re-throws AbortError for the caller to ignore.
+ */
+export async function fetchSuggestions(q: string, signal?: AbortSignal): Promise<string[]> {
+  const p = new URLSearchParams({ q })
+  let res: Response
+  try {
+    res = await fetch(`/suggest?${p}`, { signal })
+  } catch (e) {
+    if ((e as Error).name === 'AbortError') throw e
+    return []
+  }
+  if (!res.ok) return []
+  try {
+    const body = (await res.json()) as { suggestions?: string[] }
+    return body.suggestions ?? []
+  } catch {
+    return []
+  }
+}
+
+/**
  * Fetch a single-night report. Calls the API with a RELATIVE URL so it is
  * same-origin in production (CloudFront) and proxied in dev (see vite.config.ts).
  */

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -222,6 +222,16 @@ export function scoreLabel(score: number): string {
   return { excellent: 'Excellent', good: 'Good', fair: 'Fair', poor: 'Poor' }[scoreBand(score)]
 }
 
+// YYYY-MM-DD in the viewer's *local* timezone (not UTC). Using toISOString()
+// here would yield the UTC date, which is a day ahead once it's past evening in
+// the Americas — so the picker/initial load would jump to "tomorrow".
+export function toIsoDate(d: Date): string {
+  const year  = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day   = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 export function todayIso(): string {
-  return new Date().toISOString().slice(0, 10)
+  return toIsoDate(new Date())
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,7 +8,7 @@ import react from '@vitejs/plugin-react'
 // In dev there is no CloudFront, so the Vite dev server proxies those same API
 // paths to the live API origin. The origin is read from VITE_API_ORIGIN in a
 // gitignored .env.local (see .env.example) so the deployed URL stays out of the repo.
-const API_PATHS = ['/night', '/healthz', '/calendar', '/trip', '/jobs', '/nearby']
+const API_PATHS = ['/night', '/suggest', '/healthz', '/calendar', '/trip', '/jobs', '/nearby']
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -151,7 +151,11 @@ class LambdaApiStack(Stack):
             f":place-index/{place_index.index_name}"
         )
         geo_policy = iam.PolicyStatement(
-            actions=["geo:SearchPlaceIndexForText", "geo:SearchPlaceIndexForPosition"],
+            actions=[
+                "geo:SearchPlaceIndexForText",        # forward geocode (resolve)
+                "geo:SearchPlaceIndexForPosition",    # reverse geocode (coords → name)
+                "geo:SearchPlaceIndexForSuggestions", # /suggest autocomplete
+            ],
             resources=[place_index_arn],
         )
         fn.add_to_role_policy(geo_policy)


### PR DESCRIPTION
## Summary
Adds place-search **autocomplete** and ships two small UI bug fixes.

### Autocomplete
- `location.suggest()` behind the ports seam: **AWS Location** `SearchPlaceIndexForSuggestions` (aws) / **Nominatim** multi-result geocode (local), best-effort.
- New `GET /suggest?q=` endpoint; a picked suggestion resolves via the normal `/night?location=` path.
- IAM: grant `geo:SearchPlaceIndexForSuggestions` to the API role (lands atomically with this deploy).
- Frontend: **300ms-debounced, 3-char-min** suggestion fetch with in-flight abort; the existing place dropdown now shows live suggestions and falls back to recent searches. A flaky geocoder never blocks typing.
- `/suggest` added to the Vite dev proxy.

### UI fixes
- Initial date loaded from **UTC** instead of local tz — picker/initial load and the prev/next-day arrows jumped a day in the evening. Added `toIsoDate()` local-date helper.
- Prime Targets + satellite passes now show horizontal coords in the conventional order: **azimuth (with compass point) first, then altitude**.

## Cost
At ~1,000 visits/mo, autocomplete adds roughly **$1–3/mo** (likely $0 within the AWS free tier). Debounce verified: 14 keystrokes coalesced to 1 request.

## Verification
- 423 passed / 7 skipped; `tsc` clean.
- `/suggest` + debounce confirmed e2e against the local Nominatim backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)