### PR TITLE
Add live NOW marker to night timeline; fix timezone date handling

### DIFF
--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -648,7 +648,7 @@ def assemble_night(
             if not _future_date:
                 # Past date: sequential fetch (no parallelism needed — uncommon path)
                 try:
-                    days_ago = (date.today() - target).days
+                    days_ago = (_now.date() - target).days
                     if days_ago <= wx.OpenMeteoPastProvider._MAX_PAST_DAYS:
                         provider = wx.OpenMeteoPastProvider(days_ago + 2)
                     else:

--- a/PyNightSkyPredictor/tle_provider.py
+++ b/PyNightSkyPredictor/tle_provider.py
@@ -195,8 +195,8 @@ def _filter_train_tles(raw: str) -> list[tuple[str, str, str]]:
          older batches have spread out and no longer form a visible train even if they
          haven't yet reached full operational altitude
     """
-    from datetime import date, timedelta
-    cutoff = date.today() - timedelta(days=_STARLINK_RECENT_DAYS)
+    from datetime import datetime, timedelta, timezone
+    cutoff = datetime.now(timezone.utc).date() - timedelta(days=_STARLINK_RECENT_DAYS)
 
     lines  = [l.strip() for l in raw.splitlines() if l.strip()]
     result = []

--- a/PyNightSkyPredictor/trip.py
+++ b/PyNightSkyPredictor/trip.py
@@ -136,7 +136,7 @@ def _cache_key(lat: float, lon: float, d: date, with_weather: bool) -> str:
 
 
 def _within_forecast_window(d: date) -> bool:
-    return (d - date.today()).days <= _FORECAST_DAYS
+    return (d - datetime.now(_utc).date()).days <= _FORECAST_DAYS
 
 
 def fetch_night(

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -17,7 +17,7 @@ import os
 import shutil
 import time
 from contextlib import asynccontextmanager
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI, HTTPException, Query
@@ -180,7 +180,7 @@ def _check_cache_health() -> dict:
 
 def _parse_date(s: str | None, field: str = "date") -> date:
     if not s:
-        return date.today()
+        return datetime.now(timezone.utc).date()
     try:
         d = date.fromisoformat(s)
     except ValueError:
@@ -214,7 +214,7 @@ def _resolve(location: str | None, lat: float | None, lon: float | None):
 
 def _month_bounds(month: str | None) -> tuple[date, date]:
     if not month:
-        start = date.today().replace(day=1)
+        start = datetime.now(timezone.utc).date().replace(day=1)
     else:
         try:
             start = datetime.strptime(month, "%Y-%m").date().replace(day=1)

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1876,6 +1876,42 @@ html.red-mode .cond-glow { color: rgb(160, 0, 0) !important; }
   cursor: pointer;
 }
 /* Timeline event rows interleaved in the weather table */
+/* NOW marker — current time in the location's TZ, shown only while inside the night window */
+.wx-now-row td {
+  padding: 0;
+  border-top: 2px solid color-mix(in oklab, var(--accent) 80%, transparent);
+  border-bottom: none;
+}
+.wx-now-row td.wx-now-time {
+  padding: 1px 6px 1px 0;
+  background: var(--card);
+  color: var(--accent);
+  border-left: 2px solid var(--accent);
+}
+.wx-now-content {
+  position: sticky;
+  left: 68px;
+  background: var(--card);
+  z-index: 1;
+}
+.wx-now-inner {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+html.red-mode .wx-now-row td {
+  border-top-color: color-mix(in oklab, var(--accent) 40%, transparent);
+}
+html.red-mode .wx-now-row td.wx-now-time {
+  border-left-color: var(--accent);
+}
+
 .wx-ev-row td {
   padding: 0;
   border-bottom: 1px solid rgba(var(--hairline-rgb), 0.5);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, type FormEvent } from 'react'
 import './App.css'
 import { LocateFixed, ChevronLeft, ChevronRight, Clock, MapPin, X } from 'lucide-react'
 import { ApiRequestError, fetchNight, fetchSuggestions, type NightQuery } from './api'
-import { todayIso, toIsoDate, defaultImperial } from './format'
+import { todayIso, tonightIso, toIsoDate, defaultImperial } from './format'
 import ReportCard from './ReportCard'
 import DatePicker from './DatePicker'
 import type { NightReport } from './types'
@@ -33,7 +33,7 @@ export default function App() {
   const [place, setPlace] = useState('')
   const [lat, setLat] = useState('')
   const [lon, setLon] = useState('')
-  const [date, setDate] = useState(todayIso())
+  const [date, setDate] = useState(tonightIso())
   const [imperial, setImperial] = useState<boolean>(defaultImperial)
   const [locating, setLocating] = useState(false)
   const [redMode, setRedMode] = useState<boolean>(() => localStorage.getItem('redMode') === '1')
@@ -145,7 +145,7 @@ export default function App() {
     const d = p.get('date')
     if (!q && !(la && lo)) return
 
-    const targetDate = d || todayIso()
+    const targetDate = d || tonightIso()
     const { wxUnavail, satUnavail } = availabilityFor(targetDate)
 
     if (d) setDate(d)

--- a/apps/web/src/DatePicker.tsx
+++ b/apps/web/src/DatePicker.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { tonightIso } from './format'
 
 interface DatePickerProps {
   value: string   // YYYY-MM-DD
@@ -155,8 +156,8 @@ export default function DatePicker({ value, min, max, onChange }: DatePickerProp
           </div>
 
           <div className="dp-footer">
-            <button type="button" className="dp-today-btn" onClick={() => select(today)}>
-              Today
+            <button type="button" className="dp-today-btn" onClick={() => select(tonightIso())}>
+              Tonight
             </button>
           </div>
         </div>

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -148,10 +148,21 @@ function WeatherTable({ points, events = [], tz, imperial, darkIntervals, moonri
     return firstAfter.label.toLowerCase().includes('moonrise') ? 'below' : 'above'
   })()
 
-  type Row = { kind: 'event'; ev: SkyEvent; ts: number } | { kind: 'wx'; pt: WeatherPoint; ts: number }
+  // Live "now" marker — updates every 30s so it stays accurate if the page is
+  // left open. Only injected when the current moment is inside the night window.
+  const [nowTs, setNowTs] = useState(Date.now)
+  useEffect(() => {
+    const id = setInterval(() => setNowTs(Date.now()), 30_000)
+    return () => clearInterval(id)
+  }, [])
+  const isLive = sunsetTs !== -Infinity && sunriseTs !== Infinity
+               && nowTs > sunsetTs && nowTs < sunriseTs
+
+  type Row = { kind: 'event'; ev: SkyEvent; ts: number } | { kind: 'wx'; pt: WeatherPoint; ts: number } | { kind: 'now'; ts: number }
   const rows: Row[] = [
     ...visibleEvents.map(ev => ({ kind: 'event' as const, ev, ts: new Date(ev.time).getTime() })),
     ...visiblePoints.map(pt => ({ kind: 'wx'    as const, pt, ts: new Date(pt.time).getTime() })),
+    ...(isLive ? [{ kind: 'now' as const, ts: nowTs }] : []),
   ].sort((a, b) => a.ts - b.ts)
 
   const ip = { size: 12, strokeWidth: 1.5, style: { flexShrink: 0 } } as const
@@ -193,6 +204,16 @@ function WeatherTable({ points, events = [], tz, imperial, darkIntervals, moonri
           )}
           <tbody>
             {rows.map((row, i) => {
+              if (row.kind === 'now') {
+                return (
+                  <tr key="now-marker" className="wx-now-row">
+                    <td className="wx-time wx-now-time">{formatTime(new Date(row.ts).toISOString(), tz)}</td>
+                    <td colSpan={hasWx ? totalCols - 1 : 1} className="wx-now-content">
+                      <span className="wx-now-inner">▶ Now</span>
+                    </td>
+                  </tr>
+                )
+              }
               if (row.kind === 'event') {
                 const icon    = evIcon(row.ev.label)
                 const cls     = evClass(row.ev.label)

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -235,3 +235,17 @@ export function toIsoDate(d: Date): string {
 export function todayIso(): string {
   return toIsoDate(new Date())
 }
+
+// The date the *current night* belongs to — which is yesterday when it's past
+// midnight but before noon (sunrise hasn't happened yet for any US location).
+// Use this for default queries so a photographer opening the app at 2 AM sees
+// the night they're standing in, not tomorrow's upcoming observations.
+export function tonightIso(): string {
+  const now = new Date()
+  if (now.getHours() < 6) {
+    const d = new Date(now)
+    d.setDate(d.getDate() - 1)
+    return toIsoDate(d)
+  }
+  return toIsoDate(now)
+}

--- a/tests/test_date_tz.py
+++ b/tests/test_date_tz.py
@@ -1,0 +1,38 @@
+"""Guardrail: no naive date.today() calls in backend source.
+
+date.today() returns the local system date, which on a non-UTC machine
+differs from the UTC date that the AWS Lambda runtime uses. All date
+references in the API and engine must use datetime.now(timezone.utc).date()
+so behaviour is identical locally and in prod.
+
+If this test fails, replace the offending date.today() call with
+datetime.now(timezone.utc).date() (or reuse an already-captured _now.date()
+where one is in scope).
+"""
+import pathlib
+import re
+
+# Source trees that run in the Lambda / API process.
+_SOURCE_DIRS = [
+    pathlib.Path("apps/api"),
+    pathlib.Path("PyNightSkyPredictor"),
+]
+
+_PATTERN = re.compile(r'\bdate\.today\(\)')
+
+
+def test_no_naive_date_today_in_backend_source():
+    violations = []
+    for src_dir in _SOURCE_DIRS:
+        for py_file in src_dir.rglob("*.py"):
+            if "__pycache__" in py_file.parts:
+                continue
+            text = py_file.read_text()
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if _PATTERN.search(line):
+                    violations.append(f"{py_file}:{lineno}: {line.strip()}")
+
+    assert not violations, (
+        "date.today() found in backend source — use datetime.now(timezone.utc).date() instead:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

- **Live NOW marker** — Night Timeline table shows a `▶ Now` row at the current time (in the location's timezone) whenever the page is open during an active night; updates every 30 s without a page reload
- **`tonightIso()` cutoff fix** — changed from `< 12` to `< 6` so the default date is correct at morning hours and for trans-continental (US → eastern hemisphere) queries
- **DatePicker** — "Today" button renamed "Tonight", wired to `tonightIso()`
- **Timezone audit** — all `date.today()` calls in `apps/api` and `PyNightSkyPredictor` replaced with `datetime.now(timezone.utc).date()` so behaviour is identical locally and on Lambda (UTC)
- **CI guardrail** — `tests/test_date_tz.py` fails if `date.today()` is ever reintroduced into backend source

## Test plan

- [ ] Load a location and verify no console errors
- [ ] Open app between sunset and sunrise at the queried location — confirm `▶ Now` row appears at the correct position in the Night Timeline
- [ ] Confirm row updates position after 30 s without a page reload
- [ ] Confirm `▶ Now` row does not appear for past or future dates
- [ ] Verify red-mode renders the marker in red (not blue)
- [ ] Click "Tonight" in the DatePicker — confirm it returns yesterday's date before 6 AM, today's date after 6 AM
- [ ] `python -m pytest -q` — all tests pass including `test_date_tz.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)