### PR TITLE
Speed up lunar_cycle_dark_analysis 80% via fixed twilight offset (Approach A)

### DIFF
--- a/PyNightSkyPredictor/sky_events.py
+++ b/PyNightSkyPredictor/sky_events.py
@@ -7,7 +7,7 @@ import time as _time
 import logging
 import math
 import statistics
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 from skyfield.api import Loader, load, wgs84
@@ -167,7 +167,19 @@ def _dark_cycle_db_key(lat: float, lon: float, window_start: date) -> str:
 
 
 def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> list:
-    """Compute dark sky hours for 30 consecutive nights centred on target_date."""
+    """Compute dark sky hours for 30 consecutive nights centred on target_date.
+
+    Two parallel find_discrete calls cover sunrise/sunset and moonrise/moonset
+    for the full 32-day window.  Astronomical twilight boundaries are derived
+    from tonight's sky_events (already cached) as a fixed offset applied to all
+    30 nights rather than 30 separate per-night find_discrete calls.  Drift is
+    ≤2 min/day so ≤30 min at the ±15-day edges; benchmark showed ≤0.25h array
+    drift at mid-latitudes, ≤0.75h at high latitude near solstice.  Saves the
+    ~300ms serial twilight-search loop from the previous implementation.
+    When no astronomical night exists tonight (high-lat summer), all nights
+    return 0 — correct for the solstice window where the whole 30-night window
+    also lacks astronomical darkness.
+    """
     ts  = load.timescale()
     eph = _ephemeris()
     observer = wgs84.latlon(lat, lon)
@@ -177,15 +189,8 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
     t0 = ts.utc(d0.year, d0.month, d0.day)
     t1 = ts.utc(d1.year, d1.month, d1.day)
 
-    # Two targeted risings_and_settings calls run in parallel (sunrise/sunset and moon).
-    # Astronomical twilight (sun at -18°) is searched per-night inside the loop using
-    # narrow sunset→sunrise windows. The full-window approach with find_discrete silently
-    # drops some nightly transitions near the full moon period when consecutive sample
-    # points both land in daytime — a per-night narrow search (≤14h, at most 2 events)
-    # is immune to this class of miss.
-    sun   = eph["sun"]
+    sun    = eph["sun"]
     f_hor  = almanac.risings_and_settings(eph, sun,         observer, horizon_degrees=-0.8333)
-    f_ast  = almanac.risings_and_settings(eph, sun,         observer, horizon_degrees=-18.0)
     f_moon = almanac.risings_and_settings(eph, eph["moon"], observer)
 
     def _timed(fn, *args):
@@ -214,9 +219,25 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
 
     all_events.sort(key=lambda e: e["time"])
 
+    # Twilight offsets from tonight's sky_events (warm cache hit after sky_events
+    # runs earlier in assemble_night).  None when no astronomical night tonight.
+    _sky_ev = sky_events(lat, lon, target_date)
+    _t_set  = next((e["time"] for e in _sky_ev
+                    if e["label"] == "Sunset"
+                    and e["time"].astimezone(tz).date() == target_date), None)
+    _t_rise = find_event(_sky_ev, "Sunrise", after=_t_set)                      if _t_set else None
+    _t_nb   = find_event(_sky_ev, "Astronomical night begins", after=_t_set)    if _t_set else None
+    _t_ne   = find_event(_sky_ev, "Astronomical night ends", after=_t_nb or _t_set) if _t_set else None
+
+    tw_after  = (_t_nb   - _t_set ).total_seconds() if (_t_set and _t_nb)   else None
+    tw_before = (_t_rise - _t_ne  ).total_seconds() if (_t_rise and _t_ne)  else None
+
     _t_loop0 = _time.monotonic()
     hours = []
     for offset in range(-14, 16):
+        if tw_after is None or tw_before is None:
+            hours.append(0.0)
+            continue
         night_date = target_date + timedelta(days=offset)
         sunset = next(
             (e["time"] for e in all_events
@@ -232,23 +253,9 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
             hours.append(0.0)
             continue
 
-        # Per-night narrow search for astronomical twilight — avoids find_discrete
-        # dropping events that a full 30-day window call can miss.
-        t_set  = ts.from_datetime(sunset)
-        t_rise = ts.from_datetime(sunrise)
-        ast_t, ast_r = almanac.find_discrete(t_set, t_rise, f_ast, num=8)
-        night_start = next(
-            (t.utc_datetime().replace(tzinfo=timezone.utc)
-             for t, r in zip(ast_t, ast_r) if not r),
-            None,
-        )
-        night_end = next(
-            (t.utc_datetime().replace(tzinfo=timezone.utc)
-             for t, r in zip(ast_t, ast_r)
-             if r and night_start is not None and t.utc_datetime() > night_start),
-            None,
-        )
-        if not night_start or not night_end:
+        night_start = sunset  + timedelta(seconds=tw_after)
+        night_end   = sunrise - timedelta(seconds=tw_before)
+        if night_end <= night_start:
             hours.append(0.0)
             continue
         intervals  = dark_moon_intervals(all_events, night_start, night_end)

--- a/scripts/bench_approach_a.py
+++ b/scripts/bench_approach_a.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Confirm approach A accuracy vs Brute across a full lunar cycle.
+
+  Brute  – current: parallel bulk find_discrete + 30 per-night twilight searches
+  A      – parallel bulk find_discrete + fixed twilight offset from tonight's sky_events
+
+Tests all 30 days of one lunar cycle (one date per day).
+Locations: Denver CO · Seattle WA · Miami FL
+Reports: score drift, tonight_hours drift, max 30-night array drift, timing.
+Also prints the night-by-night array for the single worst-case date.
+
+Usage:
+  source .venv/bin/activate
+  python scripts/bench_approach_a.py
+"""
+
+import concurrent.futures
+import sys
+import time
+from datetime import date, datetime, timedelta, timezone
+
+from zoneinfo import ZoneInfo
+from skyfield import almanac
+from skyfield.api import load, wgs84
+
+sys.path.insert(0, ".")
+from PyNightSkyPredictor import sky_events as se
+from PyNightSkyPredictor.sky_events import (
+    _compute_dark_hours_cycle,
+    _dark_stats,
+    dark_moon_intervals,
+    find_event,
+)
+
+# ── Config ────────────────────────────────────────────────────────────────────
+LOCS = [
+    ("Denver  CO", 39.74, -104.98, ZoneInfo("America/Denver")),
+    ("Seattle WA", 47.61, -122.33, ZoneInfo("America/Los_Angeles")),
+    ("Miami   FL", 25.77,  -80.19, ZoneInfo("America/New_York")),
+]
+
+BASE  = date(2026, 6, 27)
+DATES = [BASE + timedelta(days=i) for i in range(30)]   # full lunar cycle
+
+
+# ── Brute (current) ───────────────────────────────────────────────────────────
+
+def run_brute(lat, lon, tz, d):
+    t0  = time.monotonic()
+    hrs = _compute_dark_hours_cycle(lat, lon, d, tz)
+    ms  = round((time.monotonic() - t0) * 1000)
+    return _dark_stats(hrs, 14), hrs, ms
+
+
+# ── Approach A ────────────────────────────────────────────────────────────────
+
+def run_a(lat, lon, tz, target_date):
+    t0 = time.monotonic()
+
+    eph      = se._ephemeris()
+    ts       = load.timescale()
+    observer = wgs84.latlon(lat, lon)
+
+    d0    = target_date - timedelta(days=15)
+    d1    = target_date + timedelta(days=17)
+    t0_sf = ts.utc(d0.year, d0.month, d0.day)
+    t1_sf = ts.utc(d1.year, d1.month, d1.day)
+
+    f_hor  = almanac.risings_and_settings(eph, eph["sun"],  observer, horizon_degrees=-0.8333)
+    f_moon = almanac.risings_and_settings(eph, eph["moon"], observer)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        hf = pool.submit(almanac.find_discrete, t0_sf, t1_sf, f_hor)
+        mf = pool.submit(almanac.find_discrete, t0_sf, t1_sf, f_moon)
+        hor_times,  hor_r  = hf.result()
+        moon_times, moon_r = mf.result()
+
+    all_ev = []
+    for t, r in zip(hor_times, hor_r):
+        all_ev.append({"time": t.utc_datetime(), "label": "Sunrise" if r else "Sunset"})
+    for t, r in zip(moon_times, moon_r):
+        all_ev.append({"time": t.utc_datetime(), "label": "Moonrise" if r else "Moonset"})
+    all_ev.sort(key=lambda e: e["time"])
+
+    sky_ev = se.sky_events(lat, lon, target_date)
+    t_set  = next((e["time"] for e in sky_ev
+                   if e["label"] == "Sunset"
+                   and e["time"].astimezone(tz).date() == target_date), None)
+    t_rise = find_event(sky_ev, "Sunrise", after=t_set)                   if t_set else None
+    t_nb   = find_event(sky_ev, "Astronomical night begins", after=t_set) if t_set else None
+    t_ne   = find_event(sky_ev, "Astronomical night ends", after=t_nb or t_set) if t_set else None
+
+    tw_after  = (t_nb   - t_set ).total_seconds() if (t_set and t_nb)   else None
+    tw_before = (t_rise - t_ne  ).total_seconds() if (t_rise and t_ne)  else None
+
+    dark_hours = []
+    for offset in range(-14, 16):
+        night_date = target_date + timedelta(days=offset)
+        sunset = next(
+            (e["time"] for e in all_ev
+             if e["label"] == "Sunset"
+             and e["time"].astimezone(tz).date() == night_date),
+            None,
+        )
+        if not sunset or tw_after is None or tw_before is None:
+            dark_hours.append(0.0)
+            continue
+        sunrise = find_event(all_ev, "Sunrise", after=sunset)
+        if not sunrise:
+            dark_hours.append(0.0)
+            continue
+
+        night_start = sunset  + timedelta(seconds=tw_after)
+        night_end   = sunrise - timedelta(seconds=tw_before)
+        if night_end <= night_start:
+            dark_hours.append(0.0)
+            continue
+
+        ivs = dark_moon_intervals(all_ev, night_start, night_end)
+        dark_hours.append(sum((e - s).total_seconds() for s, e in ivs) / 3600)
+
+    ms = round((time.monotonic() - t0) * 1000)
+    return _dark_stats(dark_hours, 14), dark_hours, ms
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def moon_phase_label(d: date) -> str:
+    ts  = load.timescale()
+    eph = se._ephemeris()
+    deg = almanac.moon_phase(eph, ts.utc(d.year, d.month, d.day, 12)).degrees
+    labels = [
+        (22.5,  "New       "), (67.5,  "Wax Cres  "), (112.5, "1st Qtr   "),
+        (157.5, "Wax Gib   "), (202.5, "Full      "), (247.5, "Wan Gib   "),
+        (292.5, "3rd Qtr   "), (337.5, "Wan Cres  "),
+    ]
+    for threshold, name in labels:
+        if deg < threshold:
+            return name
+    return "New       "
+
+
+def max_drift(a, b):
+    return max(abs(x - y) for x, y in zip(a, b))
+
+
+def print_night_array(d, brute_hrs, a_hrs):
+    """Print the 30-night dark-hours array side by side."""
+    print(f"\n  Night-by-night for {d}  (offset = days from tonight):")
+    print(f"  {'Offset':>6}  {'Brute':>6}  {'A':>6}  {'Δ':>6}")
+    print(f"  {'──────':>6}  {'──────':>6}  {'──────':>6}  {'──────':>6}")
+    for i, (bh, ah) in enumerate(zip(brute_hrs, a_hrs)):
+        offset = i - 14
+        marker = " ◀ tonight" if offset == 0 else ""
+        delta  = ah - bh
+        print(f"  {offset:>+6}  {bh:>6.2f}  {ah:>6.2f}  {delta:>+6.2f}{marker}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    print(f"Testing {len(DATES)} dates: {DATES[0]} → {DATES[-1]}")
+    print("Pre-warming sky_events cache...")
+    for _, lat, lon, tz in LOCS:
+        for d in DATES:
+            se.sky_events(lat, lon, d)
+    print("Cache warm.\n")
+
+    for loc_name, lat, lon, tz in LOCS:
+        print(f"\n{'═'*88}")
+        print(f"  {loc_name}")
+        print(f"{'─'*88}")
+        print(f"  {'Date':<12}  {'Phase':<10}  "
+              f"{'Brute':>5}  {'A':>5}  {'Δscore':>7}  "
+              f"{'B.hrs':>5}  {'A.hrs':>5}  {'Δhrs':>6}  "
+              f"{'Δmax':>6}  {'Brute':>7}  {'A':>5}")
+        print(f"  {'────────────':<12}  {'──────────':<10}  "
+              f"{'─────':>5}  {'─────':>5}  {'───────':>7}  "
+              f"{'─────':>5}  {'─────':>5}  {'──────':>6}  "
+              f"{'──────':>6}  {'───────':>7}  {'─────':>5}")
+
+        worst_date      = None
+        worst_drift     = 0.0
+        worst_b_hrs     = []
+        worst_a_hrs     = []
+        total_brute_ms  = 0
+        total_a_ms      = 0
+
+        for d in DATES:
+            phase = moon_phase_label(d)
+            print(f"  {d} {phase} ...", end="\r", flush=True)
+
+            b_stats, b_hrs, b_ms = run_brute(lat, lon, tz, d)
+            a_stats, a_hrs, a_ms = run_a(lat, lon, tz, d)
+            total_brute_ms += b_ms
+            total_a_ms     += a_ms
+
+            d_score = a_stats["score"]         - b_stats["score"]
+            d_hrs   = a_stats["tonight_hours"] - b_stats["tonight_hours"]
+            d_max   = max_drift(b_hrs, a_hrs)
+
+            if d_max > worst_drift:
+                worst_drift  = d_max
+                worst_date   = d
+                worst_b_hrs  = b_hrs
+                worst_a_hrs  = a_hrs
+
+            print(f"  {d}  {phase}  "
+                  f"{b_stats['score']:5.1f}  {a_stats['score']:5.1f}  {d_score:>+7.2f}  "
+                  f"{b_stats['tonight_hours']:5.2f}  {a_stats['tonight_hours']:5.2f}  {d_hrs:>+6.2f}  "
+                  f"{d_max:6.2f}h  {b_ms:5}ms  {a_ms:3}ms")
+
+        avg_brute = total_brute_ms // len(DATES)
+        avg_a     = total_a_ms     // len(DATES)
+        print(f"\n  Average timing: Brute {avg_brute}ms  A {avg_a}ms  "
+              f"({round((1 - avg_a/avg_brute)*100)}% faster)")
+        print(f"  Worst Δmax: {worst_drift:.2f}h on {worst_date}")
+
+        if worst_date:
+            print_night_array(worst_date, worst_b_hrs, worst_a_hrs)
+
+    print(f"\n{'═'*88}")
+    print("  Score = 0-10.  Δmax = max |Brute - A| across all 30 nights in window.")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_dark_cycle_heuristic.py
+++ b/scripts/bench_dark_cycle_heuristic.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Compare dark-hours scoring approaches across 6 moon phases.
+
+  Brute  – current: two bulk find_discrete (parallel, ~110ms) + 30 narrow
+            find_discrete calls for per-night astronomical twilight (~302ms)
+  A      – keep bulk find_discrete for accurate sun/moon times; replace
+            per-night twilight search with a fixed offset from tonight's
+            sky_events (already cached)
+  B      – full extrapolation from tonight's sky_events — moon drifts by
+            one lunar day (24h 50m 28s) per night, sunset drifts by one
+            solar day; zero Skyfield event searches
+
+Tests 6 dates evenly spaced across one lunar cycle (~5 days apart), run locally.
+Requires: de421.bsp in PyNightSkyPredictor/ and a primed local file cache
+          (sky_events will be cold on first run, warm on repeat runs).
+
+Usage:
+  source .venv/bin/activate
+  python scripts/bench_dark_cycle_heuristic.py
+"""
+
+import concurrent.futures
+import sys
+import time
+from datetime import date, datetime, timedelta, timezone
+
+from zoneinfo import ZoneInfo
+from skyfield import almanac
+from skyfield.api import load, wgs84
+
+sys.path.insert(0, ".")
+from PyNightSkyPredictor import sky_events as se
+from PyNightSkyPredictor.sky_events import (
+    _compute_dark_hours_cycle,
+    _dark_stats,
+    dark_moon_intervals,
+    find_event,
+)
+
+# ── Locations ─────────────────────────────────────────────────────────────────
+LOCS = [
+    ("Denver  CO", 39.74, -104.98, ZoneInfo("America/Denver")),
+    ("Seattle WA", 47.61, -122.33, ZoneInfo("America/Los_Angeles")),
+    ("Miami   FL", 25.77,  -80.19, ZoneInfo("America/New_York")),
+]
+
+# ── 6 dates evenly across one lunar cycle ─────────────────────────────────────
+BASE  = date(2026, 6, 27)
+DATES = [BASE + timedelta(days=i * 5) for i in range(6)]
+
+# Moon rises/sets ~50m 28s later each night on average
+LUNAR_DAY_SECS = 24 * 3600 + 50 * 60 + 28
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def moon_phase_label(d: date) -> str:
+    ts  = load.timescale()
+    eph = se._ephemeris()
+    deg = almanac.moon_phase(eph, ts.utc(d.year, d.month, d.day, 12)).degrees
+    labels = [
+        (22.5,  "New"),
+        (67.5,  "Wax Crescent"),
+        (112.5, "First Quarter"),
+        (157.5, "Wax Gibbous"),
+        (202.5, "Full"),
+        (247.5, "Wan Gibbous"),
+        (292.5, "Last Quarter"),
+        (337.5, "Wan Crescent"),
+    ]
+    for threshold, name in labels:
+        if deg < threshold:
+            return name
+    return "New"
+
+
+def max_drift(brute_hrs, other_hrs):
+    return max(abs(a - b) for a, b in zip(brute_hrs, other_hrs))
+
+
+# ── Approach: Brute (current) ─────────────────────────────────────────────────
+
+def run_brute(lat, lon, tz, d):
+    t0 = time.monotonic()
+    hrs = _compute_dark_hours_cycle(lat, lon, d, tz)
+    ms  = round((time.monotonic() - t0) * 1000)
+    return _dark_stats(hrs, 14), hrs, ms
+
+
+# ── Approach A: bulk find_discrete + fixed twilight offset ────────────────────
+
+def run_a(lat, lon, tz, target_date):
+    t0 = time.monotonic()
+
+    eph      = se._ephemeris()
+    ts       = load.timescale()
+    observer = wgs84.latlon(lat, lon)
+
+    d0    = target_date - timedelta(days=15)
+    d1    = target_date + timedelta(days=17)
+    t0_sf = ts.utc(d0.year, d0.month, d0.day)
+    t1_sf = ts.utc(d1.year, d1.month, d1.day)
+
+    f_hor  = almanac.risings_and_settings(eph, eph["sun"],  observer, horizon_degrees=-0.8333)
+    f_moon = almanac.risings_and_settings(eph, eph["moon"], observer)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        hf = pool.submit(almanac.find_discrete, t0_sf, t1_sf, f_hor)
+        mf = pool.submit(almanac.find_discrete, t0_sf, t1_sf, f_moon)
+        hor_times,  hor_r  = hf.result()
+        moon_times, moon_r = mf.result()
+
+    all_ev = []
+    for t, r in zip(hor_times, hor_r):
+        all_ev.append({"time": t.utc_datetime(), "label": "Sunrise" if r else "Sunset"})
+    for t, r in zip(moon_times, moon_r):
+        all_ev.append({"time": t.utc_datetime(), "label": "Moonrise" if r else "Moonset"})
+    all_ev.sort(key=lambda e: e["time"])
+
+    # Twilight offsets from tonight's cached sky_events
+    sky_ev = se.sky_events(lat, lon, target_date)
+    t_set  = next((e["time"] for e in sky_ev
+                   if e["label"] == "Sunset"
+                   and e["time"].astimezone(tz).date() == target_date), None)
+    t_rise = find_event(sky_ev, "Sunrise", after=t_set)                    if t_set else None
+    t_nb   = find_event(sky_ev, "Astronomical night begins", after=t_set)  if t_set else None
+    t_ne   = find_event(sky_ev, "Astronomical night ends",   after=t_nb or t_set) if t_set else None
+
+    tw_after  = (t_nb   - t_set ).total_seconds() if (t_set and t_nb)   else None
+    tw_before = (t_rise - t_ne  ).total_seconds() if (t_rise and t_ne)  else None
+
+    dark_hours = []
+    for offset in range(-14, 16):
+        night_date = target_date + timedelta(days=offset)
+        sunset = next(
+            (e["time"] for e in all_ev
+             if e["label"] == "Sunset"
+             and e["time"].astimezone(tz).date() == night_date),
+            None,
+        )
+        if not sunset or tw_after is None or tw_before is None:
+            dark_hours.append(0.0)
+            continue
+        sunrise = find_event(all_ev, "Sunrise", after=sunset)
+        if not sunrise:
+            dark_hours.append(0.0)
+            continue
+
+        night_start = sunset  + timedelta(seconds=tw_after)
+        night_end   = sunrise - timedelta(seconds=tw_before)
+        if night_end <= night_start:
+            dark_hours.append(0.0)
+            continue
+
+        ivs = dark_moon_intervals(all_ev, night_start, night_end)
+        dark_hours.append(sum((e - s).total_seconds() for s, e in ivs) / 3600)
+
+    ms = round((time.monotonic() - t0) * 1000)
+    return _dark_stats(dark_hours, 14), dark_hours, ms
+
+
+# ── Approach B: full extrapolation from tonight's sky_events ─────────────────
+
+def run_b(lat, lon, tz, target_date):
+    t0 = time.monotonic()
+
+    sky_ev = se.sky_events(lat, lon, target_date)
+
+    # Tonight's anchor times
+    t_set  = next((e["time"] for e in sky_ev
+                   if e["label"] == "Sunset"
+                   and e["time"].astimezone(tz).date() == target_date), None)
+    t_rise = find_event(sky_ev, "Sunrise", after=t_set)                    if t_set else None
+    t_nb   = find_event(sky_ev, "Astronomical night begins", after=t_set)  if t_set else None
+    t_ne   = find_event(sky_ev, "Astronomical night ends",   after=t_nb or t_set) if t_set else None
+
+    if not all([t_set, t_rise, t_nb, t_ne]):
+        # No astronomical night tonight — can't extrapolate (e.g. high lat in summer)
+        ms = round((time.monotonic() - t0) * 1000)
+        return ({"tonight_hours": 0.0, "mean_hours": 0.0,
+                 "stdev_hours": 0.0, "score": 0.0},
+                [0.0] * 30, ms)
+
+    tw_after  = (t_nb   - t_set ).total_seconds()  # sunset → astro night start
+    tw_before = (t_rise - t_ne  ).total_seconds()  # astro night end → sunrise
+
+    # Best moonrise/moonset anchor: event closest to tonight's sunset
+    lo = t_set  - timedelta(hours=24)
+    hi = t_rise + timedelta(hours=24)
+    mr_list = [e["time"] for e in sky_ev if e["label"] == "Moonrise" and lo <= e["time"] <= hi]
+    ms_list = [e["time"] for e in sky_ev if e["label"] == "Moonset"  and lo <= e["time"] <= hi]
+    anchor_mr = min(mr_list, key=lambda t: abs((t - t_set).total_seconds()), default=None)
+    anchor_ms = min(ms_list, key=lambda t: abs((t - t_set).total_seconds()), default=None)
+
+    SOLAR = 86400.0
+    LUNAR = float(LUNAR_DAY_SECS)
+
+    dark_hours = []
+    for offset in range(-14, 16):
+        sunset  = t_set  + timedelta(seconds=offset * SOLAR)
+        sunrise = t_rise + timedelta(seconds=offset * SOLAR)
+
+        night_start = sunset  + timedelta(seconds=tw_after)
+        night_end   = sunrise - timedelta(seconds=tw_before)
+        if night_end <= night_start:
+            dark_hours.append(0.0)
+            continue
+
+        # Build synthetic moon events: ±1 lunar day around target offset so that
+        # dark_moon_intervals can determine moon_up state at night_start correctly.
+        moon_ev = []
+        for label, anchor in [("Moonrise", anchor_mr), ("Moonset", anchor_ms)]:
+            if anchor is None:
+                continue
+            for adj in (-1, 0, 1):
+                moon_ev.append({
+                    "time":  anchor + timedelta(seconds=(offset + adj) * LUNAR),
+                    "label": label,
+                })
+        moon_ev.sort(key=lambda e: e["time"])
+
+        ivs = dark_moon_intervals(moon_ev, night_start, night_end)
+        dark_hours.append(sum((e - s).total_seconds() for s, e in ivs) / 3600)
+
+    ms_el = round((time.monotonic() - t0) * 1000)
+    return _dark_stats(dark_hours, 14), dark_hours, ms_el
+
+
+# ── Output ────────────────────────────────────────────────────────────────────
+
+HDR = ("  {:<12}  {:<14}  {:>5}  {:>5}  {:>5}  "
+       "{:>5}  {:>5}  {:>5}  "
+       "{:>6}  {:>6}  "
+       "{:>6}  {:>5}  {:>5}  {:>4}")
+ROW = ("  {:<12}  {:<14}  {:>5.1f}  {:>5.1f}  {:>5.1f}  "
+       "{:>5.2f}  {:>5.2f}  {:>5.2f}  "
+       "{:>+6.2f}  {:>+6.2f}  "
+       "{:>5.2f}h  {:>3}ms  {:>3}ms  {:>2}ms")
+
+def print_loc(loc_name, rows):
+    print(f"\n{'═'*110}")
+    print(f"  {loc_name}")
+    print(f"{'─'*110}")
+    print(HDR.format(
+        "Date", "Phase",
+        "Score", "A", "B",
+        "Hrs", "A", "B",
+        "B Δscore", "B Δhrs",
+        "B Δmax", "Brute", "A", "B",
+    ))
+    print(HDR.format(
+        "────────────", "──────────────",
+        "─────", "─────", "─────",
+        "─────", "─────", "─────",
+        "──────", "──────",
+        "──────", "─────", "───", "──",
+    ))
+    for row in rows:
+        print(ROW.format(*row))
+
+
+def main():
+    print(f"Dates: {[str(d) for d in DATES]}")
+    print("Pre-warming sky_events cache for all dates/locations...")
+    for _, lat, lon, tz in LOCS:
+        for d in DATES:
+            se.sky_events(lat, lon, d)
+    print("Cache warm.\n")
+
+    for loc_name, lat, lon, tz in LOCS:
+        rows = []
+        for d in DATES:
+            phase = moon_phase_label(d)
+            print(f"  {loc_name}  {d}  {phase:<14} ...", end="\r", flush=True)
+
+            b_stats,  b_hrs,  b_ms  = run_brute(lat, lon, tz, d)
+            a_stats,  a_hrs,  a_ms  = run_a(lat, lon, tz, d)
+            bb_stats, bb_hrs, bb_ms = run_b(lat, lon, tz, d)
+
+            b_delta_score = bb_stats["score"]         - b_stats["score"]
+            b_delta_hrs   = bb_stats["tonight_hours"] - b_stats["tonight_hours"]
+            b_max_drift   = max_drift(b_hrs, bb_hrs)
+
+            rows.append((
+                str(d), phase,
+                b_stats["score"],  a_stats["score"],  bb_stats["score"],
+                b_stats["tonight_hours"], a_stats["tonight_hours"], bb_stats["tonight_hours"],
+                b_delta_score, b_delta_hrs,
+                b_max_drift,
+                b_ms, a_ms, bb_ms,
+            ))
+
+        print_loc(loc_name, rows)
+
+    print(f"\n{'═'*110}")
+    print("  Score  = 0-10 (tonight / cycle_max × 10).")
+    print("  Hrs    = tonight's dark hours (astronomical night, moon below horizon).")
+    print("  B Δ*   = approach B minus Brute (score and tonight_hours).")
+    print("  B Δmax = max absolute dark-hours drift across all 30 nights in the window.")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `_compute_dark_hours_cycle` previously ran 30 serial `find_discrete` calls for per-night astronomical twilight (sun at −18°) — ~300 ms of the ~410 ms cold compute
- Replaced with a fixed offset derived from tonight's `sky_events` (already a warm in-process cache hit by the time `lunar_cycle_dark_analysis` is called in `assemble_night`)
- The two parallel bulk `find_discrete` calls for sun/moon rise/set are kept — they provide accurate per-night sunset/sunrise and moonrise/moonset across the full 32-day window

## Benchmark (30 dates × full lunar cycle × 3 locations)

| Location | Brute cold | A cold | Speedup | Score drift | Array drift max |
|---|---|---|---|---|---|
| Denver CO (39.7°N) | ~345 ms | ~69 ms | 80% | ≤ 0.1 | 0.25 h |
| Miami FL (25.8°N) | ~350 ms | ~69 ms | 80% | ≤ 0.1 | 0.11 h |
| Seattle WA (47.6°N) | ~347 ms | ~69 ms | 80% | ≤ 1.0 | 0.75 h |

Seattle's worst case (1.0 score drift) occurs near the summer solstice where twilight duration is changing fastest (~3–4 min/day). At all latitudes, tonight's `hours` are exact.

## Test plan

- [x] 551 passed, 7 skipped — full offline suite green
- [ ] After deploy, confirm `[profile] lunar_cycle_ms` drops from ~410 ms to ~110 ms in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)