### PR TITLE
Fix /suggest 404 in prod: add CloudFront behavior

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -428,6 +428,7 @@ class LambdaApiStack(Stack):
             ),
             additional_behaviors={
                 "/night":    api_cached,
+                "/suggest":  api_cached,   # autocomplete: edge-cache by query string
                 "/healthz":  open_cached,
                 "/calendar": no_cache,
                 "/trip":     no_cache,


### PR DESCRIPTION
## Problem
Autocomplete suggestions don't appear in production. `/suggest` was added to the Vite **dev** proxy but not to the **CloudFront** distribution, so in prod the path fell through to the default behavior (S3 SPA) and returned `index.html`. The frontend got non-JSON, silently fell back to `[]`, and showed no suggestions.

## Fix
Route `/suggest` through the existing `api_cached` behavior (same as `/night`): same-origin guard + edge-cache keyed on the query string. Edge-caching repeated prefixes is a bonus — it further reduces AWS Location Suggestions calls.

One-line change to `additional_behaviors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)