### PR TITLE
Add DynamoDB bortle cache; revert persistent tile cache

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -443,10 +443,16 @@ def lookup(lat: float, lon: float) -> dict | None:
     if _cache_key in _bortle_mem_cache:
         return _bortle_mem_cache[_cache_key]
 
-    # Fetch both rasters in parallel: on a cold container this overlaps the two
-    # S3 pixel GETs (and the two grid-open JSON GETs if not yet cached in-process).
-    # On a warm container the in-process grid cache is already hot so the only cost
-    # is two concurrent 4-byte ranged GETs vs one serial pair.
+    # DynamoDB cache: light pollution is static, so no TTL.
+    # Warm containers hit _bortle_mem_cache above; this layer covers cold containers
+    # that haven't seen this location yet, eliminating the S3 reads entirely.
+    _db_key = f"bortle|{_cache_key[0]:.2f}|{_cache_key[1]:.2f}"
+    _db_result = cache.get(_db_key)
+    if _db_result is not None:
+        _bortle_mem_cache[_cache_key] = _db_result
+        return _db_result
+
+    # S3 fetch (parallel VIIRS + Falchi).
     with ThreadPoolExecutor(max_workers=2) as _pool:
         _viirs_f  = _pool.submit(_viirs_radiance,  lat, lon)
         _falchi_f = _pool.submit(_falchi_luminance, lat, lon)
@@ -468,6 +474,10 @@ def lookup(lat: float, lon: float) -> dict | None:
             "source":         "VIIRS 2025",
         }
         _bortle_mem_cache[_cache_key] = result
+        try:
+            cache.set(_db_key, result)
+        except Exception as _e:
+            log.debug("bortle cache write failed: %s", _e)
         return result
 
     if radiance is None:
@@ -494,6 +504,10 @@ def lookup(lat: float, lon: float) -> dict | None:
         "source":         "Falchi 2016",
     }
     _bortle_mem_cache[_cache_key] = result
+    try:
+        cache.set(_db_key, result)
+    except Exception as _e:
+        log.debug("bortle cache write failed: %s", _e)
     return result
 
 

--- a/PyNightSkyPredictor/gridraster.py
+++ b/PyNightSkyPredictor/gridraster.py
@@ -65,10 +65,6 @@ class GridArray:
         self.x_res = float(meta["x_res"])
         self.y_res = float(meta["y_res"])
         self._tile_elems = self.tile * self.tile
-        # In-process tile cache: keyed by (ty, tx). S3 charges the same RTT for
-        # 4 bytes as for a full 512×512 tile (~1 MB), so we fetch the whole tile
-        # on first access and serve all subsequent pixel reads from memory.
-        self._tile_cache: dict[tuple[int, int], np.ndarray] = {}
 
     # ── coordinate ↔ pixel ────────────────────────────────────────────────────
     def _colrow(self, lat: float, lon: float) -> tuple[int, int]:
@@ -80,21 +76,10 @@ class GridArray:
 
     # ── tile fetch ────────────────────────────────────────────────────────────
     def _read_tile(self, ty: int, tx: int) -> np.ndarray:
-        """Return one tile as a (tile, tile) float32 array.
-
-        First call fetches the full tile from S3 (one ranged GET, ~1 MB) and stores
-        it in _tile_cache. Subsequent calls for the same tile return from memory.
-        Two threads racing on the same cold tile each fetch and store — the second
-        write is harmless (identical data, dict assignment is GIL-atomic)."""
-        key = (ty, tx)
-        cached = self._tile_cache.get(key)
-        if cached is not None:
-            return cached
+        """Return one tile as a (tile, tile) float32 array — one ranged GET on S3."""
         tile_id = ty * self.tiles_x + tx
         flat = self._read_elems(tile_id * self._tile_elems, self._tile_elems)
-        tile = flat.reshape(self.tile, self.tile).astype(np.float32)
-        self._tile_cache[key] = tile
-        return tile
+        return flat.reshape(self.tile, self.tile).astype(np.float32)
 
     def _read_block(self, r0: int, r1: int, c0: int, c1: int) -> np.ndarray:
         """Read the in-bounds raster sub-array [r0:r1, c0:c1] (all within the grid).
@@ -135,7 +120,9 @@ class GridArray:
                 return 0.0                                         # rasterio: outside → nodata → 0
             tx, ty = col // self.tile, row // self.tile
             rit, cit = row - ty * self.tile, col - tx * self.tile
-            value = float(self._read_tile(ty, tx)[rit, cit])
+            tile_id = ty * self.tiles_x + tx
+            elem_off = tile_id * self._tile_elems + rit * self.tile + cit
+            value = float(self._read_elems(elem_off, 1)[0])
             if self.nodata is not None and abs(value - self.nodata) < 1.0:
                 return 0.0
             return max(value, 0.0)


### PR DESCRIPTION
## Summary

**DynamoDB bortle cache** (`darksky.py`)
`lookup()` now checks `bortle|{lat:.2f}|{lon:.2f}` in DynamoDB (no TTL — light pollution is static) before hitting S3. Cache hit path:
- Warm container → `_bortle_mem_cache` (in-process dict, no I/O)
- Cold container, seen location → DynamoDB hit, ~5ms, no S3
- Cold container, new location → parallel S3 reads, write to DynamoDB once

**Revert persistent tile cache** (`gridraster.py`)
The tile cache from PR #70 held ~1MB numpy arrays per unique tile touched, indefinitely, with no eviction. The bortle result (a small dict) is the right caching granularity for cross-container reuse.

## Test plan
- [x] `pytest -q` — 551 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)