### PR TITLE
Light-dome analyzer + precomputed H3 index for initial page load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ cache/*
 # contributors). IS the committed runtime index; Docker builds COPY it. Built by
 # scripts/osm_poi_builder.py from a Geofabrik .osm.pbf. See docs/OSM_POI_INDEX.md.
 !cache/osm_pois.npz
+# Precomputed light-dome H3 index (CONUS, res 6). IS the committed runtime index;
+# the API/worker bundles COPY it. Built by scripts/build_lightdome_index.py.
+!cache/lightdome_h3.npz
 
 # AWS CDK infrastructure build artefacts (added ahead of M4)
 cdk.out/

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -26,6 +26,7 @@ RUN pip install -r requirements-api.txt
 COPY PyNightSkyPredictor/ ./PyNightSkyPredictor/
 COPY apps/ ./apps/
 COPY cache/darkhours_padus_h3.npz ./cache/darkhours_padus_h3.npz
+COPY cache/lightdome_h3.npz ./cache/lightdome_h3.npz
 
 # Drop root, same as the App Runner image — run as an unprivileged numeric UID.
 # The aws backend reads rasters from S3 and caches in DynamoDB (nothing is written to

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -29,6 +29,7 @@ COPY PyNightSkyPredictor/ ./PyNightSkyPredictor/
 COPY apps/ ./apps/
 COPY cache/darkhours_padus_h3.npz ./cache/darkhours_padus_h3.npz
 COPY cache/osm_pois.npz ./cache/osm_pois.npz
+COPY cache/lightdome_h3.npz ./cache/lightdome_h3.npz
 
 # Drop root (Lambda fs is read-only except /tmp, for any user).
 ENV HOME=/tmp

--- a/PyNightSkyPredictor/light_dome.py
+++ b/PyNightSkyPredictor/light_dome.py
@@ -51,8 +51,17 @@ changes.
 from __future__ import annotations
 
 import math
+import os
+from pathlib import Path
 
 import numpy as np
+
+try:
+    import h3 as _h3_lib
+    _HAS_H3 = True
+except ImportError:  # h3 is a runtime dep, but degrade gracefully if absent
+    _h3_lib = None
+    _HAS_H3 = False
 
 # --- configuration ---------------------------------------------------------
 
@@ -458,3 +467,117 @@ def glow_toward(detailed: dict[str, dict], azimuth_deg: float, altitude_deg: flo
     if theta <= 0.0:
         return score if alt == 0.0 else 0.0
     return score / (1.0 + (alt / theta) ** 2)
+
+
+# ===========================================================================
+# Precomputed H3 index — DarkHours light-dome lookup for the initial page load
+# ===========================================================================
+# Light dome is a pure function of static VIIRS radiance + location, so it is
+# precomputed once into an H3 index (scripts/build_lightdome_index.py) and served
+# as an O(log n) lookup on the page-load path — no 150-mile raster read. Plumbing
+# mirrors darksky._PadusIndex / _load_padus_h3_index / _padus_h3_lookup.
+
+LIGHTDOME_H3_RESOLUTION = 6          # ~36 km^2/cell — CONUS index granularity
+_LIGHTDOME_H3_FILENAME = "lightdome_h3.npz"
+_LIGHTDOME_UNAVAILABLE = object()    # sentinel: tried to load, missing/unreadable
+_lightdome_index_cache = None        # None = not yet attempted
+
+
+def _lightdome_h3_path() -> "Path | None":
+    """Resolve the index .npz path: env override → repo cache → Lambda image path."""
+    env_override = os.environ.get("PYNIGHTSKY_LIGHTDOME_H3_PATH")
+    if env_override:
+        p = Path(env_override)
+        return p if p.exists() else None
+    for candidate in (
+        Path(__file__).parent.parent / "cache" / _LIGHTDOME_H3_FILENAME,
+        Path("/app/cache") / _LIGHTDOME_H3_FILENAME,
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+class LightDomeIndex:
+    """Columnar light-dome H3 index: a sorted uint64 cell array plus parallel raw
+    per-direction value arrays (scores, dome heights, mean distances). Lookups
+    binary-search the cell array; the summary is built at lookup time so a threshold
+    recalibration needs no rebuild. Read from a compressed .npz with numpy only."""
+
+    __slots__ = ("cells", "scores", "dome_heights", "mean_distances")
+
+    def __init__(self, cells, scores, dome_heights, mean_distances):
+        self.cells = cells                    # np.ndarray[uint64], ascending (N,)
+        self.scores = scores                  # np.ndarray[float] (N, 8), order = DIRS_8
+        self.dome_heights = dome_heights      # np.ndarray[float] (N, 8), degrees
+        self.mean_distances = mean_distances  # np.ndarray[float] (N, 8); -1.0 = no glow
+
+
+def load_lightdome_index() -> "LightDomeIndex | None":
+    """Lazy-load the light-dome H3 index once per process; cache the result.
+
+    Returns None (and caches that failure) if h3/numpy is unavailable, the .npz is
+    missing, or the read fails — callers degrade gracefully (no light-dome panel).
+    """
+    global _lightdome_index_cache
+    if _lightdome_index_cache is _LIGHTDOME_UNAVAILABLE:
+        return None
+    if _lightdome_index_cache is not None:
+        return _lightdome_index_cache  # type: ignore[return-value]
+
+    if not _HAS_H3:
+        _lightdome_index_cache = _LIGHTDOME_UNAVAILABLE
+        return None
+
+    path = _lightdome_h3_path()
+    if path is None:
+        _lightdome_index_cache = _LIGHTDOME_UNAVAILABLE
+        return None
+
+    try:
+        with np.load(path) as npz:
+            cells = npz["cells"].astype(np.uint64, copy=False)
+            scores = npz["scores"].astype(np.float32, copy=False)
+            dome_heights = npz["dome_heights"].astype(np.float32, copy=False)
+            mean_distances = npz["mean_distances"].astype(np.float32, copy=False)
+        # The .npz is written sorted by cell, so np.searchsorted is valid. Guard cheaply.
+        if cells.size and not bool(np.all(cells[:-1] <= cells[1:])):
+            order = np.argsort(cells, kind="stable")
+            cells, scores, dome_heights, mean_distances = (
+                cells[order], scores[order], dome_heights[order], mean_distances[order])
+        _lightdome_index_cache = LightDomeIndex(cells, scores, dome_heights, mean_distances)
+    except Exception:
+        _lightdome_index_cache = _LIGHTDOME_UNAVAILABLE
+        return None
+
+    return _lightdome_index_cache  # type: ignore[return-value]
+
+
+def lightdome_lookup(lat: float, lon: float, index: "LightDomeIndex | None" = None) -> "dict | None":
+    """Precomputed light-dome summary for (lat, lon), or None if outside coverage.
+
+    O(log n) binary search over the H3 index — safe on the initial page-load path (no
+    raster read). Returns the same shape as :func:`summarize_horizons`. The stored
+    ``-1.0`` mean-distance sentinel maps back to ``None``.
+    """
+    if index is None:
+        index = load_lightdome_index()
+    if index is None:
+        return None
+
+    cell = _h3_lib.str_to_int(_h3_lib.latlng_to_cell(lat, lon, LIGHTDOME_H3_RESOLUTION))
+    cells = index.cells
+    i = int(np.searchsorted(cells, np.uint64(cell)))
+    if i >= cells.size or cells[i] != cell:
+        return None
+
+    sc, dh, md = index.scores[i], index.dome_heights[i], index.mean_distances[i]
+    detailed = {
+        DIRS_8[k]: {
+            "score": float(sc[k]),
+            "dome_height_deg": float(dh[k]),
+            "mean_distance_mi": None if md[k] < 0.0 else float(md[k]),
+        }
+        for k in range(8)
+    }
+    return summarize_horizons(detailed)

--- a/PyNightSkyPredictor/light_dome.py
+++ b/PyNightSkyPredictor/light_dome.py
@@ -1,0 +1,460 @@
+"""Directional horizon light-dome scoring (the "Walker kernel").
+
+Given a candidate observing site, evaluate the light-dome threat from each of the
+8 cardinal directions (N, NE, E, SE, S, SW, W, NW) using a distance-weighted 2D
+spatial kernel over upward radiance. The result tells an observer which way to point
+a wide-angle camera ("darkest horizon is NE") and which directions are spoiled
+("major light dome to the SW").
+
+Physics
+-------
+Each raster pixel of upward radiance (VIIRS, nW/cm2/sr) is treated as a point source
+whose contribution to horizon sky-glow decays with distance per **Walker's Law**:
+
+    intensity ∝ d ** (-2.5)
+
+This is steeper than the d**-2 of pure geometric (inverse-square) spreading. Walker
+(1977) measured a city's artificial zenith sky brightness falling roughly as d**-2.5
+with distance; Garstang's atmospheric-scattering modelling explains why — the scattered
+light traverses more of the low-altitude aerosol/extinction layer (the lower ~2-3 km of
+the troposphere) on its longer slant path to a distant observer, so the glow is
+attenuated faster than geometry alone predicts. Summing radiance * d**-2.5 over a 45°
+azimuth sector therefore approximates the total artificial sky-glow that sector adds to
+the observer's horizon.
+
+A related consequence (not needed for the score, but it explains the bias toward near
+sources): a dome's apparent height is roughly theta ≈ arctan(h / d), with h ≈ 3 km the
+aerosol scattering scale height. Close sources both get the steep d**-2.5 boost *and*
+throw a tall dome high into the frame; distant megacities stay low on the horizon.
+
+Design notes (why this is not a single static pixel kernel)
+-----------------------------------------------------------
+The light-pollution rasters are EPSG:4326 (geographic degrees), not equal-area. A fixed
+pixel offset spans ~69 mi per degree of latitude but only 69*cos(lat) mi per degree of
+longitude, so a kernel precomputed once in *pixel* space would be latitude-distorted
+(a ~0.7:1 ground ellipse at 45°N) and the distortion changes with the site's latitude.
+To stay physically correct while keeping queries fast, the static angular-offset grid is
+precomputed once at init, and the distance/azimuth/area arrays are built (and memoized)
+per latitude band, applying the cos(lat) longitude correction. Distances are in ground
+miles so scores are comparable across latitudes and raster resolutions.
+
+Scoring caveat
+--------------
+The relative ranking of the 8 scores and the ``darkest_direction`` are trustworthy
+immediately — they do not depend on any absolute constant. The Major/Minor severity
+thresholds have been calibrated empirically against a reference basket of known dark-sky
+and near-metro sites (see ``MAJOR_DOME_THRESHOLD`` and ``scripts/calibrate_light_dome.py``);
+they are tied to the default 150-mile geometry, so re-run that calibration if the radius
+changes.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+# --- configuration ---------------------------------------------------------
+
+DEFAULT_RADIUS_MILES = 150.0         # radius from centre; 300-mile box. Matches find_nearby's
+                                     # dome_search_radius so the two tools agree — a Bortle-9
+                                     # metro casts a real (low) dome 90-120+ mi away.
+WALKER_EXPONENT = 2.5                # d**-2.5 sky-glow decay (Walker/Garstang); see module docstring
+MILES_PER_DEG_LAT = 69.0             # ~constant; a degree of latitude is ~69 statute miles
+VIIRS_RES_DEG = 1.0 / 240.0          # ~0.004167° (~400 m) — VIIRS Black Marble native grid
+H_AEROSOL_KM = 3.0                   # aerosol scattering scale height; a dome's apparent height
+                                     # is theta ≈ arctan(h / d), so distant domes sit low
+KM_PER_MILE = 1.609344
+
+DIRS_8: tuple[str, ...] = ("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+
+# Severity thresholds on the per-direction score, which has units
+# (nW/cm2/sr) * mi**-2.5 * mi**2 = (nW/cm2/sr) * mi**-0.5 — i.e. an area-weighted glow
+# index. CALIBRATED empirically at the default 150-mile radius WITH soft binning, against a
+# reference basket (see scripts/calibrate_light_dome.py). At 150 mi darkness is a
+# *continuum* — almost everywhere has some distant-metro glow — and soft binning spreads a
+# straddling source across two directions, so peak per-direction scores for premier dark
+# parks (~0.27, e.g. Cherry Springs) and a real-but-low distant metro dome (~0.28, Phoenix
+# seen 100 mi away) are nearly equal in MAGNITUDE. They are separated instead by
+# DIRECTIONALITY: PROMINENCE_RATIO requires a dome to stand well above the darkest
+# direction, so a sharp dome (Phoenix ~34x the darkest) flags while diffuse skyglow
+# (Cherry Springs ~3.5x) stays clean. MAJOR stays robust (Joshua Tree ~2 minor vs
+# Denver/Pine Barrens ~4+). Scores scale with radius_miles and with the binning scheme,
+# so re-run the calibration if either changes.
+MINOR_DOME_THRESHOLD = 0.25          # a real, low directional dome (gated by prominence below)
+MAJOR_DOME_THRESHOLD = 3.0           # a sky-degrading dome (close/large metro within range)
+PROMINENCE_RATIO = 4.0               # a dome must be >= this * the darkest direction to count —
+                                     # separates a sharp directional dome from diffuse skyglow
+
+
+class LightDomeAnalyzer:
+    """Score the light-dome threat in each of 8 cardinal directions around a site.
+
+    The expensive, latitude-independent geometry (the per-pixel offset grid) is built
+    once at construction. The distance-weight kernel and soft direction weights depend on
+    latitude (via the cos(lat) longitude correction) and are built lazily and memoized
+    per ``lat_band_deg`` band, so repeated queries near the same latitude are cheap.
+
+    Besides the 8 directional scores, :meth:`analyze_horizons_detailed` also returns a
+    glow-weighted mean distance and the resulting dome apparent height per direction, and
+    the module function :func:`glow_toward` samples the glow at any (azimuth, altitude) —
+    the hook for scoring how a light dome affects a specific target in the sky.
+
+    Parameters
+    ----------
+    radius_miles:
+        Radius of the analysis box in ground miles (default 150 → 300-mile box),
+        matching find_nearby's dome_search_radius so distant metro domes are captured.
+    resolution_deg:
+        Pixel size in degrees of the radiance window passed to
+        :meth:`analyze_destination_horizons` (default = VIIRS native ~0.004167°).
+    lat_band_deg:
+        Granularity of the per-latitude kernel cache. 1° bands keep the cos(lat)
+        approximation error well under a percent while sharing kernels across queries.
+    """
+
+    def __init__(
+        self,
+        radius_miles: float = DEFAULT_RADIUS_MILES,
+        resolution_deg: float = VIIRS_RES_DEG,
+        lat_band_deg: float = 1.0,
+    ) -> None:
+        if radius_miles <= 0 or resolution_deg <= 0 or lat_band_deg <= 0:
+            raise ValueError("radius_miles, resolution_deg and lat_band_deg must be positive")
+
+        self.radius_miles = float(radius_miles)
+        self.resolution_deg = float(resolution_deg)
+        self.lat_band_deg = float(lat_band_deg)
+
+        # Odd pixel count so there is a true centre pixel. ``half`` pixels reach
+        # ``radius_miles`` in the latitude (constant-scale) direction.
+        half = math.ceil(radius_miles / (resolution_deg * MILES_PER_DEG_LAT))
+        self._half = half
+        self._n = 2 * half + 1
+
+        # Static, latitude-independent integer offsets from the centre pixel.
+        # row increases downward (south), col increases rightward (east).
+        offs = np.arange(-half, half + 1, dtype=np.float64)
+        self._row_off, self._col_off = np.meshgrid(offs, offs, indexing="ij")
+
+        # band-key -> (weights, dist_mi, lo_idx, hi_idx, frac, cell_area_sq_mi)
+        self._cache: dict[int, tuple] = {}
+
+    @property
+    def kernel_shape(self) -> tuple[int, int]:
+        """(N, N) — the exact window shape :meth:`analyze_destination_horizons` expects."""
+        return (self._n, self._n)
+
+    def _kernel_for_latitude(self, lat: float) -> tuple:
+        """Build (or fetch from cache) the Walker weight kernel + soft direction weights.
+
+        Returns ``(weights, dist_mi, lo_idx, hi_idx, frac, cell_area_sq_mi)``:
+
+        - ``weights`` — N×N ``d**-WALKER_EXPONENT`` (centre pixel = 0, no singularity).
+        - ``dist_mi`` — N×N ground distance of each pixel from centre, in miles (used for
+          the glow-weighted mean-distance / dome-height per direction).
+        - ``lo_idx``, ``hi_idx``, ``frac`` — *soft binning*. Each pixel's azimuth falls
+          between two adjacent cardinal directions ``lo_idx`` and ``hi_idx``; its weight is
+          shared ``(1 - frac)`` to ``lo_idx`` and ``frac`` to ``hi_idx`` (a tent / linear
+          interpolation onto the 8 nodes). This is a partition of unity — total weight per
+          pixel is conserved — so a source between two compass points (e.g. Phoenix at SSW)
+          is shared proportionally rather than snapped across a hard 22.5° edge, and the 8
+          scores vary smoothly with source bearing instead of flipping at sector borders.
+        - ``cell_area_sq_mi`` — ground area of one pixel; makes the sum an area-weighted
+          (resolution-independent) integral.
+        """
+        band = int(round(lat / self.lat_band_deg))
+        cached = self._cache.get(band)
+        if cached is not None:
+            return cached
+
+        band_center = band * self.lat_band_deg
+        cos_lat = max(math.cos(math.radians(band_center)), 1e-6)  # guard the poles
+
+        # Ground offsets in miles. Negate the row term: row increases southward, so a
+        # pixel one row *above* centre (row_off = -1) lies to the NORTH (+miles north).
+        deg_mi = self.resolution_deg * MILES_PER_DEG_LAT
+        d_north_mi = -self._row_off * deg_mi
+        d_east_mi = self._col_off * deg_mi * cos_lat
+
+        dist_mi = np.hypot(d_north_mi, d_east_mi)
+
+        # Walker d**-2.5 decay; centre pixel (d == 0) contributes nothing.
+        with np.errstate(divide="ignore"):
+            weights = (dist_mi ** (-WALKER_EXPONENT)).astype(np.float32)
+        weights[self._half, self._half] = 0.0
+
+        # Compass azimuth from centre: 0° = N, 90° = E. atan2(east, north) matches the
+        # bearing convention and format_ctx.cardinal(). Tent-interpolate onto 8 nodes.
+        az = np.degrees(np.arctan2(d_east_mi, d_north_mi)) % 360.0
+        p = az / 45.0
+        lo = np.floor(p).astype(np.int64)
+        frac = (p - lo).astype(np.float32)
+        lo_idx = (lo % 8).astype(np.int16)
+        hi_idx = ((lo + 1) % 8).astype(np.int16)
+
+        cell_area_sq_mi = deg_mi * (deg_mi * cos_lat)
+
+        result = (weights, dist_mi.astype(np.float32), lo_idx, hi_idx, frac, cell_area_sq_mi)
+        self._cache[band] = result
+        return result
+
+    def _compute(self, destination_lat: float, window_array: np.ndarray):
+        """Core vectorised pass → (scores, mean_distance_mi, dome_height_deg) arrays of len 8.
+
+        ``scores[k] = (Σ radiance·walker·soft_k) · cell_area`` (the area-weighted glow
+        index). ``mean_distance_mi[k]`` is the same soft-weighted sum, weighted again by
+        distance and normalised — the glow-weighted mean distance of the light feeding that
+        direction (NaN where there is no glow). ``dome_height_deg[k] = arctan(h / d)`` from
+        that distance — the apparent height the dome rises off the horizon.
+        """
+        window = np.asarray(window_array, dtype=np.float64)
+        if window.shape != self.kernel_shape:
+            raise ValueError(
+                f"window_array shape {window.shape} != expected kernel shape "
+                f"{self.kernel_shape}; request out_shape={self.kernel_shape} when reading "
+                "the window (a boundary slice may have come back truncated)"
+            )
+
+        weights, dist_mi, lo_idx, hi_idx, frac, cell_area = self._kernel_for_latitude(destination_lat)
+
+        wflat = (window * weights).ravel()           # radiance · walker weight, per pixel
+        lo, hi, f = lo_idx.ravel(), hi_idx.ravel(), frac.ravel()
+        dist = dist_mi.ravel()
+        w_lo, w_hi = wflat * (1.0 - f), wflat * f
+
+        raw = (np.bincount(lo, weights=w_lo, minlength=8)
+               + np.bincount(hi, weights=w_hi, minlength=8))
+        dnum = (np.bincount(lo, weights=w_lo * dist, minlength=8)
+                + np.bincount(hi, weights=w_hi * dist, minlength=8))
+
+        scores = raw * cell_area
+        with np.errstate(divide="ignore", invalid="ignore"):
+            mean_distance_mi = np.where(raw > 0.0, dnum / raw, np.nan)
+            d_km = mean_distance_mi * KM_PER_MILE
+            dome_height_deg = np.where(
+                raw > 0.0, np.degrees(np.arctan2(H_AEROSOL_KM, d_km)), 0.0)
+        return scores, mean_distance_mi, dome_height_deg
+
+    def analyze_destination_horizons(
+        self,
+        destination_lat: float,
+        destination_lon: float,  # noqa: ARG002 — symmetry of intent; lon does not affect the kernel
+        window_array: np.ndarray,
+    ) -> dict[str, float]:
+        """Return the 8 directional light-dome scores for a centred radiance window.
+
+        ``window_array`` must be the N×N (== :attr:`kernel_shape`) sub-array of upward
+        radiance centred on the destination, oriented row 0 = north (max_lat),
+        col 0 = west (min_lon) — exactly what ``raster_source.read_window`` returns.
+
+        Each score is ``Σ(radiance · walker_weight · soft_weight) · cell_area`` over the
+        window — vectorised, with soft (tent) binning across the two nearest cardinal
+        directions and no Python loop over pixels. For the per-direction mean distance and
+        dome apparent height, use :meth:`analyze_horizons_detailed`.
+        """
+        scores, _, _ = self._compute(destination_lat, window_array)
+        return {DIRS_8[i]: float(scores[i]) for i in range(8)}
+
+    def analyze_horizons_detailed(
+        self,
+        destination_lat: float,
+        destination_lon: float,  # noqa: ARG002 — symmetry of intent; lon does not affect the kernel
+        window_array: np.ndarray,
+    ) -> dict[str, dict]:
+        """Like :meth:`analyze_destination_horizons` but rich per-direction info::
+
+            {"S": {"score": 0.33, "mean_distance_mi": 95.2, "dome_height_deg": 1.1}, ...}
+
+        ``mean_distance_mi`` is the glow-weighted mean distance of the light feeding that
+        direction (``None`` if there is no glow); ``dome_height_deg`` is ``arctan(h / d)``
+        from that distance — how high the dome rises off the horizon. Feed this dict to
+        :func:`glow_toward` to sample the glow at a target's (azimuth, altitude).
+        """
+        scores, mean_dist, dome_h = self._compute(destination_lat, window_array)
+        out: dict[str, dict] = {}
+        for i, d in enumerate(DIRS_8):
+            md = float(mean_dist[i])
+            out[d] = {
+                "score": float(scores[i]),
+                "mean_distance_mi": None if math.isnan(md) else md,
+                "dome_height_deg": float(dome_h[i]),
+            }
+        return out
+
+    def _read_window(self, lat: float, lon: float, backend, dataset: str) -> np.ndarray:
+        """Fetch the centred N×N radiance window through the ports raster seam.
+
+        ``out_shape`` guarantees an exact N×N grid regardless of the raster's native
+        resolution (the resample assumes ~``resolution_deg`` pixel spacing — sub-pixel
+        alignment only). VIIRS radiance (nW/cm2/sr) is the metric; Falchi is *luminance*
+        (mcd/m2, different units) so it is intentionally not blended — pass ``"viirs"``.
+        """
+        if backend is None:
+            from . import ports
+            backend = ports.get_backend()
+
+        cos_lat = max(math.cos(math.radians(lat)), 1e-6)
+        half_lat_deg = self._half * self.resolution_deg
+        half_lon_deg = half_lat_deg / cos_lat
+
+        window = backend.raster_source.read_window(
+            dataset,
+            lat - half_lat_deg,
+            lat + half_lat_deg,
+            lon - half_lon_deg,
+            lon + half_lon_deg,
+            out_shape=self.kernel_shape,
+        )
+        if window is None:
+            raise RuntimeError(f"raster_source returned no {dataset} window for ({lat}, {lon})")
+        return window
+
+    def analyze(self, lat: float, lon: float, *, backend=None, dataset: str = "viirs") -> dict[str, float]:
+        """Convenience wrapper: fetch the radiance window via the ports seam, then score.
+
+        Returns the 8 directional scores. See :meth:`analyze_detailed` for distances and
+        dome heights.
+        """
+        return self.analyze_destination_horizons(lat, lon, self._read_window(lat, lon, backend, dataset))
+
+    def analyze_detailed(self, lat: float, lon: float, *, backend=None, dataset: str = "viirs") -> dict[str, dict]:
+        """Convenience wrapper for :meth:`analyze_horizons_detailed` (fetches the window)."""
+        return self.analyze_horizons_detailed(lat, lon, self._read_window(lat, lon, backend, dataset))
+
+
+def summarize_horizons(
+    data: dict,
+    *,
+    minor_threshold: float = MINOR_DOME_THRESHOLD,
+    major_threshold: float = MAJOR_DOME_THRESHOLD,
+    prominence_ratio: float = PROMINENCE_RATIO,
+) -> dict:
+    """Normalise the 8 directional results into a user-facing summary.
+
+    Accepts either the plain ``{dir: score}`` dict from
+    :meth:`LightDomeAnalyzer.analyze_destination_horizons` *or* the rich
+    ``{dir: {"score", "mean_distance_mi", "dome_height_deg"}}`` dict from
+    :meth:`~LightDomeAnalyzer.analyze_horizons_detailed`. When given the rich dict, each
+    flagged dome also carries ``mean_distance_mi`` and ``dome_height_deg``.
+
+    Returns::
+
+        {
+          "sky_state": "dark" | "domed" | "urban",
+          "scores": {dir: rounded_score, ...},
+          "darkest_direction": "NE",
+          "darkest_score": 0.007,
+          "domes": [ {"direction": "S", "severity": "minor", "score": 0.33,
+                      "label": "Minor light dome to the S",
+                      "mean_distance_mi": 95.2, "dome_height_deg": 1.1}, ... ],  # worst-first
+        }
+
+    A direction is flagged as a dome only if it is *both* absolutely significant
+    (score >= ``minor_threshold``) **and** directionally prominent
+    (score >= ``prominence_ratio`` * the darkest direction's score). Requiring both
+    avoids two failure modes: flagging a trivially-brighter direction at a uniformly dark
+    site (pure-relative false positive), and failing to distinguish a real directional
+    dome from uniform city glow (pure-absolute blind spot).
+
+    ``sky_state`` is a site-level classification the UI should branch on. It keys on the
+    *darkest* direction's absolute score — "how good is your best horizon?" — which the
+    prominence-gated dome list alone cannot answer (a fully-surrounded site flags *few*
+    domes because nothing stands out, which would otherwise look deceptively clean):
+
+    - ``"dark"`` — darkest direction is genuinely dark and no domes flagged;
+      ``darkest_direction`` is a real best-view horizon.
+    - ``"domed"`` — directional domes exist but a darker side remains; point away from them.
+    - ``"bright"`` — no single dome stands out, yet every direction carries real glow
+      (``minor_threshold <= darkest < major_threshold``): a uniformly washed suburban sky,
+      not a dark site and not a directional problem.
+    - ``"urban"`` — even the darkest direction is itself a major dome
+      (``darkest >= major_threshold``); there is no dark horizon. ``domes`` /
+      ``darkest_direction`` are still returned but are not a meaningful "where to point"
+      signal — the honest message is "washed out in all directions".
+
+    ``darkest_score`` is always included so the UI can caveat the darkest direction (e.g.
+    "least-bad: NW, still bright") in any state.
+    """
+    if not data:
+        raise ValueError("data must be a non-empty dict of direction -> score (or detail)")
+
+    detailed = all(isinstance(v, dict) for v in data.values())
+    scores = {d: (v["score"] if detailed else v) for d, v in data.items()}
+
+    darkest_direction = min(scores, key=scores.__getitem__)
+    darkest_score = scores[darkest_direction]
+
+    domes: list[dict] = []
+    for direction, score in scores.items():
+        significant = score >= minor_threshold
+        prominent = score >= prominence_ratio * darkest_score
+        if not (significant and prominent):
+            continue
+        severity = "major" if score >= major_threshold else "minor"
+        entry = {
+            "direction": direction,
+            "severity": severity,
+            "score": round(score, 3),
+            "label": f"{severity.capitalize()} light dome to the {direction}",
+        }
+        if detailed:
+            md = data[direction].get("mean_distance_mi")
+            entry["mean_distance_mi"] = None if md is None else round(md, 1)
+            entry["dome_height_deg"] = round(data[direction].get("dome_height_deg", 0.0), 1)
+        domes.append(entry)
+
+    domes.sort(key=lambda d: d["score"], reverse=True)
+
+    # Site-level state, keyed on the darkest direction's absolute score — "is even the best
+    # direction bad?" — which the prominence-gated dome list cannot answer.
+    if darkest_score >= major_threshold:
+        sky_state = "urban"          # no dark horizon: even the best direction is a major dome
+    elif domes:
+        sky_state = "domed"          # a directional dome, but a darker side remains
+    elif darkest_score >= minor_threshold:
+        sky_state = "bright"         # uniform glow everywhere, no single standout dome
+    else:
+        sky_state = "dark"           # genuinely dark
+
+    return {
+        "sky_state": sky_state,
+        "scores": {d: round(s, 3) for d, s in scores.items()},
+        "darkest_direction": darkest_direction,
+        "darkest_score": round(darkest_score, 3),
+        "domes": domes,
+    }
+
+
+def glow_toward(detailed: dict[str, dict], azimuth_deg: float, altitude_deg: float) -> float:
+    """Light-dome glow at an arbitrary sky position — the hook for target scoring.
+
+    Given the rich per-direction output of
+    :meth:`LightDomeAnalyzer.analyze_horizons_detailed` and a sky position
+    (``azimuth_deg`` 0=N/90=E, ``altitude_deg`` 0=horizon/90=zenith), returns the
+    interpolated glow index at that point. Tent-interpolates the horizon score and the
+    (distance-derived) dome apparent height across the two nearest cardinal directions,
+    then applies an altitude falloff anchored on that dome height:
+
+        glow(az, alt) = horizon_score(az) / (1 + (alt / theta(az))**2)
+
+    so glow is full at the horizon, half at the dome's apparent height ``theta``, and
+    tends to 0 well above it. A distant low dome (small ``theta``) barely reaches a target
+    more than a few degrees up; a near dome reaches higher. The dome height is data-driven;
+    the falloff *shape* is a heuristic.
+
+    Intended use: pass a target's azimuth/altitude (e.g. the Milky Way core or a nebula at
+    a given time) to estimate how much that direction's light dome washes it out.
+    """
+    p = (azimuth_deg % 360.0) / 45.0
+    lo = int(math.floor(p)) % 8
+    hi = (lo + 1) % 8
+    f = p - math.floor(p)
+
+    score = detailed[DIRS_8[lo]]["score"] * (1.0 - f) + detailed[DIRS_8[hi]]["score"] * f
+    theta = detailed[DIRS_8[lo]]["dome_height_deg"] * (1.0 - f) + detailed[DIRS_8[hi]]["dome_height_deg"] * f
+
+    alt = max(0.0, altitude_deg)
+    if theta <= 0.0:
+        return score if alt == 0.0 else 0.0
+    return score / (1.0 + (alt / theta) ** 2)

--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -11,6 +11,7 @@ from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from . import darksky as _ds
+from . import light_dome as _ld
 from . import moon_events as _me
 from . import ports as _ports
 from . import scoring
@@ -101,6 +102,9 @@ class NightReport:
     # Visible targets (populated when fetch_targets=True)
     visible_targets: list = field(default_factory=list)
     mw_summary:      dict | None = None   # milky_way_arch_summary output (MW targets only)
+
+    # Light dome — precomputed H3 index lookup (summarize_horizons shape); None outside coverage
+    light_dome: dict | None = None
 
     # Active meteor showers tonight (always populated)
     active_showers: list  = field(default_factory=list)
@@ -270,6 +274,10 @@ def assemble_night(
 
         # Collect darksky (S3 raster read — almost certainly done by now)
         ds_info = _ds_future.result()
+
+        # Light dome — precomputed H3 index lookup (O(log n), no raster read), so it's
+        # safe on the initial page-load path. None when outside the index coverage.
+        light_dome_info = _ld.lightdome_lookup(lat, lon)
 
         # Collect weather future (started at entry; may still be running if
         # Open-Meteo is slower than the Skyfield work above)
@@ -511,6 +519,7 @@ def assemble_night(
         dark_score=dark_score,
         light_pollution=ds_info,
         bortle_score=bortle_score,
+        light_dome=light_dome_info,
         weather_points=night_points,
         weather_score=weather_score,
         wx_source=wx_source,

--- a/PyNightSkyPredictor/render_report.py
+++ b/PyNightSkyPredictor/render_report.py
@@ -134,6 +134,17 @@ def print_report(report: NightReport, ctx: FormatCtx, show_weather: bool) -> Non
     lp = _lp_line(report)
     if lp:
         print(f"Light Pollution:    {lp}")
+    if report.light_dome:
+        _ld = report.light_dome
+        if _ld.get("sky_state") == "urban":
+            _ldl = "washed out in all directions"
+        elif _ld.get("domes"):
+            _ldl = (", ".join(f"{d['severity']} {d['direction']}" for d in _ld["domes"])
+                    + f"  ·  darkest {_ld['darkest_direction']}")
+        else:
+            _base = "uniform glow" if _ld.get("sky_state") == "bright" else "clear"
+            _ldl = f"{_base}  ·  darkest {_ld['darkest_direction']}"
+        print(f"Light Domes:        {_ldl}")
     tags = []
     if report.moon_special:
         tags.append(report.moon_special.title())

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -69,6 +69,11 @@ async def lifespan(app: FastAPI):
             except Exception as _e:
                 logging.getLogger(__name__).debug("Cache pre-warm failed: %s", _e)
             try:
+                from PyNightSkyPredictor import light_dome as _ld
+                _ld.load_lightdome_index()   # mmap/parse the ~MB light-dome H3 index once
+            except Exception as _e:
+                logging.getLogger(__name__).debug("Light-dome index pre-warm failed: %s", _e)
+            try:
                 jobs._sqs()   # build the boto3 SQS client off the first enqueue's path
             except Exception as _e:
                 logging.getLogger(__name__).debug("SQS pre-warm failed: %s", _e)

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -66,7 +66,7 @@ def _stage_worker_src() -> str:
     shutil.copytree(_REPO / "PyNightSkyPredictor", stage / "PyNightSkyPredictor", ignore=ig)
     shutil.copytree(_REPO / "apps", stage / "apps", ignore=ig)
     (stage / "cache").mkdir()
-    for _npz in ("darkhours_padus_h3.npz", "osm_pois.npz"):
+    for _npz in ("darkhours_padus_h3.npz", "osm_pois.npz", "lightdome_h3.npz"):
         shutil.copy(_REPO / "cache" / _npz, stage / "cache" / _npz)
     shutil.copy(_REPO / "requirements.txt", stage / "requirements.txt")
     return str(stage)

--- a/scripts/build_lightdome_index.py
+++ b/scripts/build_lightdome_index.py
@@ -1,0 +1,111 @@
+"""
+Build the DarkHours light-dome H3 index (cache/lightdome_h3.npz).
+
+Light dome is a pure function of static VIIRS radiance + location, so it is precomputed
+once here and served as an O(log n) lookup on the initial page-load path — no 150-mile
+raster read at request time. Mirrors the PAD-US / OSM POI index pattern.
+
+The build runs LOCALLY against the on-disk VIIRS grid (PYNIGHTSKY_BACKEND=local, memmap,
+no S3). For each H3 res-6 cell (~36 km^2) covering CONUS it computes the per-direction
+light-dome scores, dome heights, and glow-weighted mean distances, and stores them raw —
+``summarize_horizons`` runs at *lookup* time, so a threshold recalibration needs no rebuild.
+
+--- USAGE ---
+
+    # full CONUS index (committed; the Docker images copy it)
+    python scripts/build_lightdome_index.py
+
+    # a small regional index for verification (e.g. AZ/UT)
+    python scripts/build_lightdome_index.py --min-lat 33 --max-lat 42 \
+        --min-lon -117 --max-lon -110 --out /tmp/ld_az.npz
+
+--- RUNTIME LOOKUP ---
+
+    Loaded once per process and queried via light_dome.load_lightdome_index /
+    light_dome.lightdome_lookup (columnar np.searchsorted).
+"""
+import argparse
+import os
+import sys
+import time
+from multiprocessing import Pool
+from pathlib import Path
+
+import numpy as np
+import h3
+from shapely.geometry import box, mapping
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("PYNIGHTSKY_BACKEND", "local")
+from PyNightSkyPredictor.light_dome import DIRS_8, LightDomeAnalyzer  # noqa: E402
+
+RESOLUTION = 6                              # ~36.1 km^2/cell — matches the runtime lookup
+CONUS = (24.4, 49.4, -125.0, -66.9)         # min_lat, max_lat, min_lon, max_lon
+_DEFAULT_OUT = Path(__file__).resolve().parent.parent / "cache" / "lightdome_h3.npz"
+
+_analyzer: LightDomeAnalyzer | None = None
+
+
+def _init(resolution_deg: float) -> None:
+    """Pool worker init: build one analyzer per process (kernels amortise across cells)."""
+    global _analyzer
+    _analyzer = LightDomeAnalyzer(resolution_deg=resolution_deg) if resolution_deg else LightDomeAnalyzer()
+
+
+def _compute(cell_int: int):
+    """Return (cell, scores[8], heights[8], distances[8]) or None for ocean/no-data cells."""
+    lat, lon = h3.cell_to_latlng(h3.int_to_str(cell_int))
+    det = _analyzer.analyze_detailed(lat, lon)
+    scores = np.array([det[d]["score"] for d in DIRS_8], dtype=np.float32)
+    if float(scores.max()) <= 0.0:
+        return None                          # all-zero window → ocean / outside data
+    heights = np.array([det[d]["dome_height_deg"] for d in DIRS_8], dtype=np.float32)
+    dists = np.array(
+        [-1.0 if det[d]["mean_distance_mi"] is None else det[d]["mean_distance_mi"] for d in DIRS_8],
+        dtype=np.float32,
+    )
+    return cell_int, scores, heights, dists
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Build the light-dome H3 index.")
+    ap.add_argument("--min-lat", type=float, default=CONUS[0])
+    ap.add_argument("--max-lat", type=float, default=CONUS[1])
+    ap.add_argument("--min-lon", type=float, default=CONUS[2])
+    ap.add_argument("--max-lon", type=float, default=CONUS[3])
+    ap.add_argument("--out", type=Path, default=_DEFAULT_OUT)
+    ap.add_argument("--workers", type=int, default=os.cpu_count() or 4)
+    ap.add_argument("--resolution-deg", type=float, default=0.0,
+                    help="analyzer pixel size (0 = VIIRS native; coarser = faster, scores are "
+                         "resolution-independent). Keep 0 to match the live analyzer exactly.")
+    args = ap.parse_args()
+
+    poly = box(args.min_lon, args.min_lat, args.max_lon, args.max_lat)
+    cell_ints = sorted(h3.str_to_int(c) for c in h3.geo_to_cells(mapping(poly), RESOLUTION))
+    print(f"[build] {len(cell_ints)} H3 res-{RESOLUTION} cells over "
+          f"lat[{args.min_lat},{args.max_lat}] lon[{args.min_lon},{args.max_lon}]; "
+          f"{args.workers} workers")
+
+    t0 = time.time()
+    with Pool(args.workers, initializer=_init, initargs=(args.resolution_deg,)) as pool:
+        results = pool.map(_compute, cell_ints, chunksize=64)
+    rows = [r for r in results if r is not None]
+    rows.sort(key=lambda r: r[0])
+    dt = time.time() - t0
+
+    cells = np.array([r[0] for r in rows], dtype=np.uint64)
+    scores = np.array([r[1] for r in rows], dtype=np.float16)
+    heights = np.array([r[2] for r in rows], dtype=np.float16)
+    dists = np.array([r[3] for r in rows], dtype=np.float16)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(args.out, cells=cells, scores=scores,
+                        dome_heights=heights, mean_distances=dists)
+    size_mb = args.out.stat().st_size / 1e6
+    print(f"[build] kept {len(rows)}/{len(cell_ints)} land cells "
+          f"({len(cell_ints) - len(rows)} ocean/no-data skipped) in {dt:.0f}s")
+    print(f"[build] wrote {args.out} ({size_mb:.2f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/calibrate_light_dome.py
+++ b/scripts/calibrate_light_dome.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Calibrate the LightDomeAnalyzer Major/Minor thresholds against a reference basket.
+
+Runs the analyzer at the default 150-mile radius for a set of sites whose darkness class
+is known a priori, and prints the worst-direction score distribution per class. At 150 mi
+darkness is a continuum (distant-metro glow reaches almost everywhere), so the MINOR/MAJOR
+constants in ``PyNightSkyPredictor/light_dome.py`` are not separating two clean clusters:
+MAJOR is set below the close-metro floor (sky-degrading), MINOR just above premier
+dark-sky-park glow so a real-but-low distant metro dome still flags.
+
+Local backend only — uses the on-disk VIIRS grid (no network). Re-run this if the default
+``radius_miles`` geometry changes, since the score (an area-weighted glow index) scales
+with it.
+
+Usage:
+    PYNIGHTSKY_BACKEND=local python scripts/calibrate_light_dome.py
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from PyNightSkyPredictor.light_dome import LightDomeAnalyzer  # noqa: E402
+
+# class: 'pristine' (genuinely remote even within 150 mi — should stay near zero),
+#        'domed'    (a metro within ~120 mi — should flag a dome in the city direction).
+# At 150 mi there is no "rural" middle cluster: distant glow makes darkness a continuum.
+SITES = [
+    ("pristine", "Big Bend NP, TX",             29.27, -103.30),
+    ("pristine", "Cosmic Campground, NM",       33.48, -108.91),
+    ("pristine", "Great Basin NP, NV",          38.98, -114.30),
+    ("pristine", "Natural Bridges, UT",         37.60, -110.01),
+    ("pristine", "Cherry Springs SP, PA",       41.66,  -77.82),  # premier park; distant-town ceiling
+    ("domed",    "Sedona/Munds Park (Phoenix)", 34.8697, -111.4106),  # low Phoenix dome 90 mi S
+    ("domed",    "Joshua Tree NP (LA/Palm Spr)", 33.87, -115.90),
+    ("domed",    "25mi W of Las Vegas",          36.17, -115.60),
+    ("domed",    "30mi N of Phoenix",            33.88, -112.07),
+    ("domed",    "30mi S of Denver",             39.30, -104.99),
+    ("domed",    "40mi NW of Dallas",            33.30,  -97.30),
+    ("domed",    "Pine Barrens NJ (Phila/NYC)",  39.80,  -74.50),
+]
+
+
+def main() -> None:
+    analyzer = LightDomeAnalyzer()
+    by_class: dict[str, list[float]] = {}
+
+    for cls, label, lat, lon in SITES:
+        scores = list(analyzer.analyze(lat, lon).values())
+        worst = max(scores)
+        by_class.setdefault(cls, []).append(worst)
+        ordered = sorted(scores, reverse=True)
+        print(f"{cls:8s} {label:28s} worst={worst:8.2f}  2nd={ordered[1]:8.2f}  sum={sum(scores):9.2f}")
+
+    print()
+    for cls in ("pristine", "domed"):
+        v = by_class.get(cls, [])
+        if not v:
+            continue
+        print(f"{cls:8s}: worst-direction score  min={min(v):.3f}  "
+              f"median={np.median(v):.3f}  max={max(v):.3f}  (n={len(v)})")
+
+    pristine = by_class.get("pristine", [])
+    domed = by_class.get("domed", [])
+    if pristine and domed:
+        print()
+        print(f"pristine ceiling={max(pristine):.3f}  ->  domed floor={min(domed):.3f} "
+              "(continuum at 150 mi — these may overlap)")
+        from PyNightSkyPredictor.light_dome import MINOR_DOME_THRESHOLD, MAJOR_DOME_THRESHOLD
+        print(f"current constants: MINOR_DOME_THRESHOLD={MINOR_DOME_THRESHOLD}, "
+              f"MAJOR_DOME_THRESHOLD={MAJOR_DOME_THRESHOLD}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_light_dome.py
+++ b/tests/test_light_dome.py
@@ -1,0 +1,389 @@
+"""Hermetic tests for the directional light-dome analyzer.
+
+All synthetic numpy arrays — no rasterio, no S3, no network, no ephemeris.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from PyNightSkyPredictor.light_dome import (
+    DIRS_8,
+    LightDomeAnalyzer,
+    glow_toward,
+    summarize_horizons,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _radiance_for_bortle(bortle: int) -> float:
+    """VIIRS radiance mapping to the given Bortle class (mirrors test_light_dome_array)."""
+    sqm_lower = {1: 22.0, 2: 21.7, 3: 21.3, 4: 20.8,
+                 5: 20.0, 6: 19.1, 7: 18.0, 8: 17.0, 9: 0.0}
+    lower = sqm_lower.get(bortle, 17.0)
+    sqm = lower + 0.05 if lower > 0 else 0.05
+    L = 10 ** ((21.7 - sqm) / 2.5) - 0.6
+    return max(L, 0.001)
+
+
+def _coarse_analyzer(resolution_deg: float = 0.05, radius_miles: float = 30.0):
+    """Small kernel (fast) — 0.05° ≈ 3.45 mi/px → N=19 at 30-mile radius."""
+    return LightDomeAnalyzer(radius_miles=radius_miles, resolution_deg=resolution_deg)
+
+
+def _ground_distance_grid(analyzer: LightDomeAnalyzer, lat: float) -> np.ndarray:
+    """Replicate the analyzer's per-pixel ground distance (miles) for building scenes."""
+    deg_mi = analyzer.resolution_deg * 69.0
+    cos_lat = max(math.cos(math.radians(lat)), 1e-6)
+    d_north = -analyzer._row_off * deg_mi
+    d_east = analyzer._col_off * deg_mi * cos_lat
+    return np.hypot(d_north, d_east)
+
+
+# ---------------------------------------------------------------------------
+# Direction / orientation
+# ---------------------------------------------------------------------------
+
+class TestDirectionMapping:
+
+    @pytest.mark.parametrize("d_row, d_col, expected", [
+        (-3, 0, "N"),   # rows decrease northward
+        (0, 3, "E"),
+        (3, 0, "S"),
+        (0, -3, "W"),
+        (-3, 3, "NE"),
+        (3, 3, "SE"),
+        (3, -3, "SW"),
+        (-3, -3, "NW"),
+    ])
+    def test_point_source_lands_in_correct_sector(self, d_row, d_col, expected):
+        a = _coarse_analyzer()
+        c = a._half
+        win = np.zeros(a.kernel_shape, dtype=np.float64)
+        win[c + d_row, c + d_col] = 100.0  # single bright pixel
+
+        scores = a.analyze_destination_horizons(0.0, 0.0, win)
+
+        assert scores[expected] > 0.0
+        # every other direction must be exactly zero
+        for direction, score in scores.items():
+            if direction != expected:
+                assert score == 0.0, f"{direction} leaked from a {expected} source"
+
+    def test_returns_all_eight_directions(self):
+        a = _coarse_analyzer()
+        win = np.ones(a.kernel_shape, dtype=np.float64)
+        scores = a.analyze_destination_horizons(0.0, 0.0, win)
+        assert set(scores) == set(DIRS_8)
+        assert len(scores) == 8
+
+
+# ---------------------------------------------------------------------------
+# Walker d**-2.5 decay (in ground miles, not pixels)
+# ---------------------------------------------------------------------------
+
+class TestWalkerDecay:
+
+    def test_doubling_distance_drops_score_by_2_pow_2_5(self):
+        a = _coarse_analyzer()
+        c = a._half
+
+        near = np.zeros(a.kernel_shape, dtype=np.float64)
+        near[c - 3, c] = 1.0          # 3 px due north
+        far = np.zeros(a.kernel_shape, dtype=np.float64)
+        far[c - 6, c] = 1.0           # 6 px due north (2x the distance)
+
+        s_near = a.analyze_destination_horizons(0.0, 0.0, near)["N"]
+        s_far = a.analyze_destination_horizons(0.0, 0.0, far)["N"]
+
+        # rel=1e-5: weights are stored float32 (halves per-band memory at 150mi default).
+        assert s_near / s_far == pytest.approx(2 ** 2.5, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Resolution independence (the cell-area normalization)
+# ---------------------------------------------------------------------------
+
+class TestResolutionIndependence:
+
+    def test_distributed_source_score_is_resolution_stable(self):
+        """A filled annular source covering a fixed ground area should score the same
+        at two resolutions — NOT scale ~4x as a raw pixel sum would when pixels shrink."""
+        a_coarse = LightDomeAnalyzer(radius_miles=30.0, resolution_deg=0.02)
+        a_fine = LightDomeAnalyzer(radius_miles=30.0, resolution_deg=0.01)
+
+        def total_score(a: LightDomeAnalyzer) -> float:
+            dist = _ground_distance_grid(a, lat=0.0)
+            win = np.where((dist >= 10.0) & (dist <= 20.0), 5.0, 0.0)
+            return sum(a.analyze_destination_horizons(0.0, 0.0, win).values())
+
+        coarse, fine = total_score(a_coarse), total_score(a_fine)
+        # Within discretization error of the annulus boundary — far from the 4x a
+        # non-normalized raw sum would show.
+        assert coarse == pytest.approx(fine, rel=0.10)
+
+
+# ---------------------------------------------------------------------------
+# Latitude (cos-lat) correction
+# ---------------------------------------------------------------------------
+
+class TestLatitudeCorrection:
+
+    def test_east_and_north_equal_at_equator(self):
+        a = _coarse_analyzer()
+        c = a._half
+        east = np.zeros(a.kernel_shape, dtype=np.float64); east[c, c + 4] = 1.0
+        north = np.zeros(a.kernel_shape, dtype=np.float64); north[c - 4, c] = 1.0
+        se = a.analyze_destination_horizons(0.0, 0.0, east)["E"]
+        sn = a.analyze_destination_horizons(0.0, 0.0, north)["N"]
+        assert se == pytest.approx(sn, rel=1e-9)
+
+    def test_east_outweighs_north_at_high_latitude(self):
+        """At 60°N a degree of longitude is half a degree of latitude on the ground, so an
+        equal pixel-offset east source is physically *closer* → higher d**-2.5 weight."""
+        a = _coarse_analyzer()
+        c = a._half
+        east = np.zeros(a.kernel_shape, dtype=np.float64); east[c, c + 4] = 1.0
+        north = np.zeros(a.kernel_shape, dtype=np.float64); north[c - 4, c] = 1.0
+        se = a.analyze_destination_horizons(60.0, 0.0, east)["E"]
+        sn = a.analyze_destination_horizons(60.0, 0.0, north)["N"]
+        assert se > sn
+
+
+# ---------------------------------------------------------------------------
+# Shape guard
+# ---------------------------------------------------------------------------
+
+class TestShapeGuard:
+
+    def test_wrong_shape_raises(self):
+        a = _coarse_analyzer()
+        bad = np.zeros((a._n - 2, a._n), dtype=np.float64)
+        with pytest.raises(ValueError, match="kernel shape"):
+            a.analyze_destination_horizons(0.0, 0.0, bad)
+
+
+# ---------------------------------------------------------------------------
+# Normalization / summarize_horizons
+# ---------------------------------------------------------------------------
+
+class TestSummarizeHorizons:
+
+    def test_uniform_dark_has_darkest_but_no_domes(self):
+        scores = {d: 0.001 for d in DIRS_8}
+        out = summarize_horizons(scores)
+        assert out["darkest_direction"] in DIRS_8
+        assert out["domes"] == []
+
+    def test_uniform_bright_is_not_flagged_as_dome(self):
+        # All directions equally (very) bright: significant, but none stands out.
+        scores = {d: 10.0 for d in DIRS_8}
+        out = summarize_horizons(scores)
+        assert out["domes"] == []
+
+    def test_single_major_dome_to_sw(self):
+        # Explicit thresholds: this test pins the flagging *logic*, not the calibrated
+        # default constants (those are validated separately in test_calibrated_defaults).
+        scores = {d: 0.05 for d in DIRS_8}
+        scores["SW"] = 5.8
+        scores["NE"] = 0.02  # the darkest
+        out = summarize_horizons(scores, minor_threshold=0.5, major_threshold=3.0)
+
+        assert out["darkest_direction"] == "NE"
+        assert len(out["domes"]) == 1
+        dome = out["domes"][0]
+        assert dome["direction"] == "SW"
+        assert dome["severity"] == "major"
+        assert dome["label"] == "Major light dome to the SW"
+
+    def test_minor_vs_major_severity_split(self):
+        scores = {d: 0.02 for d in DIRS_8}
+        scores["E"] = 1.0    # significant + prominent, below major → minor
+        scores["W"] = 4.0    # above major
+        out = summarize_horizons(scores, minor_threshold=0.5, major_threshold=3.0)
+
+        sev = {dome["direction"]: dome["severity"] for dome in out["domes"]}
+        assert sev["E"] == "minor"
+        assert sev["W"] == "major"
+        # worst-first ordering
+        assert out["domes"][0]["direction"] == "W"
+
+    def test_calibrated_defaults_separate_rural_from_metro(self):
+        """Guards the empirical calibration: a rural-ceiling worst score (~0.1) is not a
+        dome, while a near-metro worst score (~3.5) is major — under the default constants."""
+        # rural-like: worst direction at the observed rural/pristine ceiling
+        rural = {d: 0.01 for d in DIRS_8}
+        rural["E"] = 0.1
+        assert summarize_horizons(rural)["domes"] == []
+
+        # metro-like: a dominant city dome at the observed near-metro floor
+        metro = {d: 0.05 for d in DIRS_8}
+        metro["SW"] = 3.5
+        out = summarize_horizons(metro)
+        assert len(out["domes"]) == 1
+        assert out["domes"][0]["severity"] == "major"
+
+    def test_empty_scores_raises(self):
+        with pytest.raises(ValueError):
+            summarize_horizons({})
+
+
+class TestSkyState:
+
+    def test_dark_state_when_no_domes(self):
+        out = summarize_horizons({d: 0.001 for d in DIRS_8})
+        assert out["sky_state"] == "dark"
+        assert out["domes"] == []
+        assert "darkest_score" in out
+
+    def test_domed_state_when_some_domes_but_dark_side_remains(self):
+        scores = {d: 0.05 for d in DIRS_8}
+        scores["SW"] = 5.8          # one big dome; darkest direction stays dark
+        out = summarize_horizons(scores)
+        assert out["sky_state"] == "domed"
+        assert out["domes"]
+
+    def test_urban_state_when_every_direction_is_major(self):
+        # darkest >= major_threshold → no dark horizon anywhere (Roswell-like).
+        scores = {d: 33.0 for d in DIRS_8}
+        scores["E"] = 170.0
+        out = summarize_horizons(scores)              # default major_threshold=3.0
+        assert out["sky_state"] == "urban"
+        # darkest_score is reported so the UI can caveat the "darkest" direction
+        assert out["darkest_score"] == 33.0
+
+    def test_bright_state_uniform_glow_no_standout(self):
+        # Uniformly washed (no dome stands out) but every direction carries real glow,
+        # darkest between minor and major → "bright", NOT "dark".
+        scores = {d: 2.5 for d in DIRS_8}          # uniform; prominence gate suppresses domes
+        out = summarize_horizons(scores, major_threshold=3.0)
+        assert out["domes"] == []
+        assert out["sky_state"] == "bright"
+
+    def test_urban_boundary(self):
+        # darkest just below MAJOR with uniform glow → bright; at/above → urban.
+        below = summarize_horizons({d: 2.9 for d in DIRS_8}, major_threshold=3.0)
+        assert below["sky_state"] == "bright"
+        at = summarize_horizons({d: 3.0 for d in DIRS_8}, major_threshold=3.0)
+        assert at["sky_state"] == "urban"
+
+
+# ---------------------------------------------------------------------------
+# Realistic radiance integration sanity
+# ---------------------------------------------------------------------------
+
+class TestRealisticScene:
+
+    def test_bortle_city_to_one_side_dominates(self):
+        """A Bortle-8 city patch to the south scores far above a Bortle-3 field elsewhere."""
+        a = _coarse_analyzer()
+        c = a._half
+        win = np.full(a.kernel_shape, _radiance_for_bortle(3), dtype=np.float64)
+        # bright city block a few pixels due south
+        win[c + 2 : c + 5, c - 1 : c + 2] = _radiance_for_bortle(8)
+
+        scores = a.analyze_destination_horizons(0.0, 0.0, win)
+        assert scores["S"] == max(scores.values())
+        assert scores["S"] > scores["N"]
+
+
+# ---------------------------------------------------------------------------
+# Soft (tent) binning
+# ---------------------------------------------------------------------------
+
+class TestSoftBinning:
+
+    def test_off_axis_source_shares_between_two_neighbors_only(self):
+        """A pixel between N and NE feeds both — and only those two — proportionally."""
+        a = _coarse_analyzer()
+        c = a._half
+        win = np.zeros(a.kernel_shape, dtype=np.float64)
+        win[c - 5, c + 2] = 100.0          # bearing ≈ atan2(2,5) ≈ 21.8° → between N and NE
+
+        scores = a.analyze_destination_horizons(0.0, 0.0, win)
+        assert scores["N"] > 0 and scores["NE"] > 0
+        for d in ("E", "SE", "S", "SW", "W", "NW"):
+            assert scores[d] == 0.0
+        # closer to N (21.8° < 22.5°), so N gets the larger share
+        assert scores["N"] > scores["NE"]
+
+    def test_partition_of_unity_conserves_total(self):
+        """Soft binning splits weight, never creates or destroys it: total is unchanged
+        vs a single on-axis pixel of the same value."""
+        a = _coarse_analyzer()
+        c = a._half
+        on_axis = np.zeros(a.kernel_shape, dtype=np.float64); on_axis[c - 4, c] = 100.0
+        off_axis = np.zeros(a.kernel_shape, dtype=np.float64); off_axis[c - 4, c + 1] = 100.0
+        # same radius? no — but total weight share must still sum to that pixel's full weight.
+        s_off = a.analyze_destination_horizons(0.0, 0.0, off_axis)
+        # reconstruct the single pixel's full (unsplit) contribution via the kernel
+        w, dist, lo, hi, frac, area = a._kernel_for_latitude(0.0)
+        full = 100.0 * float(w[c - 4, c + 1]) * area
+        assert sum(s_off.values()) == pytest.approx(full, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Mean distance & dome apparent height
+# ---------------------------------------------------------------------------
+
+class TestMeanDistanceAndDomeHeight:
+
+    def test_near_source_is_closer_and_taller_than_far_source(self):
+        a = _coarse_analyzer()  # 0.05° ≈ 3.45 mi/px
+        c = a._half
+
+        near = np.zeros(a.kernel_shape, dtype=np.float64); near[c + 3, c] = 100.0   # 3 px S
+        far = np.zeros(a.kernel_shape, dtype=np.float64); far[c + 9, c] = 100.0      # 9 px S
+
+        dn = a.analyze_horizons_detailed(0.0, 0.0, near)["S"]
+        df = a.analyze_horizons_detailed(0.0, 0.0, far)["S"]
+
+        assert dn["mean_distance_mi"] < df["mean_distance_mi"]
+        assert dn["dome_height_deg"] > df["dome_height_deg"]   # closer dome rises higher
+        # sanity: ~3 px * 3.45 mi/px ≈ 10.4 mi
+        assert dn["mean_distance_mi"] == pytest.approx(3 * a.resolution_deg * 69.0, rel=1e-3)
+
+    def test_no_glow_direction_reports_none_distance(self):
+        a = _coarse_analyzer()
+        c = a._half
+        win = np.zeros(a.kernel_shape, dtype=np.float64); win[c + 3, c] = 100.0   # only S
+        detailed = a.analyze_horizons_detailed(0.0, 0.0, win)
+        assert detailed["N"]["mean_distance_mi"] is None
+        assert detailed["N"]["dome_height_deg"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# glow_toward — target sampling
+# ---------------------------------------------------------------------------
+
+class TestGlowToward:
+
+    def _southern_detail(self):
+        a = _coarse_analyzer()
+        c = a._half
+        win = np.zeros(a.kernel_shape, dtype=np.float64); win[c + 4, c] = 1000.0   # bright S
+        return a.analyze_horizons_detailed(0.0, 0.0, win)
+
+    def test_horizon_equals_score_and_decays_with_altitude(self):
+        d = self._southern_detail()
+        theta = d["S"]["dome_height_deg"]
+        at_horizon = glow_toward(d, 180.0, 0.0)
+        at_theta = glow_toward(d, 180.0, theta)
+        high = glow_toward(d, 180.0, 80.0)
+
+        assert at_horizon == pytest.approx(d["S"]["score"], rel=1e-9)
+        assert at_theta == pytest.approx(d["S"]["score"] / 2.0, rel=1e-6)  # half at dome height
+        assert high < at_theta
+
+    def test_dark_direction_has_negligible_glow(self):
+        d = self._southern_detail()
+        assert glow_toward(d, 0.0, 10.0) < glow_toward(d, 180.0, 10.0)
+
+    def test_detailed_dict_flows_through_summarize(self):
+        d = self._southern_detail()
+        out = summarize_horizons(d, minor_threshold=0.0, major_threshold=1e9)
+        s_dome = next(x for x in out["domes"] if x["direction"] == "S")
+        assert "mean_distance_mi" in s_dome and "dome_height_deg" in s_dome

--- a/tests/test_lightdome_index.py
+++ b/tests/test_lightdome_index.py
@@ -1,0 +1,88 @@
+"""Hermetic tests for the precomputed light-dome H3 index loader + lookup.
+
+Builds a tiny synthetic .npz and exercises load/lookup — no raster, no S3, no network.
+"""
+import numpy as np
+import pytest
+
+import PyNightSkyPredictor.light_dome as ld
+
+h3 = pytest.importorskip("h3")
+RES = ld.LIGHTDOME_H3_RESOLUTION
+
+
+def _write_index(path, entries):
+    """entries: list of (lat, lon, scores8, heights8, dists8) — written sorted by cell."""
+    cells = np.array(
+        [h3.str_to_int(h3.latlng_to_cell(la, lo, RES)) for la, lo, *_ in entries],
+        dtype=np.uint64,
+    )
+    order = np.argsort(cells, kind="stable")
+    np.savez_compressed(
+        path,
+        cells=cells[order],
+        scores=np.array([e[2] for e in entries], dtype=np.float16)[order],
+        dome_heights=np.array([e[3] for e in entries], dtype=np.float16)[order],
+        mean_distances=np.array([e[4] for e in entries], dtype=np.float16)[order],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    ld._lightdome_index_cache = None
+    yield
+    ld._lightdome_index_cache = None
+
+
+def _domed_scores():
+    s = [0.05] * 8
+    s[ld.DIRS_8.index("SW")] = 5.0          # a clear major dome to the SW
+    s[ld.DIRS_8.index("NE")] = 0.01         # the darkest
+    return s
+
+
+def test_load_and_lookup_hit(tmp_path, monkeypatch):
+    lat, lon = 34.8697, -111.4106
+    heights = [1.0] * 8
+    dists = [50.0] * 8
+    _write_index(tmp_path / "ld.npz", [(lat, lon, _domed_scores(), heights, dists)])
+    monkeypatch.setenv("PYNIGHTSKY_LIGHTDOME_H3_PATH", str(tmp_path / "ld.npz"))
+
+    out = ld.lightdome_lookup(lat, lon)
+    assert out is not None
+    assert out["sky_state"] == "domed"
+    assert out["darkest_direction"] == "NE"
+    assert out["domes"][0]["direction"] == "SW"
+    assert out["domes"][0]["severity"] == "major"
+
+
+def test_lookup_miss_returns_none(tmp_path, monkeypatch):
+    _write_index(tmp_path / "ld.npz", [(34.8697, -111.4106, _domed_scores(), [1.0] * 8, [50.0] * 8)])
+    monkeypatch.setenv("PYNIGHTSKY_LIGHTDOME_H3_PATH", str(tmp_path / "ld.npz"))
+    # a far-away coordinate is a different H3 cell → not in the index
+    assert ld.lightdome_lookup(0.0, 0.0) is None
+
+
+def test_sentinel_distance_maps_to_none(tmp_path, monkeypatch):
+    lat, lon = 40.77, -113.89
+    dists = [50.0] * 8
+    dists[ld.DIRS_8.index("SW")] = -1.0      # no-glow sentinel on the flagged direction
+    _write_index(tmp_path / "ld.npz", [(lat, lon, _domed_scores(), [1.0] * 8, dists)])
+    monkeypatch.setenv("PYNIGHTSKY_LIGHTDOME_H3_PATH", str(tmp_path / "ld.npz"))
+
+    out = ld.lightdome_lookup(lat, lon)
+    sw = next(d for d in out["domes"] if d["direction"] == "SW")
+    assert sw["mean_distance_mi"] is None
+
+
+def test_missing_file_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYNIGHTSKY_LIGHTDOME_H3_PATH", str(tmp_path / "does_not_exist.npz"))
+    assert ld.load_lightdome_index() is None
+    assert ld.lightdome_lookup(34.8697, -111.4106) is None
+
+
+def test_cell_round_trip():
+    lat, lon = 34.8697, -111.4106
+    cell = h3.latlng_to_cell(lat, lon, RES)
+    rlat, rlon = h3.cell_to_latlng(cell)
+    assert abs(rlat - lat) < 0.2 and abs(rlon - lon) < 0.2   # within a res-6 cell radius


### PR DESCRIPTION
## What

Adds **DarkHours light-dome analysis**: which compass directions from a site are spoiled by city light domes, and how high they sit on the horizon — delivered on the **initial page load** via a precomputed index (no raster read on the hot path).

### 1. `LightDomeAnalyzer` (engine) — `PyNightSkyPredictor/light_dome.py`
- Distance-weighted Walker kernel (`d^-2.5` sky-glow decay) over VIIRS radiance, 150-mile radius (matches `find_nearby`'s `dome_search_radius`).
- Per-latitude `cos(lat)`-corrected kernel over the EPSG:4326 rasters via the ports seam — no GDAL.
- **Soft (tent) binning** so a source straddling two compass points (e.g. Phoenix at SSW) is shared, not snapped to a hard edge.
- `analyze_horizons_detailed` returns glow-weighted **mean distance** and **dome apparent height** (`arctan(h/d)`) per direction; distant domes correctly sit low (~1°).
- `glow_toward(az, alt)` samples glow at any sky position — the hook for per-target light-dome penalties.
- `summarize_horizons` emits a site-level `sky_state` (`dark`/`bright`/`domed`/`urban`) keyed on the darkest direction.
- Thresholds calibrated at 150 mi + soft binning against a reference basket (`scripts/calibrate_light_dome.py`); sites separate by **directionality** (prominence), not magnitude.

### 2. Precomputed H3 index — instant page-load lookup
- Light dome is a pure function of static VIIRS data + location, so it's precomputed once into an **H3 res-6 CONUS index** (~36 km²/cell, 338,325 land cells, `cache/lightdome_h3.npz`) and served as an `O(log n)` `np.searchsorted` lookup. Mirrors the PAD-US / OSM POI index pattern.
- `NightReport.light_dome` populated inline in `assemble_night`; auto-serialized to `/night` via `dataclasses.asdict`. Bundled into the API image + worker zip + CDK staging. API cold-start prewarm.
- Stores raw per-direction values; `summarize_horizons` runs at lookup time, so a threshold recalibration needs **no rebuild**.

## Performance (in-region, throwaway Lambda, torn down)
| | live raster compute | precomputed index |
|---|---|---|
| warm per-query | ~457 ms (328 ms S3 read + ~130 ms compute) | **0.133 ms** lookup |
| cold (first hit) | ~8.5 s | one-time 2.8 s index parse (prewarmed off-path) + 0.13 ms |

~3,400× faster warm; the page-load path reads nothing.

## Verification
- 38 hermetic light-dome tests; full suite **461 passed, 7 skipped**.
- Precomputed lookup matches the live engine (Δscore < 0.007); CONUS city spot-checks match known results (Roswell `urban`, Cherry Springs/Big Bend `dark`, Sedona minor-S, Bonneville Wendover SW/W).
- End-to-end: `/night` JSON carries `light_dome`, no internal-nomenclature leaks.

## Notes / follow-ups
- **Frontend not yet wired**: the `light_dome` field ships in the payload but no component renders it (the all-sky/compass visual is mocked, not built).
- Out-of-CONUS pins return `null` (frontend hides the panel); a lazy compute-and-cache fallback is future work.
- This branch also carries a pre-existing `a4dc284` (NightVision) ahead of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)