### PR TITLE
Red Light mode: red Night Vision toggle as a visual cue

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -33,15 +33,18 @@
   padding: 6px 11px;
   border-radius: 999px;
   background: var(--card);
-  border: 1px solid var(--card-border);
-  color: var(--text-dim);
+  /* Always red — a visual cue that this toggles red/night-vision mode. (In red
+     mode the button is .active and switches to the themed pure red below.) */
+  border: 1px solid rgba(227, 86, 80, 0.4);
+  color: #e35650;
   font: 500 12px var(--sans);
   letter-spacing: 0.01em;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
 }
 .night-vision-toggle:hover {
-  color: var(--text-h);
+  color: #ff6f66;
+  border-color: rgba(227, 86, 80, 0.7);
 }
 .night-vision-toggle.active {
   color: var(--poor);


### PR DESCRIPTION
## Summary
Follow-up to #39 (Red Light / night-vision mode). The **Night Vision** toggle now renders red — red moon icon, red label, faint red border — even when inactive, so users get a visual cue about what it does.

When the toggle is active (red mode on) it still switches to the themed pure red (`.active → var(--poor)`), so night mode stays free of green/blue leak.

## Changes
- `apps/web/src/App.css` — `.night-vision-toggle` inactive state: red text/icon (`#e35650`) + faint red border; hover brightens to `#ff6f66`.

## Notes for reviewer
- Net diff is a single CSS rule (the broader red-light feature shipped in #39).
- Verified in the browser: red cue shows in normal mode; toggling into red mode still works and the button stays pure red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)