### PR TITLE
Fix API zip bundling: copy requirements.txt into staging dir

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -89,6 +89,8 @@ def _stage_api_src() -> str:
     (stage / "cache").mkdir()
     for _npz in ("darkhours_padus_h3.npz", "lightdome_h3.npz"):
         shutil.copy(_REPO / "cache" / _npz, stage / "cache" / _npz)
+    # requirements-api.txt has `-r requirements.txt`; both must be present for pip.
+    shutil.copy(_REPO / "requirements.txt", stage / "requirements.txt")
     shutil.copy(_REPO / "requirements-api.txt", stage / "requirements-api.txt")
     return str(stage)
 


### PR DESCRIPTION
Hotfix for the failed deploy in #63.

`requirements-api.txt` uses `-r requirements.txt` to include the base deps, but `_stage_api_src()` only copied `requirements-api.txt` into the bundling input directory. pip failed when it couldn't find the referenced file.

Fix: copy `requirements.txt` alongside `requirements-api.txt` in `_stage_api_src()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)