### PR TITLE
Prime Targets: condition viability engine + landscape curation (Phases 1–3)

### DIFF
--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -121,6 +121,193 @@ class NightReport:
     sat_starlink_unavailable: bool = False  # True → Starlink group TLE fetch failed
 
 
+# ---------------------------------------------------------------------------
+# Phase 1: Condition-Driven Viability Engine
+# ---------------------------------------------------------------------------
+
+_CLOUD_BLOCK_PCT          = 70    # cloud_cover_pct > this → blocked
+_DOME_BLOCK_SCORE         = 0.25  # glow_toward() >= this → light_dome blocker (= MINOR_DOME_THRESHOLD)
+_WEATHER_GAP_SECS         = 5400  # 90 min nearest-neighbour tolerance (matches _merge_7timer)
+_MIN_VIABLE_MIN           = 30    # effective window must be at least this long to be viable
+_MOON_WASHOUT_RADIUS_DEG  = 45.0  # washout zone radius at 100% illumination;
+                                   # scales linearly → effective = 45° × (illum/100)
+
+
+def _apply_condition_vectors(
+    targets: list,
+    weather_points: list,
+    light_dome_info: "dict | None",
+    illumination_pct: float,
+) -> None:
+    """Post-process VisibleTarget list with atmospheric, dome, and lunar viability vectors.
+
+    Mutates TargetWindow and VisibleTarget fields in-place. Called after both the
+    target future and the weather future have resolved in assemble_night().
+    """
+    # Pre-build the detailed-format dict glow_toward() needs, reconstructed from
+    # the summarize_horizons() output (scores + dome_heights are already present).
+    detailed_for_glow = None
+    if light_dome_info is not None:
+        detailed_for_glow = {
+            d: {
+                "score": light_dome_info["scores"][d],
+                "dome_height_deg": light_dome_info["dome_heights"][d],
+            }
+            for d in _ld.DIRS_8
+        }
+
+    for target in targets:
+        for window in target.windows:
+            blockers: list[str] = []
+
+            # --- Atmospheric Vector (MCVI) -----------------------------------
+            # Collect candidate weather points bracketing this window.
+            gap = timedelta(seconds=_WEATHER_GAP_SECS)
+            candidates = [
+                p for p in weather_points
+                if window.start - gap <= p.time <= window.end + gap
+            ]
+
+            if not candidates:
+                # No weather data → fail-open: use geometric limits.
+                eff_start = window.start
+                eff_end   = window.end
+            else:
+                # Tag each candidate as viable (cloud + transparency only; no humidity).
+                def _wx_viable(p) -> bool:
+                    cloud_ok = (p.cloud_cover_pct is None or
+                                p.cloud_cover_pct <= _CLOUD_BLOCK_PCT)
+                    transp_ok = (p.transparency is None or
+                                 p.transparency != "Poor")
+                    return cloud_ok and transp_ok
+
+                tagged = [(p, _wx_viable(p)) for p in sorted(candidates, key=lambda p: p.time)]
+
+                # Build contiguous viable blocks from the tagged points.
+                viable_blocks: list[tuple] = []  # (block_start_time, block_end_time)
+                block_start = None
+                block_end   = None
+                for p, ok in tagged:
+                    if ok:
+                        if block_start is None:
+                            block_start = p.time
+                        block_end = p.time
+                    else:
+                        if block_start is not None:
+                            viable_blocks.append((block_start, block_end))
+                        block_start = block_end = None
+                if block_start is not None:
+                    viable_blocks.append((block_start, block_end))
+
+                if not viable_blocks:
+                    # Entire window is blocked.
+                    eff_start = eff_end = None
+                    # Determine which blocker types fired.
+                    cloud_fired = any(
+                        p.cloud_cover_pct is not None and p.cloud_cover_pct > _CLOUD_BLOCK_PCT
+                        for p, _ in tagged
+                    )
+                    transp_fired = any(
+                        p.transparency == "Poor"
+                        for p, _ in tagged
+                    )
+                    if cloud_fired:
+                        blockers.append("cloud")
+                    if transp_fired:
+                        blockers.append("transparency")
+                else:
+                    # Priority A: block containing peak_time.
+                    peak = window.peak_time or window.start
+                    optimal = next(
+                        (b for b in viable_blocks if b[0] <= peak <= b[1]),
+                        None,
+                    )
+                    if optimal is None:
+                        # Priority B: longest block.
+                        optimal = max(
+                            viable_blocks,
+                            key=lambda b: (b[1] - b[0]).total_seconds(),
+                        )
+
+                    # Truncate against physical and K&S photographic limits.
+                    start_candidates = [
+                        t for t in [window.start, window.photo_start, optimal[0]]
+                        if t is not None
+                    ]
+                    end_candidates = [
+                        t for t in [window.photo_cutoff, window.end, optimal[1]]
+                        if t is not None
+                    ]
+                    eff_start = max(start_candidates)
+                    eff_end   = min(end_candidates)
+
+            window.effective_start = eff_start
+            window.effective_end   = eff_end
+
+            # --- Light Dome Vector -------------------------------------------
+            if detailed_for_glow is not None:
+                glow = _ld.glow_toward(
+                    detailed_for_glow,
+                    window.peak_az_deg,
+                    window.peak_alt_deg,
+                )
+                window.dome_glow_at_peak = round(glow, 4)
+                if glow >= _DOME_BLOCK_SCORE:
+                    blockers.append("light_dome")
+            else:
+                window.dome_glow_at_peak = None
+
+            # --- Lunar Proximity Vector --------------------------------------
+            # Geometric proximity check: target within (radius × illum/100)°
+            # of the moon triggers "moon_washout". Distinct from the K&S
+            # photometric model used for photo_cutoff — this labels the
+            # "pointing directly at the moon" case for the Phase 2 UI badge.
+            if (illumination_pct > KS_CRESCENT_EXEMPTION_PCT
+                    and window.moon_sep_at_peak_deg is not None):
+                effective_radius = _MOON_WASHOUT_RADIUS_DEG * (illumination_pct / 100.0)
+                if window.moon_sep_at_peak_deg < effective_radius:
+                    blockers.append("moon_washout")
+
+            window.blockers = blockers
+
+            # --- Best Time ---------------------------------------------------
+            if eff_start is None or eff_end is None:
+                window.best_time = None
+            else:
+                peak = window.peak_time or window.start
+                if eff_start <= peak <= eff_end:
+                    window.best_time = peak
+                else:
+                    # Snap to the effective boundary nearest the celestial peak.
+                    dist_start = abs((peak - eff_start).total_seconds())
+                    dist_end   = abs((peak - eff_end).total_seconds())
+                    window.best_time = eff_start if dist_start <= dist_end else eff_end
+
+            # --- Weather score at best time ----------------------------------
+            if window.best_time is not None and weather_points:
+                nearest = min(
+                    weather_points,
+                    key=lambda p: abs((p.time - window.best_time).total_seconds()),
+                )
+                if abs((nearest.time - window.best_time).total_seconds()) <= _WEATHER_GAP_SECS:
+                    window.weather_score_at_best = wx.rate_conditions(nearest)
+
+        # --- VisibleTarget viability rollup ----------------------------------
+        best_w = max(target.windows, key=lambda w: w.peak_alt_deg)
+        if best_w.effective_start is None or best_w.effective_end is None:
+            target.viability = "blocked"
+        else:
+            eff_duration_min = (
+                (best_w.effective_end - best_w.effective_start).total_seconds() / 60
+            )
+            if eff_duration_min < _MIN_VIABLE_MIN:
+                target.viability = "blocked"
+            elif best_w.blockers:
+                target.viability = "degraded"
+            else:
+                target.viability = "ok"
+
+
 def assemble_night(
     lat: float,
     lon: float,
@@ -476,6 +663,10 @@ def assemble_night(
 
     # --- Active meteor showers (always computed — fast date check only) ---
     active_showers = _tgt.active_meteor_showers(target)
+
+    # --- Phase 1: Condition Vectors — apply after weather + targets resolved ---
+    if fetch_targets and target_list:
+        _apply_condition_vectors(target_list, night_points, light_dome_info, illumination)
 
     # --- Overall rating ---
     _tc = time.monotonic()

--- a/PyNightSkyPredictor/targets.json
+++ b/PyNightSkyPredictor/targets.json
@@ -5,7 +5,8 @@
     "ra": "05h 35m 17s",
     "dec": "-05° 23' 28\"",
     "magnitude": 4.0,
-    "surface_brightness": 13.0
+    "surface_brightness": 13.0,
+    "angular_size_arcmin": 65
   },
   {
     "name": "Lagoon Nebula",
@@ -13,7 +14,8 @@
     "ra": "18h 03m 37s",
     "dec": "-24° 23' 12\"",
     "magnitude": 5.8,
-    "surface_brightness": 14.0
+    "surface_brightness": 14.0,
+    "angular_size_arcmin": 90
   },
   {
     "name": "Eagle Nebula",
@@ -21,7 +23,8 @@
     "ra": "18h 18m 48s",
     "dec": "-13° 49' 00\"",
     "magnitude": 6.4,
-    "surface_brightness": 14.5
+    "surface_brightness": 14.5,
+    "angular_size_arcmin": 7
   },
   {
     "name": "Swan Nebula",
@@ -29,7 +32,8 @@
     "ra": "18h 20m 26s",
     "dec": "-16° 10' 36\"",
     "magnitude": 6.0,
-    "surface_brightness": 14.0
+    "surface_brightness": 14.0,
+    "angular_size_arcmin": 11
   },
   {
     "name": "Trifid Nebula",
@@ -37,7 +41,8 @@
     "ra": "18h 02m 23s",
     "dec": "-23° 01' 48\"",
     "magnitude": 6.3,
-    "surface_brightness": 14.5
+    "surface_brightness": 14.5,
+    "angular_size_arcmin": 28
   },
   {
     "name": "Ring Nebula",
@@ -45,7 +50,8 @@
     "ra": "18h 53m 35s",
     "dec": "+33° 01' 45\"",
     "magnitude": 8.8,
-    "surface_brightness": 13.0
+    "surface_brightness": 13.0,
+    "angular_size_arcmin": 1.4
   },
   {
     "name": "Dumbbell Nebula",
@@ -53,7 +59,8 @@
     "ra": "19h 59m 36s",
     "dec": "+22° 43' 16\"",
     "magnitude": 7.4,
-    "surface_brightness": 13.5
+    "surface_brightness": 13.5,
+    "angular_size_arcmin": 8
   },
   {
     "name": "Veil Nebula",
@@ -61,7 +68,8 @@
     "ra": "20h 45m 38s",
     "dec": "+30° 42' 30\"",
     "magnitude": 7.0,
-    "surface_brightness": 17.0
+    "surface_brightness": 17.0,
+    "angular_size_arcmin": 180
   },
   {
     "name": "North America Nebula",
@@ -69,7 +77,8 @@
     "ra": "20h 58m 47s",
     "dec": "+44° 20' 00\"",
     "magnitude": 4.0,
-    "surface_brightness": 17.5
+    "surface_brightness": 17.5,
+    "angular_size_arcmin": 120
   },
   {
     "name": "Crab Nebula",
@@ -77,7 +86,8 @@
     "ra": "05h 34m 32s",
     "dec": "+22° 00' 52\"",
     "magnitude": 8.4,
-    "surface_brightness": 12.5
+    "surface_brightness": 12.5,
+    "angular_size_arcmin": 7
   },
   {
     "name": "Helix Nebula",
@@ -85,7 +95,8 @@
     "ra": "22h 29m 38s",
     "dec": "-20° 50' 13\"",
     "magnitude": 7.3,
-    "surface_brightness": 13.5
+    "surface_brightness": 13.5,
+    "angular_size_arcmin": 25
   },
   {
     "name": "Carina Nebula",
@@ -93,7 +104,8 @@
     "ra": "10h 43m 48s",
     "dec": "-59° 52' 04\"",
     "magnitude": 1.0,
-    "surface_brightness": 14.0
+    "surface_brightness": 14.0,
+    "angular_size_arcmin": 120
   },
   {
     "name": "Rosette Nebula",
@@ -101,7 +113,8 @@
     "ra": "06h 31m 55s",
     "dec": "+04° 56' 00\"",
     "magnitude": 5.5,
-    "surface_brightness": 17.0
+    "surface_brightness": 17.0,
+    "angular_size_arcmin": 80
   },
   {
     "name": "Andromeda Galaxy",
@@ -109,7 +122,8 @@
     "ra": "00h 42m 44s",
     "dec": "+41° 16' 09\"",
     "magnitude": 3.4,
-    "surface_brightness": 13.5
+    "surface_brightness": 13.5,
+    "angular_size_arcmin": 190
   },
   {
     "name": "Triangulum Galaxy",
@@ -117,7 +131,8 @@
     "ra": "01h 33m 51s",
     "dec": "+30° 39' 37\"",
     "magnitude": 5.7,
-    "surface_brightness": 14.2
+    "surface_brightness": 14.2,
+    "angular_size_arcmin": 70
   },
   {
     "name": "Whirlpool Galaxy",
@@ -125,7 +140,8 @@
     "ra": "13h 29m 53s",
     "dec": "+47° 11' 43\"",
     "magnitude": 8.4,
-    "surface_brightness": 13.0
+    "surface_brightness": 13.0,
+    "angular_size_arcmin": 11
   },
   {
     "name": "Sombrero Galaxy",
@@ -133,7 +149,8 @@
     "ra": "12h 39m 59s",
     "dec": "-11° 37' 23\"",
     "magnitude": 8.0,
-    "surface_brightness": 12.0
+    "surface_brightness": 12.0,
+    "angular_size_arcmin": 8.7
   },
   {
     "name": "Pinwheel Galaxy",
@@ -141,7 +158,8 @@
     "ra": "14h 03m 13s",
     "dec": "+54° 20' 57\"",
     "magnitude": 7.9,
-    "surface_brightness": 14.8
+    "surface_brightness": 14.8,
+    "angular_size_arcmin": 28
   },
   {
     "name": "Bode's Galaxy",
@@ -149,7 +167,8 @@
     "ra": "09h 55m 33s",
     "dec": "+69° 03' 55\"",
     "magnitude": 6.9,
-    "surface_brightness": 12.5
+    "surface_brightness": 12.5,
+    "angular_size_arcmin": 26
   },
   {
     "name": "Sculptor Galaxy",
@@ -157,7 +176,8 @@
     "ra": "00h 47m 33s",
     "dec": "-25° 17' 18\"",
     "magnitude": 7.1,
-    "surface_brightness": 13.0
+    "surface_brightness": 13.0,
+    "angular_size_arcmin": 40
   },
   {
     "name": "Centaurus A",
@@ -165,7 +185,8 @@
     "ra": "13h 25m 28s",
     "dec": "-43° 01' 09\"",
     "magnitude": 6.8,
-    "surface_brightness": 12.5
+    "surface_brightness": 12.5,
+    "angular_size_arcmin": 25
   },
   {
     "name": "Large Magellanic Cloud",
@@ -173,7 +194,8 @@
     "ra": "05h 23m 34s",
     "dec": "-69° 45' 22\"",
     "magnitude": 0.9,
-    "surface_brightness": 13.5
+    "surface_brightness": 13.5,
+    "angular_size_arcmin": 645
   },
   {
     "name": "Small Magellanic Cloud",
@@ -181,7 +203,8 @@
     "ra": "00h 52m 38s",
     "dec": "-72° 48' 01\"",
     "magnitude": 2.7,
-    "surface_brightness": 14.5
+    "surface_brightness": 14.5,
+    "angular_size_arcmin": 318
   },
   {
     "name": "Leo Triplet",
@@ -189,63 +212,72 @@
     "ra": "11h 20m 15s",
     "dec": "+12° 59' 29\"",
     "magnitude": 9.0,
-    "surface_brightness": 13.5
+    "surface_brightness": 13.5,
+    "angular_size_arcmin": 40
   },
   {
     "name": "Pleiades",
     "type": "cluster",
     "ra": "03h 47m 24s",
     "dec": "+24° 07' 00\"",
-    "magnitude": 1.6
+    "magnitude": 1.6,
+    "angular_size_arcmin": 110
   },
   {
     "name": "Hercules Cluster",
     "type": "cluster",
     "ra": "16h 41m 42s",
     "dec": "+36° 27' 36\"",
-    "magnitude": 5.8
+    "magnitude": 5.8,
+    "angular_size_arcmin": 20
   },
   {
     "name": "Omega Centauri",
     "type": "cluster",
     "ra": "13h 26m 47s",
     "dec": "-47° 28' 47\"",
-    "magnitude": 3.9
+    "magnitude": 3.9,
+    "angular_size_arcmin": 36
   },
   {
     "name": "Double Cluster",
     "type": "cluster",
     "ra": "02h 19m 00s",
     "dec": "+57° 07' 42\"",
-    "magnitude": 4.3
+    "magnitude": 4.3,
+    "angular_size_arcmin": 60
   },
   {
     "name": "Beehive Cluster",
     "type": "cluster",
     "ra": "08h 40m 22s",
     "dec": "+19° 41' 17\"",
-    "magnitude": 3.7
+    "magnitude": 3.7,
+    "angular_size_arcmin": 95
   },
   {
     "name": "47 Tucanae",
     "type": "cluster",
     "ra": "00h 24m 06s",
     "dec": "-72° 04' 52\"",
-    "magnitude": 4.0
+    "magnitude": 4.0,
+    "angular_size_arcmin": 30
   },
   {
     "name": "Wild Duck Cluster",
     "type": "cluster",
     "ra": "18h 51m 05s",
     "dec": "-06° 16' 00\"",
-    "magnitude": 6.3
+    "magnitude": 6.3,
+    "angular_size_arcmin": 14
   },
   {
     "name": "Jewel Box",
     "type": "cluster",
     "ra": "12h 53m 42s",
     "dec": "-60° 21' 24\"",
-    "magnitude": 4.2
+    "magnitude": 4.2,
+    "angular_size_arcmin": 10
   },
   {
     "name": "Galactic Core",

--- a/PyNightSkyPredictor/targets.py
+++ b/PyNightSkyPredictor/targets.py
@@ -4,7 +4,7 @@
 import json
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -33,6 +33,10 @@ DEFAULT_MOON_MIN_SEP   = float(_c["moon_min_separation_deg"])
 DEFAULT_MOON_MAX_ILLUM = float(_c["moon_max_illumination_pct"])
 SAMPLE_INTERVAL_MIN    = 10
 PLANET_PRIME_MIN_ALT   = 20  # planets are bright enough to be prime at lower altitudes
+
+# Landscape prominence thresholds
+_SB_DIFFUSE_THRESHOLD    = 16.0   # mag/arcsec² — above this, requires narrowband filter
+_ANGULAR_SIZE_MIN_ARCMIN = 9.0    # below this, too compact for wide-field landscape
 
 _CATALOG_PATH = Path(__file__).parent / "targets.json"
 
@@ -64,6 +68,13 @@ class TargetWindow:
     visual_cutoff: "datetime | None" = None    # last sample where visual observation is viable
     photo_start: "datetime | None" = None      # first viable sample (set when moon delays window start)
     ks_computed: bool = False                  # True when K&S was run and the full window is viable
+    # Phase 1: Condition Vectors (set by predictor._apply_condition_vectors)
+    effective_start: "datetime | None" = None  # MCVI lower bound; UI binds displayed window here
+    effective_end: "datetime | None" = None    # MCVI upper bound; condition-gated window end
+    best_time: "datetime | None" = None        # recommended observation moment within effective window
+    blockers: list = field(default_factory=list)  # ["cloud","transparency","light_dome","moon_washout"]
+    weather_score_at_best: "int | None" = None    # rate_conditions() score at best_time
+    dome_glow_at_peak: "float | None" = None      # glow_toward() at (peak_az_deg, peak_alt_deg)
 
 
 @dataclass
@@ -72,6 +83,28 @@ class VisibleTarget:
     type: str
     windows: list      # list[TargetWindow]
     note: str | None   # e.g. "3 days before peak" for meteor showers
+    viability: str = "ok"  # "ok" | "degraded" | "blocked" — set by _apply_condition_vectors
+    angular_size_arcmin: "float | None" = None   # from catalog; None for planets/meteors/MW
+    landscape_suitability: str = "prominent"     # "prominent" | "diffuse" | "too_small"
+
+
+def _landscape_suitability(sb: "float | None", angular_size: "float | None") -> str:
+    """
+    Classify a target's suitability for wide-angle landscape astrophotography.
+
+    Returns 'prominent' | 'diffuse' | 'too_small'.
+    - 'diffuse': surface brightness ≥ 16.0 mag/arcsec² — requires narrowband filter for DSLR
+    - 'too_small': angular_size < 9 arcmin — sub-pixel at 14–35mm focal lengths
+    - 'prominent': passes both thresholds; visible in standard wide-field shots
+    Objects with no angular_size (planets, meteor showers, milky_way) default to 'prominent'.
+    """
+    if angular_size is None:
+        return "prominent"
+    if sb is not None and sb >= _SB_DIFFUSE_THRESHOLD:
+        return "diffuse"
+    if angular_size < _ANGULAR_SIZE_MIN_ARCMIN:
+        return "too_small"
+    return "prominent"
 
 
 # ---------------------------------------------------------------------------
@@ -413,7 +446,13 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
         )
         return None
 
-    return VisibleTarget(name=name, type=ttype, windows=windows, note=note)
+    angular_size = entry.get("angular_size_arcmin")
+    land_suit    = _landscape_suitability(entry.get("surface_brightness"), angular_size)
+    return VisibleTarget(
+        name=name, type=ttype, windows=windows, note=note,
+        angular_size_arcmin=angular_size,
+        landscape_suitability=land_suit,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1204,6 +1204,56 @@ details summary {
   font-size: 12px;
 }
 
+/* ── Blocked/unviable target rows ─────────────────────────────── */
+/* Use color demotion instead of opacity — opacity breaks contrast on dark field */
+.tg-row-blocked td {
+  color: var(--text-dim);  /* 5:1 guaranteed contrast on --card */
+}
+.tg-row-blocked {
+  filter: saturate(0.35);  /* desaturate hue; does not affect luminance/contrast */
+}
+
+/* Section divider before the unviable group */
+.tg-unviable-hdr td {
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 12px 10px 4px;
+  border-top: 1px dashed rgba(var(--hairline-rgb), 0.5);
+  border-bottom: none;
+}
+
+/* Blocker reason chip */
+.tg-blocker-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+/* Clipped-window asterisk — hover tooltip on desktop, inline on touch */
+.tg-clip-indicator {
+  color: var(--text-dim);
+  cursor: help;
+  margin-left: 2px;
+  font-size: 10px;
+  vertical-align: super;
+}
+@media (hover: none) {
+  .tg-clip-indicator[data-tip]::after {
+    content: ' (' attr(data-tip) ')';
+    font-size: 10px;
+    color: var(--text-dim);
+    font-style: italic;
+    vertical-align: baseline;
+  }
+}
+
 /* ── Targets table: Conditions column ────────────────────────── */
 .tg-table th.tg-cond-col,
 .tg-table td.tg-cond-col {

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -346,12 +346,31 @@ function SatellitePasses({ report }: { report: NightReport; }) {
 
 // ── Targets helpers ──────────────────────────────────────────────────────────
 
+// nebula / galaxy / cluster are collapsed into a single display group ("dso")
+// so the targets table shows a clean unlabeled DSO block followed by Planets.
+const DSO_TYPES = new Set(['nebula', 'galaxy', 'cluster'])
+
 const TYPE_ORDER: Record<string, number> = {
-  meteor_shower: 0, cluster: 1, planet: 2, nebula: 3, galaxy: 4,
+  meteor_shower: 0,
+  dso:           1,  // nebula + galaxy + cluster
+  planet:        2,
 }
 const TYPE_LABELS: Record<string, string> = {
-  meteor_shower: 'Meteor Showers', cluster: 'Clusters',
-  planet: 'Planets', nebula: 'Nebulae', galaxy: 'Galaxies',
+  meteor_shower: 'Meteor Showers',
+  // 'dso' has no label — after prominence filtering the list is short enough
+  planet: 'Planets',
+}
+
+const MOON_ARCMIN = 30
+
+function moonScaleLabel(arcmin: number | null | undefined): string | null {
+  if (arcmin == null) return null
+  const ratio = arcmin / MOON_ARCMIN
+  if (ratio >= 1.5) return `${Math.round(ratio)}x Moon`
+  if (ratio >= 1.0) return '1x Moon'
+  if (ratio >= 0.5) return '½ Moon'
+  if (ratio >= 0.3) return '⅓ Moon'
+  return null
 }
 
 // ── Milky Way card ───────────────────────────────────────────────────────────
@@ -608,44 +627,223 @@ function MeteorShowerCard({ target, zhr, report }: {
   )
 }
 
+// ── Blocker badge (Phase 2) ───────────────────────────────────────────────────
+
+function BlockerBadge({ blockers }: { blockers: string[] }) {
+  let label = 'Unavailable Tonight'
+  if (blockers.includes('cloud') || blockers.includes('transparency'))
+    label = 'Obscured by Clouds'
+  else if (blockers.includes('moon_washout'))
+    label = 'Washed Out by Moon'
+  else if (blockers.includes('light_dome'))
+    label = 'Lost in Light Dome'
+  return <span className="tg-blocker-badge">[ {label} ]</span>
+}
+
+function clipTooltip(w: TargetWindow, tz: string): string {
+  const b = w.blockers ?? []
+  const end = w.effective_end
+  if (b.includes('cloud') || b.includes('transparency'))
+    return `Window clipped by cloud cover${end ? ` at ${formatTime(end, tz)}` : ''}`
+  if (b.includes('moon_washout')) return 'Window limited by moonlight'
+  if (b.includes('light_dome'))   return 'Viewing constrained by horizon glow'
+  return 'Window clipped by conditions'
+}
+
+function clipReasonShort(w: TargetWindow): string {
+  const b = w.blockers ?? []
+  if (b.includes('cloud') || b.includes('transparency')) return 'cloud'
+  if (b.includes('moon_washout')) return 'moon'
+  if (b.includes('light_dome'))   return 'dome'
+  return 'conditions'
+}
+
+// ── TargetsTable ──────────────────────────────────────────────────────────────
+
 function TargetsTable({ targets, report }: { targets: VisibleTarget[]; report: NightReport }) {
   const tz = report.tz_name
 
-  // Milky Way + meteor showers rendered separately as cards; rest filtered to prime
-  const nonMW = targets
+  // Milky Way + meteor showers rendered separately as cards; rest filtered to prime prominent
+  const allPrime = targets
     .filter(t => t.type !== 'milky_way' && t.type !== 'meteor_shower')
     .filter(t => isPrime(t, report.dark_intervals))
+    .filter(t => (t.landscape_suitability ?? 'prominent') === 'prominent')
 
-  const sorted = [...nonMW].sort((a, b) => {
-    const ao = TYPE_ORDER[a.type] ?? 99
-    const bo = TYPE_ORDER[b.type] ?? 99
-    if (ao !== bo) return ao - bo
-    const at = bestWindow(a).peak_time ?? ''
-    const bt = bestWindow(b).peak_time ?? ''
-    return at.localeCompare(bt)
-  })
+  const viable   = allPrime.filter(t => t.viability !== 'blocked')
+  const unviable = allPrime.filter(t => t.viability === 'blocked')
 
-  // Group by type
-  const groups: { type: string; targets: VisibleTarget[] }[] = []
-  for (const t of sorted) {
-    const last = groups[groups.length - 1]
-    if (last && last.type === t.type) last.targets.push(t)
-    else groups.push({ type: t.type, targets: [t] })
-  }
+  if (allPrime.length === 0) return null
 
-  // Flatten groups into a single list of row descriptors for the table
+  // Shared sort + group logic.
+  // nebula / galaxy / cluster are normalized to 'dso' so they render as one unlabeled block.
   type RowItem =
     | { kind: 'header'; type: string; key: string }
-    | { kind: 'target'; target: VisibleTarget; key: string }
+    | { kind: 'target'; target: VisibleTarget; key: string; blocked?: boolean }
 
-  if (sorted.length === 0) return null
+  const displayType = (t: VisibleTarget) => DSO_TYPES.has(t.type) ? 'dso' : t.type
 
-  const rows: RowItem[] = []
-  for (const g of groups) {
-    rows.push({ kind: 'header', type: g.type, key: `hdr-${g.type}` })
-    for (const t of g.targets) {
-      rows.push({ kind: 'target', target: t, key: `${g.type}-${t.name}` })
+  function sortAndGroup(list: VisibleTarget[], blocked = false): RowItem[] {
+    const sorted = [...list].sort((a, b) => {
+      const ao = TYPE_ORDER[displayType(a)] ?? 99
+      const bo = TYPE_ORDER[displayType(b)] ?? 99
+      if (ao !== bo) return ao - bo
+      const at = bestWindow(a).peak_time ?? ''
+      const bt = bestWindow(b).peak_time ?? ''
+      return at.localeCompare(bt)
+    })
+    const groups: { type: string; targets: VisibleTarget[] }[] = []
+    for (const t of sorted) {
+      const dt   = displayType(t)
+      const last = groups[groups.length - 1]
+      if (last && last.type === dt) last.targets.push(t)
+      else groups.push({ type: dt, targets: [t] })
     }
+    const rows: RowItem[] = []
+    for (const g of groups) {
+      if (TYPE_LABELS[g.type]) {
+        rows.push({ kind: 'header', type: g.type, key: `hdr-${blocked ? 'blocked-' : ''}${g.type}` })
+      }
+      for (const t of g.targets) {
+        rows.push({ kind: 'target', target: t, key: `${g.type}-${t.name}`, blocked })
+      }
+    }
+    return rows
+  }
+
+  const viableRows   = sortAndGroup(viable, false)
+  const unviableRows = sortAndGroup(unviable, true)
+
+  function renderTargetRow(t: VisibleTarget, key: string, blocked: boolean) {
+    const w         = bestWindow(t)
+    const name      = t.type === 'meteor_shower' ? `${t.name} Meteor Shower` : t.name
+    const sizeLabel = moonScaleLabel(t.angular_size_arcmin)
+
+    // photo_cutoff clips both Best Viewing and Astro Window (mirrors CLI)
+    const hasClip = !!(w.photo_cutoff
+      && new Date(w.photo_cutoff) > new Date(w.start)
+      && new Date(w.photo_cutoff) < new Date(w.end))
+
+    // Fixed-width helpers — each piece gets a min-width span so columns
+    // stay consistent across rows regardless of digit count or direction length.
+    const Tt  = ({ t }: { t: string })    => <span className="tg-t">{formatTime(t, tz)}</span>
+    const Alt = ({ deg }: { deg: number }) => <span className="tg-alt">{Math.round(deg)}°</span>
+    const Az  = ({ az }: { az: number })   => <span className="tg-az">{Math.round(az)}°</span>
+    const Dir = ({ az }: { az: number })   => <span className="tg-dir">{cardinal(az)}</span>
+    const Sep = () => <span className="tg-p"> – </span>
+
+    if (blocked) {
+      // Blocked rows: show blocker badge instead of timing data
+      const wxPt = w.peak_time && !report.wx_no_data && !report.wx_pending
+        ? wxAtTime(report.weather_points, w.peak_time)
+        : null
+      const glow = report.light_dome && w.peak_alt_deg != null
+        ? glowToward(report.light_dome, w.peak_az_deg, w.peak_alt_deg)
+        : null
+      return (
+        <tr key={key} className="tg-row-blocked">
+          <td>
+            {name}
+            {t.note    && <span className="tg-note"> · {t.note}</span>}
+            {sizeLabel && <span className="tg-note"> · Size: {sizeLabel}</span>}
+          </td>
+          <td className="wx-num"><BlockerBadge blockers={t.windows[0]?.blockers ?? []} /></td>
+          <td className="tg-sky">—</td>
+          <td className="tg-cond-col"><CondBadges wxPt={wxPt} glow={glow} /></td>
+          <td className="wx-num">—</td>
+        </tr>
+      )
+    }
+
+    // Best Viewing: prefer backend best_time, fall back to photo_cutoff/peak
+    let bestViewJsx: React.ReactNode = '—'
+    if (w.peak_time && w.peak_alt_deg != null) {
+      const effectiveBestTime = w.best_time ?? (hasClip ? w.photo_cutoff! : w.peak_time)
+      const effectiveBestAlt  = altAt(effectiveBestTime, w)
+      bestViewJsx = (
+        <>
+          <Tt t={effectiveBestTime} />
+          <span className="tg-p"> @ Az </span><Az az={w.peak_az_deg} /><span className="tg-p"> </span><Dir az={w.peak_az_deg} />
+          <span className="tg-p"> · Alt </span><Alt deg={effectiveBestAlt} />
+        </>
+      )
+    }
+
+    // Window: use effective_start/effective_end from condition vectors when available
+    let winJsx: React.ReactNode = '—'
+    if (w.peak_time) {
+      const rawEnd    = hasClip ? w.photo_cutoff! : w.end
+      const effStart  = w.effective_start ?? w.start
+      const effEnd    = w.effective_end   ?? rawEnd
+      const effStartAlt = altAt(effStart, w)
+      const effEndAlt   = altAt(effEnd, w)
+      const isClipped = effStart > w.start || effEnd < rawEnd
+
+      // Visual-observation extension beyond photo_cutoff (preserved from original logic)
+      const visualExtJsx = hasClip && w.visual_cutoff ? (() => {
+        const extraMin = Math.round(
+          (new Date(w.visual_cutoff).getTime() - new Date(w.photo_cutoff!).getTime()) / 60000
+        )
+        return extraMin >= 10 ? <span className="tg-p"> +{extraMin}m visual</span> : null
+      })() : null
+
+      winJsx = (
+        <>
+          <Tt t={effStart} /><span className="tg-p"> @ </span><Alt deg={effStartAlt} />
+          <Sep />
+          <Tt t={effEnd} /><span className="tg-p"> @ </span><Alt deg={effEndAlt} />
+          {isClipped && (
+            <span
+              className="tg-clip-indicator"
+              title={clipTooltip(w, tz)}
+              data-tip={clipReasonShort(w)}
+            >*</span>
+          )}
+          {visualExtJsx}
+        </>
+      )
+    }
+
+    const peakForSky = w.best_time ?? (hasClip ? w.photo_cutoff! : w.peak_time)
+    const sky = peakForSky
+      ? skyCondition(
+          peakForSky, report.dark_intervals, report.night_start, report.night_end,
+          report.illumination_pct, report.moonrise, report.moonset,
+          w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg,
+        )
+      : '—'
+
+    const skyCls = skyClass(sky)
+    const moonNote = w.moon_interference && !sky.startsWith('Moon')
+    const moonIsUpAtPeak = peakForSky
+      ? moonUpAt(peakForSky, report.moonrise, report.moonset)
+      : false
+    const moonNoteText = moonNote
+      ? (moonIsUpAtPeak ? ' · moon wash minimal' : ' · pre-moonrise')
+      : null
+
+    // Conditions: weather rating icon + glow at target's azimuth/altitude
+    const wxPt = peakForSky && !report.wx_no_data && !report.wx_pending
+      ? wxAtTime(report.weather_points, peakForSky)
+      : null
+    const glow = report.light_dome && w.peak_alt_deg != null
+      ? glowToward(report.light_dome, w.peak_az_deg, w.peak_alt_deg)
+      : null
+
+    return (
+      <tr key={key}>
+        <td>
+          {name}
+          {t.note    && <span className="tg-note"> · {t.note}</span>}
+          {sizeLabel && <span className="tg-note"> · Size: {sizeLabel}</span>}
+        </td>
+        <td className="wx-num">{bestViewJsx}</td>
+        <td className={`tg-sky ${skyCls}`}>
+          {sky}{moonNoteText ? <span className="tg-moon-note">{moonNoteText}</span> : null}
+        </td>
+        <td className="tg-cond-col"><CondBadges wxPt={wxPt} glow={glow} /></td>
+        <td className="wx-num">{winJsx}</td>
+      </tr>
+    )
   }
 
   return (
@@ -661,7 +859,7 @@ function TargetsTable({ targets, report }: { targets: VisibleTarget[]; report: N
           </tr>
         </thead>
         <tbody>
-          {rows.map(row => {
+          {viableRows.map(row => {
             if (row.kind === 'header') {
               return (
                 <tr key={row.key} className="tg-group-hdr">
@@ -669,101 +867,26 @@ function TargetsTable({ targets, report }: { targets: VisibleTarget[]; report: N
                 </tr>
               )
             }
-
-            const t    = row.target
-            const w    = bestWindow(t)
-            const name = t.type === 'meteor_shower' ? `${t.name} Meteor Shower` : t.name
-
-            // photo_cutoff clips both Best Viewing and Astro Window (mirrors CLI)
-            const hasClip = !!(w.photo_cutoff
-              && new Date(w.photo_cutoff) > new Date(w.start)
-              && new Date(w.photo_cutoff) < new Date(w.end))
-
-            // Fixed-width helpers — each piece gets a min-width span so columns
-            // stay consistent across rows regardless of digit count or direction length.
-            const Tt  = ({ t }: { t: string })    => <span className="tg-t">{formatTime(t, tz)}</span>
-            const Alt = ({ deg }: { deg: number }) => <span className="tg-alt">{Math.round(deg)}°</span>
-            const Az  = ({ az }: { az: number })   => <span className="tg-az">{Math.round(az)}°</span>
-            const Dir = ({ az }: { az: number })   => <span className="tg-dir">{cardinal(az)}</span>
-            const Sep = () => <span className="tg-p"> – </span>
-
-            let bestViewJsx: React.ReactNode = '—'
-            if (w.peak_time && w.peak_alt_deg != null) {
-              const bestTime = hasClip ? w.photo_cutoff! : w.peak_time
-              const bestAlt  = hasClip ? altAt(w.photo_cutoff!, w) : w.peak_alt_deg
-              bestViewJsx = (
-                <>
-                  <Tt t={bestTime} />
-                  <span className="tg-p"> @ Az </span><Az az={w.peak_az_deg} /><span className="tg-p"> </span><Dir az={w.peak_az_deg} />
-                  <span className="tg-p"> · Alt </span><Alt deg={bestAlt} />
-                </>
-              )
-            }
-
-            let winJsx: React.ReactNode = '—'
-            if (w.peak_time) {
-              if (hasClip) {
-                const clipAlt   = altAt(w.photo_cutoff!, w)
-                const visualEnd = w.visual_cutoff ?? w.end
-                const extraMs   = new Date(visualEnd).getTime() - new Date(w.photo_cutoff!).getTime()
-                const extraMin  = Math.round(extraMs / 60000)
-                winJsx = (
-                  <>
-                    <Tt t={w.start} /><span className="tg-p"> @ </span><Alt deg={w.start_alt_deg} />
-                    <Sep />
-                    <Tt t={w.photo_cutoff!} /><span className="tg-p"> @ </span><Alt deg={clipAlt} />
-                    {extraMin >= 10 && <span className="tg-p"> +{extraMin}m visual</span>}
-                  </>
-                )
-              } else {
-                winJsx = (
-                  <>
-                    <Tt t={w.start} /><span className="tg-p"> @ </span><Alt deg={w.start_alt_deg} />
-                    <Sep />
-                    <Tt t={w.end} /><span className="tg-p"> @ </span><Alt deg={w.end_alt_deg} />
-                  </>
-                )
-              }
-            }
-
-            const peakForSky = hasClip ? w.photo_cutoff! : w.peak_time
-            const sky = peakForSky
-              ? skyCondition(
-                  peakForSky, report.dark_intervals, report.night_start, report.night_end,
-                  report.illumination_pct, report.moonrise, report.moonset,
-                  w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg,
-                )
-              : '—'
-
-            const skyCls = skyClass(sky)
-            const moonNote = w.moon_interference && !sky.startsWith('Moon')
-            const moonIsUpAtPeak = peakForSky
-              ? moonUpAt(peakForSky, report.moonrise, report.moonset)
-              : false
-            const moonNoteText = moonNote
-              ? (moonIsUpAtPeak ? ' · moon wash minimal' : ' · pre-moonrise')
-              : null
-
-            // Conditions: weather rating icon + glow at target's azimuth/altitude
-            const wxPt = peakForSky && !report.wx_no_data && !report.wx_pending
-              ? wxAtTime(report.weather_points, peakForSky)
-              : null
-            const glow = report.light_dome && w.peak_alt_deg != null
-              ? glowToward(report.light_dome, w.peak_az_deg, w.peak_alt_deg)
-              : null
-
-            return (
-              <tr key={row.key}>
-                <td>{name}{t.note ? <span className="tg-note"> · {t.note}</span> : null}</td>
-                <td className="wx-num">{bestViewJsx}</td>
-                <td className={`tg-sky ${skyCls}`}>
-                  {sky}{moonNoteText ? <span className="tg-moon-note">{moonNoteText}</span> : null}
-                </td>
-                <td className="tg-cond-col"><CondBadges wxPt={wxPt} glow={glow} /></td>
-                <td className="wx-num">{winJsx}</td>
-              </tr>
-            )
+            return renderTargetRow(row.target, row.key, false)
           })}
+
+          {unviable.length > 0 && (
+            <>
+              <tr className="tg-unviable-hdr">
+                <td colSpan={5}>Unavailable Tonight</td>
+              </tr>
+              {unviableRows.map(row => {
+                if (row.kind === 'header') {
+                  return (
+                    <tr key={row.key} className="tg-group-hdr tg-row-blocked">
+                      <td colSpan={5}>{TYPE_LABELS[row.type] ?? row.type}</td>
+                    </tr>
+                  )
+                }
+                return renderTargetRow(row.target, row.key, true)
+              })}
+            </>
+          )}
         </tbody>
       </table>
     </div>
@@ -1462,14 +1585,20 @@ export default function ReportCard({
 
       {showTargets && (() => {
         const showerTargets  = r.visible_targets.filter(t => t.type === 'meteor_shower')
-        const primeCount     = r.visible_targets.filter(t => isPrime(t, r.dark_intervals)).length
+        const primeDSOs      = r.visible_targets
+          .filter(t => t.type !== 'milky_way' && t.type !== 'meteor_shower')
+          .filter(t => isPrime(t, r.dark_intervals))
+          .filter(t => (t.landscape_suitability ?? 'prominent') === 'prominent')
+        const viableCount    = primeDSOs.filter(t => t.viability !== 'blocked').length
+        const blockedCount   = primeDSOs.filter(t => t.viability === 'blocked').length
         const hasAnything    = r.visible_targets.length > 0
 
         return (
         <details className="targets" open>
           <summary>
-            Prime Targets
-            {primeCount > 0 ? ` (${primeCount})` : ''}
+            Iconic Sky Features
+            {viableCount > 0 ? ` (${viableCount})` : ''}
+            {blockedCount > 0 ? ` · ${blockedCount} blocked` : ''}
           </summary>
           {!hasAnything
             ? <p className="sat-notice" style={{ paddingTop: 10 }}>No prime targets for this night.</p>
@@ -1502,7 +1631,7 @@ export default function ReportCard({
                   </div>
                 )}
                 <TargetsTable targets={r.visible_targets} report={r} />
-                {primeCount === 0 && !r.mw_summary && showerTargets.length === 0 && (
+                {primeDSOs.length === 0 && !r.mw_summary && showerTargets.length === 0 && (
                   <p className="sat-notice" style={{ paddingTop: 10 }}>
                     {r.dark_intervals.length === 0
                       ? 'No astronomical darkness this night — moon prevents dark-sky observing.'

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -43,6 +43,13 @@ export interface TargetWindow {
   moon_alt_at_peak_deg: number | null
   photo_cutoff: string | null   // last moment viable for astrophotography
   visual_cutoff: string | null  // last moment viable for visual observation
+  // Phase 1: Condition Vectors
+  effective_start: string | null    // MCVI lower bound (condition-gated window start)
+  effective_end: string | null      // MCVI upper bound (condition-gated window end)
+  best_time: string | null          // recommended observation moment within [effective_start, effective_end]
+  blockers: string[]                // e.g. ["cloud", "transparency", "light_dome", "moon_washout"]
+  weather_score_at_best: number | null  // rate_conditions() score (1–10) at best_time
+  dome_glow_at_peak: number | null  // glow_toward() value at peak az/alt; null outside CONUS
 }
 
 export interface VisibleTarget {
@@ -50,6 +57,9 @@ export interface VisibleTarget {
   type: string
   windows: TargetWindow[]
   note: string | null
+  viability: 'ok' | 'degraded' | 'blocked'  // Phase 1: aggregate condition state
+  angular_size_arcmin: number | null         // Phase 3: catalog angular extent
+  landscape_suitability: 'prominent' | 'diffuse' | 'too_small'  // Phase 3: wide-field filter
 }
 
 export interface WeatherPoint {

--- a/tests/test_condition_vectors.py
+++ b/tests/test_condition_vectors.py
@@ -1,0 +1,372 @@
+"""Tests for predictor._apply_condition_vectors (Phase 1 Viability Engine)."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from PyNightSkyPredictor.predictor import _apply_condition_vectors, _CLOUD_BLOCK_PCT, _MIN_VIABLE_MIN
+from PyNightSkyPredictor.targets import TargetWindow, VisibleTarget
+from PyNightSkyPredictor.weather import WeatherPoint
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UTC = timezone.utc
+_BASE = datetime(2025, 7, 1, 22, 0, 0, tzinfo=_UTC)  # nominal "window start"
+
+
+def _make_window(
+    start_offset_h=0,
+    end_offset_h=4,
+    peak_offset_h=2,
+    peak_alt=45.0,
+    peak_az=180.0,
+    moon_sep=90.0,
+    moon_alt=10.0,
+    moon_interference=False,
+    photo_cutoff=None,
+    photo_start=None,
+):
+    start = _BASE + timedelta(hours=start_offset_h)
+    end   = _BASE + timedelta(hours=end_offset_h)
+    peak  = _BASE + timedelta(hours=peak_offset_h)
+    return TargetWindow(
+        start=start,
+        end=end,
+        start_alt_deg=20.0,
+        end_alt_deg=15.0,
+        peak_time=peak,
+        peak_alt_deg=peak_alt,
+        peak_az_deg=peak_az,
+        moon_interference=moon_interference,
+        moon_sep_at_peak_deg=moon_sep,
+        moon_alt_at_peak_deg=moon_alt,
+        photo_cutoff=photo_cutoff,
+        photo_start=photo_start,
+    )
+
+
+def _make_target(window):
+    return VisibleTarget(name="M42", type="nebula", windows=[window], note=None)
+
+
+def _wx(offset_h, cloud=0, transparency="Excellent", humidity=50):
+    return WeatherPoint(
+        time=_BASE + timedelta(hours=offset_h),
+        cloud_cover_pct=cloud,
+        seeing_arcsec=None,
+        transparency=transparency,
+        humidity_pct=humidity,
+        wind_speed_ms=None,
+        lifted_index=None,
+        precip_type="none",
+        temperature_c=15.0,
+        feels_like_c=14.0,
+    )
+
+
+def _run(target, weather=None, light_dome=None, illumination=0.0):
+    _apply_condition_vectors(
+        [target],
+        weather or [],
+        light_dome,
+        illumination,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atmospheric Vector — MCVI
+# ---------------------------------------------------------------------------
+
+def test_no_weather_noop():
+    """Empty weather list → fail-open: effective window = geometric window."""
+    w = _make_window()
+    t = _make_target(w)
+    _run(t)
+    assert w.effective_start == w.start
+    assert w.effective_end   == w.end
+    assert w.blockers        == []
+    assert t.viability       == "ok"
+
+
+def test_clear_night_no_blockers():
+    """All weather points clear → effective window = geometric window."""
+    w  = _make_window()
+    wx = [_wx(i) for i in range(5)]
+    t  = _make_target(w)
+    _run(t, weather=wx)
+    assert w.effective_start == w.start
+    assert w.effective_end   == w.end
+    assert w.blockers        == []
+    assert t.viability       == "ok"
+
+
+def test_early_night_cloud_clears_later():
+    """Cloudy for first 2 hours, then clear — effective_start advances past cloud block."""
+    w = _make_window(peak_offset_h=3)  # peak at hour 3 (in clear period)
+    wx_pts = [
+        _wx(0, cloud=90),   # blocked
+        _wx(1, cloud=85),   # blocked
+        _wx(2, cloud=20),   # clear
+        _wx(3, cloud=10),   # clear (contains peak)
+        _wx(4, cloud=5),    # clear
+    ]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    # MCVI should find the block starting at hour 2
+    assert w.effective_start is not None
+    assert w.effective_start >= _BASE + timedelta(hours=2)
+    assert w.effective_end   == w.end
+    assert "cloud" not in w.blockers  # peak IS in a viable block
+    assert w.best_time == w.peak_time
+    assert t.viability in ("ok", "degraded")
+
+
+def test_mid_night_gap_peak_in_first_block():
+    """Clear → 1h cloudy gap → clear. Peak in first block → MCVI = first block."""
+    w = _make_window(peak_offset_h=1)  # peak at hour 1 (first clear block)
+    wx_pts = [
+        _wx(0, cloud=0),    # clear
+        _wx(1, cloud=5),    # clear — contains peak
+        _wx(2, cloud=95),   # blocked (gap)
+        _wx(3, cloud=10),   # clear (second block)
+        _wx(4, cloud=5),    # clear
+    ]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    # effective_end should be capped before the gap
+    assert w.effective_start == w.start
+    assert w.effective_end is not None
+    assert w.effective_end <= _BASE + timedelta(hours=2)
+    assert w.best_time == w.peak_time
+
+
+def test_mid_night_gap_peak_in_gap_selects_longer_block():
+    """Peak falls in cloudy gap → MCVI selects the longer viable block."""
+    w = _make_window(peak_offset_h=2)  # peak at hour 2 (in gap)
+    wx_pts = [
+        _wx(0, cloud=0),    # clear  — block A: 1 point
+        _wx(1, cloud=90),   # blocked
+        _wx(2, cloud=80),   # blocked — peak is here
+        _wx(3, cloud=90),   # blocked
+        _wx(4, cloud=0),    # clear  — block B: 1 point (same duration, but B is after gap)
+        # Add a second point to block B so it's clearly longer
+    ]
+    # Make first block shorter and second block longer
+    wx_pts = [
+        _wx(0, cloud=0),    # block A: 1 point
+        _wx(1, cloud=95),   # blocked
+        _wx(2, cloud=95),   # blocked — peak
+        _wx(3, cloud=5),    # block B
+        _wx(4, cloud=5),    # block B  (longer: 2 points)
+    ]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    # Block B is longer; effective_start should be in block B
+    assert w.effective_start is not None
+    assert w.effective_start >= _BASE + timedelta(hours=3)
+
+
+def test_fully_cloudy_night():
+    """All weather points blocked → effective_start = effective_end = None, blocked."""
+    w = _make_window()
+    wx_pts = [_wx(i, cloud=95) for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert w.effective_start is None
+    assert w.effective_end   is None
+    assert "cloud" in w.blockers
+    assert w.best_time       is None
+    assert t.viability       == "blocked"
+
+
+def test_transparency_poor_blocks():
+    """transparency=Poor → "transparency" in blockers (cloud may be fine)."""
+    w = _make_window()
+    wx_pts = [_wx(i, cloud=10, transparency="Poor") for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert "transparency" in w.blockers
+    assert t.viability == "blocked"
+
+
+def test_humidity_excluded():
+    """High humidity alone must NOT trigger any blocker."""
+    w = _make_window()
+    wx_pts = [_wx(i, cloud=5, transparency="Excellent", humidity=95) for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert w.blockers == []
+    assert t.viability == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Light Dome Vector
+# ---------------------------------------------------------------------------
+
+def _dome_info(direction_scores: dict, direction_heights: dict):
+    """Build a minimal LightDomeSummary-shaped dict."""
+    dirs = ("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+    return {
+        "sky_state": "domed",
+        "scores": {d: direction_scores.get(d, 0.0) for d in dirs},
+        "dome_heights": {d: direction_heights.get(d, 0.0) for d in dirs},
+        "darkest_direction": "N",
+        "darkest_score": 0.01,
+        "domes": [],
+    }
+
+
+def test_dome_block_at_peak_azimuth():
+    """High dome score at target azimuth (S) → light_dome blocker."""
+    # glow_toward at az=180 (S), alt=5 with score=1.0, theta=10 → glow ≈ 0.8 > 0.25
+    ld = _dome_info({"S": 1.0, "SE": 0.5, "SW": 0.5}, {"S": 10.0, "SE": 10.0, "SW": 10.0})
+    w  = _make_window(peak_az=180.0, peak_alt=5.0)
+    t  = _make_target(w)
+    _run(t, light_dome=ld)
+    assert "light_dome" in w.blockers
+    assert w.dome_glow_at_peak is not None
+    assert w.dome_glow_at_peak >= 0.25
+    assert t.viability in ("degraded", "blocked")
+
+
+def test_dome_no_block_high_altitude():
+    """Same dome, target at 60° altitude — altitude falloff keeps glow below threshold."""
+    # glow = score / (1 + (alt/theta)^2) = 1.0 / (1 + (60/10)^2) = 1/37 ≈ 0.027
+    ld = _dome_info({"S": 1.0, "SE": 0.5, "SW": 0.5}, {"S": 10.0, "SE": 10.0, "SW": 10.0})
+    w  = _make_window(peak_az=180.0, peak_alt=60.0)
+    t  = _make_target(w)
+    _run(t, light_dome=ld)
+    assert "light_dome" not in w.blockers
+    assert w.dome_glow_at_peak is not None
+    assert w.dome_glow_at_peak < 0.25
+
+
+def test_dome_none_outside_coverage():
+    """No dome info (outside CONUS) → dome_glow_at_peak is None, no blocker."""
+    w = _make_window()
+    t = _make_target(w)
+    _run(t, light_dome=None)
+    assert w.dome_glow_at_peak is None
+    assert "light_dome" not in w.blockers
+
+
+# ---------------------------------------------------------------------------
+# Lunar Proximity Vector
+# ---------------------------------------------------------------------------
+
+def test_moon_washout_full_moon_tight_separation():
+    """Full moon (100%), 10° sep → within 45° radius → moon_washout blocker."""
+    w = _make_window(moon_sep=10.0, moon_alt=45.0)
+    t = _make_target(w)
+    _run(t, illumination=100.0)
+    assert "moon_washout" in w.blockers
+    assert t.viability in ("degraded", "blocked")
+
+
+def test_moon_no_washout_crescent_exempt():
+    """≤20% illumination (crescent exemption) → no moon_washout regardless of separation."""
+    w = _make_window(moon_sep=5.0, moon_alt=45.0)
+    t = _make_target(w)
+    _run(t, illumination=15.0)
+    assert "moon_washout" not in w.blockers
+
+
+def test_moon_no_washout_wide_separation():
+    """Bright moon (90%) but 120° separation; effective radius = 40.5° < 120° → no washout."""
+    w = _make_window(moon_sep=120.0, moon_alt=45.0)
+    t = _make_target(w)
+    _run(t, illumination=90.0)
+    assert "moon_washout" not in w.blockers
+
+
+def test_moon_washout_inside_weighted_radius():
+    """80% moon, 30° sep; effective radius = 36° > 30° → washout."""
+    w = _make_window(moon_sep=30.0, moon_alt=30.0)
+    t = _make_target(w)
+    _run(t, illumination=80.0)
+    assert "moon_washout" in w.blockers
+
+
+# ---------------------------------------------------------------------------
+# Best Time
+# ---------------------------------------------------------------------------
+
+def test_best_time_uses_peak_when_inside_effective():
+    """Peak falls within the effective window → best_time = peak_time."""
+    w = _make_window(peak_offset_h=2)
+    wx_pts = [_wx(i) for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert w.best_time == w.peak_time
+
+
+def test_best_time_snaps_to_eff_end_when_peak_cut_off():
+    """Weather cuts window at hour 1 but peak is at hour 2 → best_time = eff_end."""
+    w = _make_window(peak_offset_h=2)
+    wx_pts = [
+        _wx(0, cloud=0),
+        _wx(1, cloud=0),
+        _wx(2, cloud=95),   # blocked — peak is here
+        _wx(3, cloud=95),
+        _wx(4, cloud=95),
+    ]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    # peak (hour 2) is past effective_end (near hour 1); snap to effective_end
+    assert w.best_time is not None
+    assert w.best_time <= _BASE + timedelta(hours=2)
+
+
+def test_best_time_none_when_fully_blocked():
+    """Entirely cloudy → best_time = None."""
+    w = _make_window()
+    wx_pts = [_wx(i, cloud=95) for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert w.best_time is None
+
+
+def test_best_time_never_exceeds_effective_end():
+    """Invariant: best_time <= effective_end when both are set."""
+    w = _make_window(peak_offset_h=3)
+    wx_pts = [
+        _wx(0, cloud=0),
+        _wx(1, cloud=0),
+        _wx(2, cloud=95),
+        _wx(3, cloud=95),
+        _wx(4, cloud=95),
+    ]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    if w.best_time is not None and w.effective_end is not None:
+        assert w.best_time <= w.effective_end
+
+
+# ---------------------------------------------------------------------------
+# photo_start / photo_cutoff K&S integration
+# ---------------------------------------------------------------------------
+
+def test_photo_start_clamps_effective_start():
+    """photo_start (K&S lower bound) must gate effective_start from going too early."""
+    photo_start = _BASE + timedelta(hours=1)
+    w = _make_window(photo_start=photo_start)
+    # All weather clear, so MCVI would set effective_start = window.start (hour 0).
+    # But photo_start is hour 1, so effective_start should be max(hour0, hour1) = hour1.
+    wx_pts = [_wx(i) for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert w.effective_start == photo_start
+
+
+def test_photo_cutoff_clamps_effective_end():
+    """photo_cutoff (K&S upper bound) gates effective_end."""
+    photo_cutoff = _BASE + timedelta(hours=2)
+    w = _make_window(photo_cutoff=photo_cutoff)
+    wx_pts = [_wx(i) for i in range(5)]
+    t = _make_target(w)
+    _run(t, weather=wx_pts)
+    assert w.effective_end <= photo_cutoff

--- a/tests/test_landscape_prominence.py
+++ b/tests/test_landscape_prominence.py
@@ -1,0 +1,101 @@
+"""Tests for Phase 3 landscape prominence classification and moon-scale labeling."""
+
+import pytest
+
+from PyNightSkyPredictor.targets import (
+    _landscape_suitability,
+    _SB_DIFFUSE_THRESHOLD,
+    _ANGULAR_SIZE_MIN_ARCMIN,
+)
+
+
+# ---------------------------------------------------------------------------
+# _landscape_suitability() — classification logic
+# ---------------------------------------------------------------------------
+
+def test_diffuse_high_sb():
+    assert _landscape_suitability(17.0, 180) == "diffuse"
+
+def test_diffuse_boundary_at_16():
+    # Threshold is inclusive: SB == 16.0 → diffuse
+    assert _landscape_suitability(16.0, 60) == "diffuse"
+
+def test_not_diffuse_just_below_16():
+    assert _landscape_suitability(15.9, 60) == "prominent"
+
+def test_too_small_below_threshold():
+    assert _landscape_suitability(13.0, 7) == "too_small"
+
+def test_too_small_at_8_9():
+    # Threshold is strict: size < 9.0 → too_small
+    assert _landscape_suitability(13.0, 8.9) == "too_small"
+
+def test_prominent_at_9_exactly():
+    # 9.0 is NOT filtered
+    assert _landscape_suitability(13.5, 9.0) == "prominent"
+
+def test_prominent_normal_dso():
+    # Orion-like object: high SB, large
+    assert _landscape_suitability(13.0, 65) == "prominent"
+
+def test_diffuse_takes_priority_over_size():
+    # SB check runs before size check; Ring Nebula-like (tiny AND diffuse SB)
+    assert _landscape_suitability(17.0, 1.4) == "diffuse"
+
+def test_no_sb_cluster_large():
+    # Clusters have no surface_brightness field; large cluster is prominent
+    assert _landscape_suitability(None, 110) == "prominent"
+
+def test_no_sb_cluster_small():
+    # Small cluster (no SB) still fails on size
+    assert _landscape_suitability(None, 8) == "too_small"
+
+def test_no_angular_size_planet():
+    # Planets/meteors/MW have no angular_size — always prominent
+    assert _landscape_suitability(None, None) == "prominent"
+
+
+# ---------------------------------------------------------------------------
+# moonScaleLabel() — Python port for breakpoint verification
+# ---------------------------------------------------------------------------
+# This mirrors the TypeScript moonScaleLabel() in ReportCard.tsx.
+
+MOON_ARCMIN = 30
+
+def _moon_scale_label(arcmin):
+    """Python port of moonScaleLabel() in ReportCard.tsx."""
+    if arcmin is None:
+        return None
+    ratio = arcmin / MOON_ARCMIN
+    if ratio >= 1.5:
+        return f"{round(ratio)}x Moon"
+    if ratio >= 1.0:
+        return "1x Moon"
+    if ratio >= 0.5:
+        return "½ Moon"
+    if ratio >= 0.3:
+        return "⅓ Moon"
+    return None
+
+
+def test_moon_scale_large():
+    # Andromeda: 190' → round(190/30) = 6
+    assert _moon_scale_label(190) == "6x Moon"
+
+def test_moon_scale_exact_1x():
+    assert _moon_scale_label(30) == "1x Moon"
+
+def test_moon_scale_half():
+    # Helix: 25' → ratio 0.83
+    assert _moon_scale_label(25) == "½ Moon"
+
+def test_moon_scale_third():
+    # Swan Nebula: 11' → ratio 0.37
+    assert _moon_scale_label(11) == "⅓ Moon"
+
+def test_moon_scale_null_compact():
+    # Ring Nebula: 1.4' → ratio 0.047 → below ⅓ threshold
+    assert _moon_scale_label(7) is None
+
+def test_moon_scale_null_input():
+    assert _moon_scale_label(None) is None


### PR DESCRIPTION
## Summary

- **Phase 1 — Viability Engine**: `_apply_condition_vectors()` evaluates three condition vectors (MCVI atmospheric, light dome at target azimuth, lunar proximity) to clip each target's effective viewing window and classify viability as `ok | degraded | blocked`. New fields on `TargetWindow`: `effective_start/end`, `best_time`, `blockers`, `weather_score_at_best`, `dome_glow_at_peak`. New field on `VisibleTarget`: `viability`.
- **Phase 2 — Viability UI**: `TargetsTable` splits into "Viable Tonight" and "Unavailable Tonight" sections. Blocked rows render `BlockerBadge` ([ Obscured by Clouds ] / [ Washed Out by Moon ] / [ Lost in Light Dome ]), are desaturated, and show a clip indicator (`*`) when the window was truncated. Best Viewing prefers backend `best_time`; Window column uses `effective_start/effective_end`.
- **Phase 3 — Landscape Curation**: `angular_size_arcmin` added to all 32 DSO catalog entries. `_landscape_suitability()` gates objects as `prominent | diffuse | too_small` (SB ≥ 16.0 = narrowband-only; size < 9′ = sub-pixel at wide-field). Non-prominent targets (Ring Nebula, Crab, Veil, North America, Rosette, Dumbbell, Sombrero, Eagle) filtered entirely. Section header → "Iconic Sky Features". DSO sub-categories collapsed to a single unlabeled block; only Planets retain a sub-header. Moon-scale size tags added: `· Size: 6x Moon`, `· Size: ½ Moon`, etc.

## Test plan

- [ ] `python -m pytest -q` — 499 passed, 7 skipped (38 new tests: 21 condition vectors + 17 landscape prominence)
- [ ] Security CI (`security.yml`) passes on this branch
- [ ] Verify in prod: section reads "Iconic Sky Features (N)"; DSOs appear in unlabeled block above Planets; Ring/Crab/Veil/North America/Rosette/Dumbbell absent; size tags present (e.g. "Andromeda Galaxy · Size: 6x Moon"); blocked targets show diagnostic badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)