### PR TITLE
fix: warmup EventBridge rule crashes Mangum — send synthetic Function URL v2 payload

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -153,13 +153,44 @@ class LambdaApiStack(Stack):
         )
 
         # --- Scheduled warmup ping — keeps one container alive, prevents cold starts ---
-        # EventBridge invokes Lambda directly every 4 minutes; LWA converts to POST /warmup.
+        # EventBridge invokes Lambda directly every 4 minutes with a synthetic Function URL
+        # v2.0 payload so Mangum can infer the HTTPGateway handler (raw EB events have no
+        # requestContext and crash Mangum before any code runs).
         # Cost: ~10,800 invocations/month + ~1,620 GB-s — both within Lambda free tier.
         warmup_rule = events.Rule(
             self, "WarmupRule",
             schedule=events.Schedule.rate(Duration.minutes(4)),
         )
-        warmup_rule.add_target(targets.LambdaFunction(fn))
+        warmup_rule.add_target(targets.LambdaFunction(
+            fn,
+            event=events.RuleTargetInput.from_object({
+                "version": "2.0",
+                "routeKey": "POST /warmup",
+                "rawPath": "/warmup",
+                "rawQueryString": "",
+                "headers": {
+                    "host": "warmup.internal",
+                    "x-forwarded-proto": "https",
+                },
+                "requestContext": {
+                    "accountId": "warmup",
+                    "apiId": "warmup",
+                    "domainName": "warmup.internal",
+                    "http": {
+                        "method": "POST",
+                        "path": "/warmup",
+                        "protocol": "HTTP/1.1",
+                        "sourceIp": "127.0.0.1",
+                        "userAgent": "EventBridge/warmup",
+                    },
+                    "requestId": "warmup",
+                    "routeKey": "$default",
+                    "stage": "$default",
+                    "timeEpoch": 0,
+                },
+                "isBase64Encoded": False,
+            }),
+        ))
 
         # least-privilege data access (reference foundational resources)
         bucket = s3.Bucket.from_bucket_name(self, "RasterBucket", raster_bucket)


### PR DESCRIPTION
## Problem

The API Lambda (`PyNightSkyLambda-ApiF70053CD-B1Hd20YcsiTr`) was showing a ~48–100% error rate in CloudWatch. Every invocation from the EventBridge warmup rule was failing with:

```
RuntimeError: The adapter was unable to infer a handler to use for the event.
  File "/var/task/mangum/adapter.py", line 54, in infer
```

## Root cause

The warmup `events.Rule` was invoking the Lambda with **no custom input**, so EventBridge delivered its default event structure (fields: `source`, `detail-type`, `detail`, etc.). Mangum's `HTTPGateway` handler requires `version` + `requestContext` to match; the bare EB event has neither, so every warmup ping crashed before executing any application code.

The CDK comment claimed "LWA converts to POST /warmup" but Lambda Web Adapter was never attached (`Layers: null`), so the conversion never happened.

Real CloudFront traffic (Function URL v2.0 events) was unaffected — confirmed by direct invocation tests.

## Fix

Pass a synthetic Function URL v2.0 payload as the `RuleTargetInput` on the EventBridge target. Mangum's `HTTPGateway` handler matches on `version: "2.0"` + `requestContext`, routes to the existing `POST /warmup` handler, and returns `200 {"warm": true}`.

Verified against the live Lambda before this PR:
```
POST /warmup 200  (14 ms, 1161 MB used)
{"warm": true}
```

## Reviewer notes

- No application code changes — only `cdk/lambda_api_stack.py`.
- Deploy via the normal squash-merge → CI → `cdk deploy` flow. Error rate drops to zero within one warmup cycle (~4 min after deploy).
- The stale LWA comment is replaced with an accurate description of the synthetic payload approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)