### PR TITLE
Restore calendar outlook with cached scoring, dedup nearby/calendar requests

### DIFF
--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -394,12 +394,22 @@ def assemble_night(
     fetch_weather: bool = True,
     fetch_targets: bool = False,
     fetch_satellites: bool = False,
+    use_cycle_window: bool = False,
 ) -> NightReport:
     """
     Compute a complete NightReport for the given location and date.
 
     Raises ValueError if no sunset or sunrise can be found for the
     date/location (e.g. polar day/night).
+
+    use_cycle_window=True (calendar/trip path only — /night and the CLI leave
+    this False): derive sunset/sunrise/night_start/night_end/dark_hours_tonight
+    from lunar_cycle_dark_analysis()'s already-computed 30-night window instead
+    of an independent sky_events() call. No event timeline, no moonrise/moonset —
+    NightSummary (the calendar path's result type) doesn't carry any of those.
+    This extends the same fixed-twilight-offset approximation dark_score already
+    accepts (see sky_events.py) to moon_score/weather-windowing too, but only
+    for this path; output is otherwise unaffected.
     """
     def _local(dt):
         return dt.astimezone(tz)
@@ -457,32 +467,59 @@ def assemble_night(
                 _sl_future = _pool.submit(_tle_mod.get_starlink_train_tles)
 
         # --- Skyfield work runs concurrently with the I/O threads above ---
-        events = se.sky_events(lat, lon, target)
-        _t["sky_events_ms"] = round((time.monotonic() - _t0) * 1000)
+        _precomputed_dark_hours_tonight = None
+        cycle = None
+        if use_cycle_window:
+            # Calendar/trip path: reuse the (already-deduplicated across a calendar
+            # range — see sky_events.py's per-location lock) dark-cycle window
+            # instead of an independent sky_events() call.
+            _t["sky_events_ms"] = 0
+            _tc = time.monotonic()
+            cycle      = se.lunar_cycle_dark_analysis(lat, lon, target, tz)
+            dark_score = cycle["score"]
+            _t["lunar_cycle_ms"] = round((time.monotonic() - _tc) * 1000)
 
-        # --- Key event times ---
-        _tc = time.monotonic()
-        sunset = next(
-            (e["time"] for e in events
-             if e["label"] == "Sunset" and _local(e["time"]).date() == target),
-            None,
-        )
-        if not sunset:
-            raise ValueError(f"No sunset found for {target} at {lat:.4f}, {lon:.4f}")
+            tonight = cycle["tonight"]
+            sunset  = tonight["sunset"]
+            if not sunset:
+                raise ValueError(f"No sunset found for {target} at {lat:.4f}, {lon:.4f}")
+            sunrise = tonight["sunrise"]
+            if not sunrise:
+                raise ValueError(f"No sunrise found after sunset on {target}")
 
-        sunrise = se.find_event(events, "Sunrise", after=sunset)
-        if not sunrise:
-            raise ValueError(f"No sunrise found after sunset on {target}")
+            moonrise = moonset = None
+            night_start = tonight["night_start"]
+            night_end   = tonight["night_end"]
+            night_events = []
+            _precomputed_dark_hours_tonight = tonight["dark_hours"]
+            _tc = time.monotonic()  # for the event_parse_ms line below (~0ms here)
+        else:
+            events = se.sky_events(lat, lon, target)
+            _t["sky_events_ms"] = round((time.monotonic() - _t0) * 1000)
 
-        moonrise    = se.find_last_event(events, "Moonrise", before=sunrise)
-        moonset     = se.find_event(events, "Moonset", after=sunset)
-        night_start = se.find_event(events, "Astronomical night begins", after=sunset, before=sunrise)
-        night_end   = se.find_event(events, "Astronomical night ends",   after=night_start or sunset, before=sunrise)
+            # --- Key event times ---
+            _tc = time.monotonic()
+            sunset = next(
+                (e["time"] for e in events
+                 if e["label"] == "Sunset" and _local(e["time"]).date() == target),
+                None,
+            )
+            if not sunset:
+                raise ValueError(f"No sunset found for {target} at {lat:.4f}, {lon:.4f}")
 
-        # Events within the display window (sunset/moonrise → sunrise/moonset)
-        window_start = min(sunset, moonrise) if moonrise and moonrise < sunset else sunset
-        window_end   = max(sunrise, moonset) if moonset  and moonset  > sunrise else sunrise
-        night_events = [e for e in events if window_start <= e["time"] <= window_end]
+            sunrise = se.find_event(events, "Sunrise", after=sunset)
+            if not sunrise:
+                raise ValueError(f"No sunrise found after sunset on {target}")
+
+            moonrise    = se.find_last_event(events, "Moonrise", before=sunrise)
+            moonset     = se.find_event(events, "Moonset", after=sunset)
+            night_start = se.find_event(events, "Astronomical night begins", after=sunset, before=sunrise)
+            night_end   = se.find_event(events, "Astronomical night ends",   after=night_start or sunset, before=sunrise)
+
+            # Events within the display window (sunset/moonrise → sunrise/moonset)
+            window_start = min(sunset, moonrise) if moonrise and moonrise < sunset else sunset
+            window_end   = max(sunrise, moonset) if moonset  and moonset  > sunrise else sunrise
+            night_events = [e for e in events if window_start <= e["time"] <= window_end]
 
         _t["event_parse_ms"] = round((time.monotonic() - _tc) * 1000)
 
@@ -496,8 +533,15 @@ def assemble_night(
 
         # --- Dark intervals ---
         if night_start and night_end:
-            intervals          = se.dark_moon_intervals(events, night_start, night_end)
-            dark_hours_tonight = sum((e - s).total_seconds() for s, e in intervals) / 3600
+            if _precomputed_dark_hours_tonight is not None:
+                # use_cycle_window path: already computed by the dark-cycle window
+                # loop (which folds moonrise/moonset into this scalar internally —
+                # see sky_events.py); NightSummary doesn't need the raw intervals.
+                dark_hours_tonight = _precomputed_dark_hours_tonight
+                intervals = []
+            else:
+                intervals          = se.dark_moon_intervals(events, night_start, night_end)
+                dark_hours_tonight = sum((e - s).total_seconds() for s, e in intervals) / 3600
             total_astro_hours  = (night_end - night_start).total_seconds() / 3600
 
             # Moon score: weight moonlit fraction by K&S sky-brightening credit rather
@@ -534,10 +578,13 @@ def assemble_night(
             moon_score             = round(10 * ks_moon_credit(illumination), 1)
 
         # --- Lunar cycle dark analysis ---
-        _tc = time.monotonic()
-        cycle      = se.lunar_cycle_dark_analysis(lat, lon, target, tz)
-        dark_score = cycle["score"]
-        _t["lunar_cycle_ms"] = round((time.monotonic() - _tc) * 1000)
+        # (already computed above for the use_cycle_window path — cycle/dark_score
+        # were set together with sunset/sunrise/night_start/night_end in that case)
+        if cycle is None:
+            _tc = time.monotonic()
+            cycle      = se.lunar_cycle_dark_analysis(lat, lon, target, tz)
+            dark_score = cycle["score"]
+            _t["lunar_cycle_ms"] = round((time.monotonic() - _tc) * 1000)
 
         # --- Collect I/O (weather + darksky started at function entry) ---
         _tc = time.monotonic()

--- a/PyNightSkyPredictor/sky_events.py
+++ b/PyNightSkyPredictor/sky_events.py
@@ -3,11 +3,12 @@
 
 import concurrent.futures as _futures
 import json
+import threading
 import time as _time
 import logging
 import math
 import statistics
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from skyfield.api import Loader, load, wgs84
@@ -161,9 +162,83 @@ def dark_moon_intervals(events: list, night_start, night_end) -> list:
 # entirely for locations already computed in this container's lifetime.
 _mem_dark_cycle: dict[str, dict] = {}
 
+# Per-location locks serialize the expensive Skyfield compute path in
+# lunar_cycle_dark_analysis. Without this, a /calendar request dispatches
+# ~20 nights at once to a shared thread pool, and every one of them misses
+# the still-empty cache and redundantly computes its own ~30-night window
+# (profiling: 20/30 calls paying the full ~3s cost instead of ~1-3). The
+# lock lets concurrent callers wait for an in-flight computation and reuse
+# it via the overlap check below, instead of racing past it.
+_dark_cycle_locks: dict[str, threading.Lock] = {}
+_dark_cycle_locks_guard = threading.Lock()
+
+
+def _dark_cycle_lock_for(lat: float, lon: float) -> threading.Lock:
+    key = f"{lat:.2f},{lon:.2f}"
+    with _dark_cycle_locks_guard:
+        lock = _dark_cycle_locks.get(key)
+        if lock is None:
+            lock = _dark_cycle_locks[key] = threading.Lock()
+        return lock
+
+
+def _dark_cycle_overlap_hit(loc_prefix: str, target_date: date) -> dict | None:
+    """Dark stats from any cached window for this location that covers target_date."""
+    for mk, entry in _mem_dark_cycle.items():
+        if not mk.startswith(loc_prefix):
+            continue
+        cached_ws  = date.fromisoformat(entry["window_start"])
+        cached_end = cached_ws + timedelta(days=len(entry["nights"]) - 1)
+        if cached_ws <= target_date <= cached_end:
+            tonight_idx = (target_date - cached_ws).days
+            log.debug("Dark cycle mem-cache hit (overlap) for %s idx %d", mk, tonight_idx)
+            return _dark_stats(entry["nights"], tonight_idx)
+    return None
+
 
 def _dark_cycle_db_key(lat: float, lon: float, window_start: date) -> str:
-    return f"dark_cycle|{lat:.2f}|{lon:.2f}|{window_start.isoformat()}"
+    # v2: each night is a record (sunset/sunrise/night_start/night_end/dark_hours)
+    # instead of a bare dark-hours float, so assemble_night()'s calendar path can
+    # derive moon_score/weather-windowing inputs from this window instead of an
+    # independent sky_events() call.
+    return f"dark_cycle_v2|{lat:.2f}|{lon:.2f}|{window_start.isoformat()}"
+
+
+def _nights_to_json(nights: list[dict]) -> list[dict]:
+    """Serialize a per-night dark-cycle window for cache storage (datetimes -> ISO strings)."""
+    def _iso(t):
+        return t.isoformat() if t is not None else None
+    return [
+        {
+            "sunset":      _iso(n["sunset"]),
+            "sunrise":     _iso(n["sunrise"]),
+            "night_start": _iso(n["night_start"]),
+            "night_end":   _iso(n["night_end"]),
+            "dark_hours":  n["dark_hours"],
+        }
+        for n in nights
+    ]
+
+
+def _nights_from_json(raw: list[dict]) -> list[dict]:
+    """Restore a per-night dark-cycle window from cache storage (ISO strings -> datetimes)."""
+    def _dt(s):
+        if s is None:
+            return None
+        t = datetime.fromisoformat(s)
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+        return t
+    return [
+        {
+            "sunset":      _dt(n["sunset"]),
+            "sunrise":     _dt(n["sunrise"]),
+            "night_start": _dt(n["night_start"]),
+            "night_end":   _dt(n["night_end"]),
+            "dark_hours":  n["dark_hours"],
+        }
+        for n in raw
+    ]
 
 
 def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> list:
@@ -232,12 +307,17 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
     tw_after  = (_t_nb   - _t_set ).total_seconds() if (_t_set and _t_nb)   else None
     tw_before = (_t_rise - _t_ne  ).total_seconds() if (_t_rise and _t_ne)  else None
 
+    # Sanity bound for the fixed twilight-offset approximation applied below: a
+    # real astronomical-twilight duration is minutes to a couple hours, never
+    # anywhere close to this. If it ever is, something's wrong with the inputs
+    # (e.g. bad ephemeris data) — log it and treat that night as degenerate
+    # rather than silently emit a night_start/night_end that could have drifted
+    # onto the wrong calendar day.
+    _MAX_SANE_TWILIGHT_OFFSET_S = 6 * 3600
+
     _t_loop0 = _time.monotonic()
-    hours = []
+    nights = []
     for offset in range(-14, 16):
-        if tw_after is None or tw_before is None:
-            hours.append(0.0)
-            continue
         night_date = target_date + timedelta(days=offset)
         sunset = next(
             (e["time"] for e in all_events
@@ -245,34 +325,59 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
              and e["time"].astimezone(tz).date() == night_date),
             None,
         )
-        if not sunset:
-            hours.append(0.0)
-            continue
-        sunrise = find_event(all_events, "Sunrise", after=sunset)
-        if not sunrise:
-            hours.append(0.0)
-            continue
+        sunrise = find_event(all_events, "Sunrise", after=sunset) if sunset else None
 
-        night_start = sunset  + timedelta(seconds=tw_after)
-        night_end   = sunrise - timedelta(seconds=tw_before)
-        if night_end <= night_start:
-            hours.append(0.0)
-            continue
-        intervals  = dark_moon_intervals(all_events, night_start, night_end)
-        total_secs = sum((e - s).total_seconds() for s, e in intervals)
-        hours.append(total_secs / 3600)
+        night_start = night_end = None
+        dark_hours  = 0.0
+        if (sunset and sunrise and tw_after is not None and tw_before is not None
+                and tw_after <= _MAX_SANE_TWILIGHT_OFFSET_S
+                and tw_before <= _MAX_SANE_TWILIGHT_OFFSET_S):
+            night_start = sunset  + timedelta(seconds=tw_after)
+            night_end   = sunrise - timedelta(seconds=tw_before)
+            if night_end > night_start:
+                intervals  = dark_moon_intervals(all_events, night_start, night_end)
+                total_secs = sum((e - s).total_seconds() for s, e in intervals)
+                dark_hours = total_secs / 3600
+            else:
+                # Degenerate window (offset pushed past a real boundary) — don't
+                # expose a night_start/night_end that's no longer meaningful.
+                log.warning(
+                    "dark_cycle: degenerate window for %s at offset %+d (night_end <= night_start)",
+                    night_date, offset,
+                )
+                night_start = night_end = None
+        elif tw_after is not None and (
+                tw_after > _MAX_SANE_TWILIGHT_OFFSET_S or (tw_before or 0) > _MAX_SANE_TWILIGHT_OFFSET_S):
+            log.warning("dark_cycle: implausible twilight offset for %s (tw_after=%s tw_before=%s) — skipping",
+                        night_date, tw_after, tw_before)
+
+        nights.append({
+            "sunset":      sunset,
+            "sunrise":     sunrise,
+            "night_start": night_start,
+            "night_end":   night_end,
+            "dark_hours":  dark_hours,
+        })
 
     log.info("dark_cycle loop=%dms", round((_time.monotonic() - _t_loop0) * 1000))
-    return hours
+    return nights
 
 
-def _dark_stats(dark_hours: list, tonight_idx: int) -> dict:
-    """Derive mean, stdev, and ratio-to-maximum score from a dark-hours array.
+def _dark_stats(nights: list, tonight_idx: int) -> dict:
+    """Derive mean, stdev, and ratio-to-maximum score from a dark-hours window.
 
     Score = tonight / cycle_max × 10.  The best night of the cycle earns 10;
     every other night scales linearly from there.  Zero dark hours = 0.
+
+    Also returns a read-only copy of the requested night's own record (sunset/
+    sunrise/night_start/night_end/dark_hours) so assemble_night()'s calendar
+    path can derive moon_score/weather-windowing inputs from it instead of an
+    independent sky_events() call. A copy, not a reference — nights[tonight_idx]
+    may be a live entry inside the shared _mem_dark_cycle cache.
     """
-    tonight = dark_hours[tonight_idx]
+    dark_hours   = [n["dark_hours"] for n in nights]
+    tonight_rec  = dict(nights[tonight_idx])
+    tonight      = dark_hours[tonight_idx]
     mean_h  = statistics.mean(dark_hours)
     stdev_h = statistics.stdev(dark_hours) if len(dark_hours) > 1 else 0.0
     max_h   = max(dark_hours)
@@ -284,6 +389,7 @@ def _dark_stats(dark_hours: list, tonight_idx: int) -> dict:
         "mean_hours":    round(mean_h,  1),
         "stdev_hours":   round(stdev_h, 1),
         "score":         round(min(10.0, max(0.0, score)), 1),
+        "tonight":       tonight_rec,
     }
 
 
@@ -292,50 +398,65 @@ def lunar_cycle_dark_analysis(lat: float, lon: float, target_date: date, tz) -> 
     Return dark sky stats for a 30-night window centred on target_date.
 
     Three-layer lookup:
-      1. Module-level dict (_mem_dark_cycle) — zero-cost on warm containers.
+      1. Module-level dict (_mem_dark_cycle) — zero-cost on warm containers,
+         including an overlap check: any cached window for this location that
+         covers target_date is reused, not just an exact window_start match.
       2. DynamoDB per-window key — shared across containers, no TTL (astronomical
          data is immutable for a given location+window).
-      3. Compute fresh via Skyfield (~410ms at 3008 MB), then populate both layers.
+      3. Compute fresh via Skyfield (~2-3s at 3008 MB — see scripts/profile_calendar.py),
+         then populate both layers.
+
+    Steps 2-3 run under a per-location lock (_dark_cycle_lock_for) so concurrent
+    callers for overlapping windows wait for an in-flight computation and reuse
+    it via the overlap check, rather than each redundantly computing their own.
     """
     window_start = target_date - timedelta(days=14)
     mem_key      = f"{lat:.2f},{lon:.2f}:{window_start.isoformat()}"
     db_key       = _dark_cycle_db_key(lat, lon, window_start)
+    loc_prefix   = f"{lat:.2f},{lon:.2f}:"
 
     # 1. In-process cache — exact hit
     if mem_key in _mem_dark_cycle:
         log.debug("Dark cycle mem-cache hit (exact) for %s", mem_key)
-        return _dark_stats(_mem_dark_cycle[mem_key]["dark_hours"], 14)
+        return _dark_stats(_mem_dark_cycle[mem_key]["nights"], 14)
 
-    # 1b. In-process cache — overlap: any cached window for this location covers target_date
-    loc_prefix = f"{lat:.2f},{lon:.2f}:"
-    for mk, entry in _mem_dark_cycle.items():
-        if not mk.startswith(loc_prefix):
-            continue
-        cached_ws  = date.fromisoformat(entry["window_start"])
-        cached_end = cached_ws + timedelta(days=len(entry["dark_hours"]) - 1)
-        if cached_ws <= target_date <= cached_end:
-            tonight_idx = (target_date - cached_ws).days
-            log.debug("Dark cycle mem-cache hit (overlap) for %s idx %d", mk, tonight_idx)
-            return _dark_stats(entry["dark_hours"], tonight_idx)
+    # 1b. In-process cache — overlap
+    hit = _dark_cycle_overlap_hit(loc_prefix, target_date)
+    if hit is not None:
+        return hit
 
-    # 2. DynamoDB cache
-    cached = _cache.get(db_key)
-    if cached:
-        log.debug("Dark cycle DynamoDB hit for %s", db_key)
-        _mem_dark_cycle[mem_key] = cached
-        return _dark_stats(cached["dark_hours"], 14)
+    with _dark_cycle_lock_for(lat, lon):
+        # Re-check — a concurrent caller for this location may have just
+        # finished and populated the cache while we were waiting for the lock.
+        if mem_key in _mem_dark_cycle:
+            log.debug("Dark cycle mem-cache hit (exact, post-lock) for %s", mem_key)
+            return _dark_stats(_mem_dark_cycle[mem_key]["nights"], 14)
+        hit = _dark_cycle_overlap_hit(loc_prefix, target_date)
+        if hit is not None:
+            return hit
 
-    # 3. Compute and persist
-    log.debug("Dark cycle cache miss for %s — computing 30-night window", mem_key)
-    dark_hours = _compute_dark_hours_cycle(lat, lon, target_date, tz)
-    entry = {"window_start": window_start.isoformat(), "dark_hours": dark_hours}
-    try:
-        _cache.set(db_key, entry)
-    except Exception as e:
-        log.warning("Dark cycle cache write failed (non-fatal): %s", e)
-    _mem_dark_cycle[mem_key] = entry
+        # 2. DynamoDB cache — stored as ISO strings (json.dumps can't handle
+        # raw datetimes), so parse back into real datetimes before caching
+        # in-process or handing off to _dark_stats.
+        cached = _cache.get(db_key)
+        if cached:
+            log.debug("Dark cycle DynamoDB hit for %s", db_key)
+            nights = _nights_from_json(cached["nights"])
+            _mem_dark_cycle[mem_key] = {"window_start": cached["window_start"], "nights": nights}
+            return _dark_stats(nights, 14)
 
-    return _dark_stats(dark_hours, 14)
+        # 3. Compute and persist
+        log.debug("Dark cycle cache miss for %s — computing 30-night window", mem_key)
+        nights = _compute_dark_hours_cycle(lat, lon, target_date, tz)
+        entry = {"window_start": window_start.isoformat(), "nights": nights}
+        try:
+            _cache.set(db_key, {"window_start": window_start.isoformat(),
+                                "nights": _nights_to_json(nights)})
+        except Exception as e:
+            log.warning("Dark cycle cache write failed (non-fatal): %s", e)
+        _mem_dark_cycle[mem_key] = entry
+
+        return _dark_stats(nights, 14)
 
 
 def moon_phase_info(at_utc: object) -> tuple:

--- a/PyNightSkyPredictor/trip.py
+++ b/PyNightSkyPredictor/trip.py
@@ -137,8 +137,8 @@ def _cache_key(lat: float, lon: float, d: date, with_weather: bool) -> str:
     return f"night_v3:{lat:.4f},{lon:.4f},{d.isoformat()},wx={int(with_weather)}"
 
 
-def _within_forecast_window(d: date) -> bool:
-    return (d - datetime.now(_utc).date()).days <= _FORECAST_DAYS
+def _within_forecast_window(d: date, horizon_days: int = _FORECAST_DAYS) -> bool:
+    return (d - datetime.now(_utc.utc).date()).days <= horizon_days
 
 
 def fetch_night(
@@ -148,15 +148,18 @@ def fetch_night(
     tz: ZoneInfo,
     display_name: str,
     fetch_weather: bool = True,
+    weather_horizon_days: int = _FORECAST_DAYS,
 ) -> NightSummary | None:
     """
     Return a NightSummary for one location and date, using cache where possible.
 
-    Weather is only fetched for dates within the 16-day forecast window;
-    beyond that the score uses astronomical factors only (weights
-    redistribute automatically in rate_night).
+    Weather is only fetched for dates within `weather_horizon_days` (default the
+    16-day Open-Meteo forecast window); beyond that the score uses astronomical
+    factors only (weights redistribute automatically in rate_night). Callers with a
+    stricter product-level cutoff (e.g. the calendar tool's 7-day trust window) can
+    override this per call.
     """
-    use_weather = fetch_weather and _within_forecast_window(d)
+    use_weather = fetch_weather and _within_forecast_window(d, weather_horizon_days)
     key = _cache_key(lat, lon, d, use_weather)
 
     cached = _cache.get(key)
@@ -168,6 +171,7 @@ def fetch_night(
             lat, lon, d, tz,
             display_name=display_name,
             fetch_weather=use_weather,
+            use_cycle_window=True,
         )
     except ValueError as e:
         log.warning("Skipping %s on %s: %s", display_name, d, e)
@@ -210,6 +214,7 @@ def plan_trip(
     date_start: date,
     date_end: date,
     fetch_weather: bool = True,
+    weather_horizon_days: int = _FORECAST_DAYS,
     progress_fn=None,
 ) -> TripReport:
     """
@@ -220,6 +225,8 @@ def plan_trip(
         date_start:   first night of the range
         date_end:     last night of the range (inclusive)
         fetch_weather: include weather for dates within the forecast window
+        weather_horizon_days: per-night cutoff (days from today) for including
+                       weather in the score; defaults to the 16-day forecast window
         progress_fn:  optional callable(completed, total) for progress reporting
 
     Returns:
@@ -233,7 +240,8 @@ def plan_trip(
 
     def _fetch_one(loc, d):
         tz = ZoneInfo(loc["tz_name"])
-        return fetch_night(loc["lat"], loc["lon"], d, tz, loc["display_name"], fetch_weather)
+        return fetch_night(loc["lat"], loc["lon"], d, tz, loc["display_name"],
+                            fetch_weather, weather_horizon_days)
 
     tasks = [
         (loc, date_start + timedelta(days=i))

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,7 +1,7 @@
 """PyNightSky HTTP API — a thin JSON layer over the engine.
 
-Wraps predictor.assemble_night() as FastAPI endpoints, reusing the same
-location/timezone resolution the CLI uses. No engine logic
+Wraps predictor.assemble_night() and trip.plan_trip() as FastAPI endpoints,
+reusing the same location/timezone resolution the CLI uses. No engine logic
 lives here; handlers only resolve inputs, call the engine, and serialize.
 
 Run locally:   uvicorn apps.api.main:app --reload --port 8080
@@ -17,7 +17,7 @@ import os
 import shutil
 import time
 from contextlib import asynccontextmanager
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI, HTTPException, Query
@@ -132,6 +132,8 @@ _MAX_DATE = date(2050, 12, 31)
 _MAX_NAME_LEN = 200                 # geocode query length cap
 _NEARBY_RADIUS_DEFAULT = 60         # /nearby default search radius (miles)
 _NEARBY_RADIUS_MAX = 120            # 10 of 11 sample rings; good density up to ~2.5h drive
+_MAX_CALENDAR_DAYS = 30              # /calendar range-length cap (mirrors old _MAX_TRIP_DAYS)
+_CALENDAR_WEATHER_HORIZON_DAYS = 7   # per-night weather cutoff for the calendar tool specifically
 
 
 # ── health check helpers ──────────────────────────────────────────────────────
@@ -320,6 +322,33 @@ def nearby(
     else:
         raise HTTPException(400, "Provide 'location' or both 'lat' and 'lon'.")
     job_id = jobs.submit({"type": "nearby", "lat": la, "lon": lo, "radius_miles": radius})
+    return _accepted(job_id)
+
+
+@app.get("/calendar")
+def calendar_view(
+    location: str | None = Query(None, max_length=_MAX_NAME_LEN),
+    lat: float | None = Query(None, ge=-90, le=90),
+    lon: float | None = Query(None, ge=-180, le=180),
+    start: str | None = Query(None, description="YYYY-MM-DD; default today"),
+    days: int = Query(7, ge=1, le=_MAX_CALENDAR_DAYS, description="Range length in days"),
+):
+    """Submit a multi-night outlook job for one location → 202 + job_id (poll /jobs/{id}).
+
+    Weather is only included in a night's score within _CALENDAR_WEATHER_HORIZON_DAYS
+    of today; nights further out score on astronomical factors alone.
+    """
+    la, lo, disp, tz = _resolve(location, lat, lon)
+    s = _parse_date(start, "start")
+    e = s + timedelta(days=days - 1)
+    if e > _MAX_DATE:
+        raise HTTPException(400, f"end date {e} is outside the supported ephemeris range.")
+    loc_dict = {"lat": la, "lon": lo, "display_name": disp, "tz_name": str(tz)}
+    job_id = jobs.submit({
+        "type": "calendar", "locs": [loc_dict],
+        "start": s.isoformat(), "end": e.isoformat(),
+        "weather": True, "weather_horizon_days": _CALENDAR_WEATHER_HORIZON_DAYS,
+    })
     return _accepted(job_id)
 
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,7 +1,7 @@
 """PyNightSky HTTP API — a thin JSON layer over the engine.
 
-Wraps predictor.assemble_night() and trip.plan_trip() as FastAPI endpoints,
-reusing the same location/timezone resolution the CLI uses. No engine logic
+Wraps predictor.assemble_night() as FastAPI endpoints, reusing the same
+location/timezone resolution the CLI uses. No engine logic
 lives here; handlers only resolve inputs, call the engine, and serialize.
 
 Run locally:   uvicorn apps.api.main:app --reload --port 8080
@@ -11,8 +11,6 @@ Backend:       PYNIGHTSKY_BACKEND=local (default) or =aws (+ table/bucket env).
 from apps.logging_config import configure as _configure_logging
 _configure_logging()
 
-import calendar as _cal
-import concurrent.futures as _futures
 import functools
 import logging
 import os
@@ -131,8 +129,6 @@ if _xray_enabled:
 # ── input bounds (data sanity + abuse/DoS guards) ────────────────────────────
 _MIN_DATE = date(1900, 1, 1)        # de421.bsp ephemeris coverage (~1900–2050)
 _MAX_DATE = date(2050, 12, 31)
-_MAX_TRIP_DAYS = 30                  # /trip date-range span cap
-_MAX_TRIP_LOCATIONS = 10            # /trip location-count cap
 _MAX_NAME_LEN = 200                 # geocode query length cap
 _NEARBY_RADIUS_DEFAULT = 60         # /nearby default search radius (miles)
 _NEARBY_RADIUS_MAX = 120            # 10 of 11 sample rings; good density up to ~2.5h drive
@@ -212,23 +208,6 @@ def _resolve(location: str | None, lat: float | None, lon: float | None):
         disp = _loc.reverse_geocode(lat, lon) or f"{lat:.4f}°, {lon:.4f}°"
         return lat, lon, disp, tz
     raise HTTPException(400, "Provide 'location' or both 'lat' and 'lon'.")
-
-
-def _month_bounds(month: str | None) -> tuple[date, date]:
-    if not month:
-        start = datetime.now(timezone.utc).date().replace(day=1)
-    else:
-        try:
-            start = datetime.strptime(month, "%Y-%m").date().replace(day=1)
-        except ValueError:
-            raise HTTPException(400, f"Invalid month {month!r} (expected YYYY-MM).")
-    last = _cal.monthrange(start.year, start.month)[1]
-    end = start.replace(day=last)
-    if start < _MIN_DATE or end > _MAX_DATE:
-        raise HTTPException(
-            400, f"month {start.strftime('%Y-%m')} is outside the supported range "
-                 f"{_MIN_DATE.year}..{_MAX_DATE.year}.")
-    return start, end
 
 
 # ── endpoints ────────────────────────────────────────────────────────────────
@@ -319,69 +298,6 @@ def _accepted(job_id: str) -> JSONResponse:
         content={"job_id": job_id, "status": "pending", "poll": f"/jobs/{job_id}"},
     )
 
-
-@app.get("/calendar")
-def calendar(
-    location: str | None = Query(None, max_length=_MAX_NAME_LEN),
-    lat: float | None = Query(None, ge=-90, le=90),
-    lon: float | None = Query(None, ge=-180, le=180),
-    month: str | None = Query(None, description="YYYY-MM; default current month"),
-    weather: bool = False,
-):
-    """Submit a month-view job for one location → 202 + job_id (poll /jobs/{id})."""
-    la, lo, disp, tz = _resolve(location, lat, lon)        # sync: validates + geocodes
-    start, end = _month_bounds(month)
-    loc_dict = {"lat": la, "lon": lo, "display_name": disp, "tz_name": str(tz)}
-    job_id = jobs.submit({"locs": [loc_dict], "start": start.isoformat(),
-                          "end": end.isoformat(), "weather": weather})
-    return _accepted(job_id)
-
-
-@app.get("/trip")
-def trip(
-    locations: list[str] = Query(..., description="Repeatable location name(s) to compare"),
-    start: str = Query(..., description="YYYY-MM-DD"),
-    end: str = Query(..., description="YYYY-MM-DD"),
-    weather: bool = False,
-):
-    """Submit a multi-location score-matrix job → 202 + job_id (poll /jobs/{id})."""
-    if len(locations) > _MAX_TRIP_LOCATIONS:
-        raise HTTPException(400, f"Too many locations: {len(locations)} (max {_MAX_TRIP_LOCATIONS}).")
-    s, e = _parse_date(start, "start"), _parse_date(end, "end")
-    if e < s:
-        raise HTTPException(400, "'end' must be on or after 'start'.")
-    if (e - s).days > _MAX_TRIP_DAYS:
-        raise HTTPException(
-            400, f"Date range too large: {(e - s).days} days (max {_MAX_TRIP_DAYS}). "
-                 f"Narrow the range.")
-    for name in locations:
-        if len(name) > _MAX_NAME_LEN:
-            raise HTTPException(400, f"Location name too long (max {_MAX_NAME_LEN}).")
-
-    def _geocode_one(name: str):
-        try:
-            la, lo, disp, tz_name = _loc.resolve(name)
-            return {"lat": la, "lon": lo, "display_name": disp, "tz_name": tz_name}
-        except ValueError as ex:
-            raise ValueError(f"{name!r}: {ex}")
-        except RuntimeError as ex:
-            raise RuntimeError(f"{name!r}: {ex}")
-
-    # Geocode all locations in parallel while preserving original order.
-    max_workers = min(len(locations), 10)
-    with _futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
-        ordered_futs = [pool.submit(_geocode_one, name) for name in locations]
-    locs = []
-    for fut in ordered_futs:
-        try:
-            locs.append(fut.result())
-        except ValueError as ex:
-            raise HTTPException(404, str(ex))
-        except RuntimeError as ex:
-            raise HTTPException(502, str(ex))
-    job_id = jobs.submit({"locs": locs, "start": s.isoformat(),
-                          "end": e.isoformat(), "weather": weather})
-    return _accepted(job_id)
 
 
 @app.get("/nearby")

--- a/apps/jobs.py
+++ b/apps/jobs.py
@@ -1,4 +1,4 @@
-"""Async job lifecycle for the long /calendar + /trip computes (M6.3).
+"""Async job lifecycle for the long /calendar + /nearby computes (M6.3).
 
 Fully-async contract: the endpoints resolve + validate synchronously (fast, cached
 geocode; 4xx on bad input immediately), then hand the heavy multi-night compute to a
@@ -51,18 +51,20 @@ def _run_nearby_job(params: dict) -> dict:
 def run_job(params: dict) -> dict:
     """Dispatch a job to the appropriate handler based on params['type'].
 
-    params for "nearby": {"type": "nearby", "lat": float, "lon": float, "radius_miles": int}
-    params for "trip"  : {"locs": [...], "start": "YYYY-MM-DD", "end": "YYYY-MM-DD", "weather": bool}
-    Defaulting to "trip" when "type" is absent keeps all existing calendar/trip jobs working.
+    params for "nearby"   : {"type": "nearby", "lat": float, "lon": float, "radius_miles": int}
+    params for "calendar" : {"type": "calendar", "locs": [...], "start": "YYYY-MM-DD",
+                             "end": "YYYY-MM-DD", "weather": bool, "weather_horizon_days"?: int}
+    Defaulting to the calendar path when "type" is absent keeps old records working.
     """
     if params.get("type") == "nearby":
         return _run_nearby_job(params)
-    # trip/calendar path — locations already geocoded at submit time
+    # calendar path — locations already geocoded at submit time
     report = _trip.plan_trip(
         params["locs"],
         date.fromisoformat(params["start"]),
         date.fromisoformat(params["end"]),
         fetch_weather=bool(params.get("weather", False)),
+        weather_horizon_days=params.get("weather_horizon_days") or _trip._FORECAST_DAYS,
     )
     return trip_report_to_dict(report)
 

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -199,6 +199,10 @@ html.red-mode .dp-popover {
   border: 1px solid rgba(255, 0, 0, 0.20);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.60);
 }
+html.red-mode .crp-popover {
+  border: 1px solid rgba(255, 0, 0, 0.20);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.60);
+}
 html.red-mode .dp-header {
   background: rgba(255, 0, 0, 0.06);
   border-bottom-color: rgba(255, 0, 0, 0.18);
@@ -256,6 +260,25 @@ html.red-mode .nearby-trigger {
 }
 html.red-mode .nearby-trigger:active {
   border: 1px solid rgba(255, 0, 0, 0.20);
+}
+/* .heatmap-cell uses namespaced hm-poor/fair/good/excellent classes (not the
+   app's bare band-* names) specifically to avoid colliding with the generic
+   score-card tint rule above. But --poor/fair/good/excellent are themselves
+   near-identical dark reds in red-mode (single-hue palette), which reads as
+   one indistinct color across the tiny heatmap squares. Same fix as the
+   .bar-fill bands above: differentiate by fill saturation, not hue. */
+html.red-mode .heatmap-cell.hm-poor {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(255, 0, 0, 0.45);
+}
+html.red-mode .heatmap-cell.hm-fair {
+  background: rgba(255, 0, 0, 0.30);
+}
+html.red-mode .heatmap-cell.hm-good {
+  background: rgba(255, 0, 0, 0.62);
+}
+html.red-mode .heatmap-cell.hm-excellent {
+  background: rgba(255, 0, 0, 0.88);
 }
 html.red-mode .mode-toggle,
 html.red-mode .units-toggle {
@@ -1192,6 +1215,20 @@ details summary {
   gap: 3px;
 }
 
+/* ── planning tools section ──────────────────────────────────────────────── */
+.planning-tools-body {
+  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.planning-tool-title {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
 /* ── nearby dark-sky section ─────────────────────────────────────────────── */
 .nearby-body {
   padding-top: 10px;
@@ -1289,6 +1326,245 @@ details summary {
 .nearby-dome-dist {
   white-space: nowrap;
   text-align: right;
+}
+/* ── calendar range picker (Grafana-style trigger + popover) ────────────── */
+.crp-wrap {
+  position: relative;
+  display: inline-block;
+}
+.crp-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  /* .nearby-trigger's mono/uppercase/tracking suits short fixed labels
+     (60 MI, 7 DAYS); this button shows a dynamic date-range summary and
+     sits beside Search a place / Use my location, so match those instead —
+     plain body font, sentence case, no letter-spacing. */
+  font: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+}
+.crp-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 60;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  width: max-content;
+  max-width: min(560px, 92vw);
+  background: var(--pop-bg);
+  border-top: 1px solid rgba(255, 255, 255, 0.85);
+  border-left: 1px solid rgba(255, 255, 255, 0.85);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.22);
+  border-right: 1px solid rgba(0, 0, 0, 0.22);
+  border-radius: 3px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  padding: 14px;
+  animation: dropdown-in 0.13s ease both;
+}
+.crp-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+}
+.crp-col-presets {
+  min-width: 160px;
+  border-left: 1px solid var(--card-border);
+  padding-left: 18px;
+}
+.crp-col-title {
+  /* Matches .planning-tool-title / .nearby-highlight-label — the app's
+     sub-section-label convention (sentence case, not uppercase). */
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+.crp-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.crp-field label {
+  /* Matches .field > span — the app's form-field-label convention
+     (uppercase mono), since From/To are literal form field labels. */
+  font-size: 10px;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-dim);
+}
+.crp-field .dp-trigger {
+  /* DatePicker's trigger uses font: inherit, sized for the primary search
+     field; scale it down to match this dense popover instead of inheriting
+     the page's larger base font. */
+  font-size: 13px;
+  padding: 8px 10px;
+}
+.crp-apply {
+  margin-top: 4px;
+  font: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+}
+.crp-apply:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.crp-preset-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.crp-preset-list button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 7px 10px;
+  background: none;
+  border: none;
+  border-left: 2px solid transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--sans);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.crp-preset-list button:hover {
+  background: var(--surface-2, rgba(0, 0, 0, 0.05));
+}
+.crp-preset-list button.active {
+  border-left-color: var(--accent);
+  background: var(--surface-2, rgba(0, 0, 0, 0.05));
+  color: var(--accent);
+  font-weight: 600;
+}
+/* ── outlook telemetry ribbon ─────────────────────────────────────────────── */
+.telemetry-ribbon {
+  border: 1px solid var(--card-border);
+}
+/* Best-night hero metric — same pattern as .overall-num/.overall-label/
+   .overall-sub on the main score card, scaled down for this compact panel. */
+.telemetry-hero {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--card-border);
+}
+.telemetry-hero-num {
+  font-size: 32px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--text-h);
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+.telemetry-hero-num.band-excellent { color: var(--excellent); }
+.telemetry-hero-num.band-good      { color: var(--good); }
+.telemetry-hero-num.band-fair      { color: var(--fair); }
+.telemetry-hero-num.band-poor      { color: var(--poor); }
+.telemetry-hero-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.telemetry-hero-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-h);
+}
+.telemetry-hero-sub {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.heatmap-body {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--card-border);
+}
+.heatmap-dow-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 3px;
+  max-width: 220px;
+  margin-bottom: 3px;
+}
+.heatmap-dow-row span {
+  text-align: center;
+  font-size: 9px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+}
+.heatmap-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 3px;
+  max-width: 220px;
+}
+.heatmap-cell {
+  width: 100%;
+  aspect-ratio: 1;
+  padding: 0;
+  border: none;
+  background: var(--text-dim);
+  cursor: pointer;
+}
+.heatmap-cell-empty {
+  background: transparent;
+  cursor: default;
+  visibility: hidden;
+}
+.heatmap-cell.hm-excellent { background: var(--excellent); }
+.heatmap-cell.hm-good      { background: var(--good); }
+.heatmap-cell.hm-fair      { background: var(--fair); }
+.heatmap-cell.hm-poor      { background: var(--poor); }
+.heatmap-cell.muted { opacity: 0.4; }
+.heatmap-cell.selected {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+.telemetry-readout {
+  padding: 10px 12px;
+  background: var(--field-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.telemetry-readout .meta-row { font-size: 13px; }
+.telemetry-selected-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+.telemetry-selected-date {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-h);
+}
+.telemetry-score-excellent { color: var(--excellent); font-weight: 600; }
+.telemetry-score-good      { color: var(--good);      font-weight: 600; }
+.telemetry-score-fair      { color: var(--fair);       font-weight: 600; }
+.telemetry-score-poor      { color: var(--poor);       font-weight: 600; }
+.telemetry-mini-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 4px;
+}
+.telemetry-mini-bars .bar-row {
+  grid-template-columns: 84px 1fr 30px;
+  gap: 8px;
+  font-size: 12px;
+}
+.telemetry-mini-bars .bar-track {
+  height: 5px;
 }
 /* POI-first reachability affordances */
 .poi-namelink {
@@ -2205,6 +2481,10 @@ html.red-mode .wx-now-row td.wx-now-time {
   top: calc(100% + 6px);
   left: 0;
   width: min(100%, 340px);
+  /* width:100% resolves against .dp-wrap, which shrinks to its trigger's
+     content width in a flex row (e.g. the calendar custom-range pickers) —
+     without a floor here the 7-column day grid gets squeezed illegibly. */
+  min-width: 260px;
   z-index: 60;
   background: var(--pop-bg);
   border-top: 1px solid rgba(255, 255, 255, 0.85);
@@ -2507,6 +2787,18 @@ html.red-mode .wx-now-row td.wx-now-time {
   /* Blocked target rows: allow badge text to wrap instead of clipping */
   .tg-row-blocked td {
     white-space: normal;
+  }
+  .heatmap-body {
+    padding: 6px;
+  }
+  .heatmap-dow-row,
+  .heatmap-grid {
+    max-width: 180px;
+    gap: 2px;
+  }
+  .telemetry-readout {
+    font-size: 11px;
+    padding: 8px;
   }
 }
 

--- a/apps/web/src/CalendarRangePicker.tsx
+++ b/apps/web/src/CalendarRangePicker.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from 'react'
+import { CalendarDays, ChevronDown } from 'lucide-react'
+import type { CalendarResult } from './types'
+import { tonightIso, addDaysIso, daySpan } from './format'
+import DatePicker from './DatePicker'
+
+export type CalendarPickerState =
+  | { phase: 'idle' }
+  | { phase: 'loading'; start: string; days: number }
+  | { phase: 'done'; data: CalendarResult; days: number }
+  | { phase: 'error'; message: string }
+
+const PRESET_DAYS = [7, 14, 30]
+
+function fmtShort(iso: string): string {
+  return new Date(iso + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Grafana-style time-range picker, adapted for a date-only, forward-looking,
+ * <=30-day outlook: a trigger button showing the current selection, opening a
+ * two-column popover — quick presets (click-to-apply) beside a custom From/To
+ * range (calendar-only inputs + an explicit Apply).
+ */
+export default function CalendarRangePicker({
+  state,
+  onApply,
+}: {
+  state: CalendarPickerState
+  onApply: (start: string, days: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [draftStart, setDraftStart] = useState(() => tonightIso())
+  const [draftEnd, setDraftEnd] = useState(() => addDaysIso(tonightIso(), 6))
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  function handleDraftStartChange(v: string) {
+    setDraftStart(v)
+    setDraftEnd(cur => {
+      if (cur < v) return v
+      if (cur > addDaysIso(v, 29)) return addDaysIso(v, 29)
+      return cur
+    })
+  }
+
+  function applyPreset(days: number) {
+    onApply(tonightIso(), days)
+    setOpen(false)
+  }
+
+  function applyCustom() {
+    onApply(draftStart, daySpan(draftStart, draftEnd))
+    setOpen(false)
+  }
+
+  const span = daySpan(draftStart, draftEnd)
+  const customInvalid = !draftStart || !draftEnd || span < 1 || span > 30
+
+  const label =
+    state.phase === 'loading' ? 'Checking…'
+    : state.phase === 'done'  ? `${fmtShort(state.data.date_start)} – ${fmtShort(state.data.date_end)}`
+    : 'Select range'
+
+  const isActivePreset = (days: number) =>
+    state.phase === 'done' && state.days === days && state.data.date_start === tonightIso()
+
+  return (
+    <div className="crp-wrap" ref={wrapRef}>
+      <button
+        type="button"
+        className="crp-trigger nearby-trigger"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen(o => !o)}
+      >
+        <CalendarDays size={13} strokeWidth={2} />
+        <span>{label}</span>
+        <ChevronDown size={13} strokeWidth={2} />
+      </button>
+
+      {open && (
+        <div className="crp-popover" role="dialog" aria-label="Select outlook range">
+          <div className="crp-col">
+            <div className="crp-col-title">Custom range</div>
+            <div className="crp-field">
+              <label>From</label>
+              <DatePicker value={draftStart} min={tonightIso()} onChange={handleDraftStartChange} />
+            </div>
+            <div className="crp-field">
+              <label>To</label>
+              <DatePicker value={draftEnd} min={draftStart} max={addDaysIso(draftStart, 29)} onChange={setDraftEnd} />
+            </div>
+            <button type="button" className="nearby-trigger crp-apply" disabled={customInvalid} onClick={applyCustom}>
+              Apply range
+            </button>
+          </div>
+          <div className="crp-col crp-col-presets">
+            <div className="crp-col-title">Quick ranges</div>
+            <ul className="crp-preset-list">
+              {PRESET_DAYS.map(d => (
+                <li key={d}>
+                  <button
+                    type="button"
+                    className={isActivePreset(d) ? 'active' : ''}
+                    onClick={() => applyPreset(d)}
+                  >
+                    Next {d} days
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/OutlookTelemetryRibbon.tsx
+++ b/apps/web/src/OutlookTelemetryRibbon.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from 'react'
+import type { CalendarNight, CalendarResult } from './types'
+import { scoreBand, scoreLabel, tonightIso, formatHm } from './format'
+import { MoonPhaseSvg, ScoreBar } from './shared'
+
+const DOW = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const DOW_SHORT = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
+function dateParts(iso: string): { dow: string; mmdd: string; long: string } {
+  const d = new Date(iso + 'T00:00:00')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const long = `${DOW[d.getDay()]}, ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
+  return { dow: DOW[d.getDay()], mmdd: `${mm}/${dd}`, long }
+}
+
+/**
+ * Compact calendar-style heat map: one small square per night, colored by
+ * score band, laid out in day-of-week-aligned rows (like a contribution
+ * calendar). Best night is called out as a hero metric; a detail panel below
+ * shows the selected/hovered night. Composite score is whatever the API
+ * returned — moon + dark hours + weather + bortle only, satellites never
+ * factor in.
+ */
+export default function OutlookTelemetryRibbon({ data, days }: { data: CalendarResult; days: number }) {
+  const nights = useMemo(() => [...data.nights].sort((a, b) => a.date.localeCompare(b.date)), [data.nights])
+  const best = data.ranked[0] as CalendarNight | undefined
+  const [selectedDate, setSelectedDate] = useState<string | null>(best?.date ?? nights[0]?.date ?? null)
+  const selected = nights.find(n => n.date === selectedDate) ?? nights[0] ?? null
+  const today = tonightIso()
+
+  // Pad leading cells so the grid's columns line up with day-of-week, like a real calendar.
+  const leadingBlanks = nights.length ? new Date(nights[0].date + 'T00:00:00').getDay() : 0
+  const cells: (CalendarNight | null)[] = [...Array<null>(leadingBlanks).fill(null), ...nights]
+
+  const bestBand = best?.score != null ? scoreBand(best.score) : null
+  const selectedBand = selected?.score != null ? scoreBand(selected.score) : null
+  const sc = selected?.score_components
+
+  return (
+    <div className="telemetry-ribbon">
+      {best?.score != null && (
+        <div className="telemetry-hero">
+          <div className={`telemetry-hero-num${bestBand ? ` band-${bestBand}` : ''}`}>{best.score.toFixed(1)}</div>
+          <div className="telemetry-hero-meta">
+            <div className="telemetry-hero-label">{scoreLabel(best.score)}</div>
+            <div className="telemetry-hero-sub">Best night, {days}-day outlook · {dateParts(best.date).long}</div>
+          </div>
+        </div>
+      )}
+
+      <div className="heatmap-body">
+        <div className="heatmap-dow-row" aria-hidden="true">
+          {DOW_SHORT.map((d, i) => <span key={i}>{d}</span>)}
+        </div>
+        <div className="heatmap-grid">
+          {cells.map((n, i) => {
+            if (!n) return <span key={`pad-${i}`} className="heatmap-cell heatmap-cell-empty" />
+            const band = n.score != null ? scoreBand(n.score) : null
+            const isPast = n.date < today
+            const isMuted = isPast || n.score == null
+            const isSelected = n.date === selectedDate
+            const { dow, mmdd } = dateParts(n.date)
+            return (
+              <button
+                key={n.date}
+                type="button"
+                className={[
+                  'heatmap-cell',
+                  band ? `hm-${band}` : '',
+                  isMuted ? 'muted' : '',
+                  isSelected ? 'selected' : '',
+                ].filter(Boolean).join(' ')}
+                onMouseEnter={() => setSelectedDate(n.date)}
+                onClick={() => setSelectedDate(n.date)}
+                aria-pressed={isSelected}
+                title={`${dow} ${mmdd} — ${n.score != null ? n.score.toFixed(1) : 'N/A'}`}
+                aria-label={`${dow} ${mmdd}, score ${n.score != null ? n.score.toFixed(1) : 'unavailable'}`}
+              />
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="telemetry-readout">
+        {selected ? (
+          <>
+            <div className="telemetry-selected-head">
+              <MoonPhaseSvg phaseName={selected.phase_name} illuminationPct={selected.illumination_pct} size={30} />
+              <div className="telemetry-selected-date">{dateParts(selected.date).long}</div>
+            </div>
+            <div className="meta-row">
+              <span className="meta-k">Score</span>
+              <span className={`meta-v${selectedBand ? ` telemetry-score-${selectedBand}` : ''}`}>
+                {selected.score != null ? `${selected.score.toFixed(1)} · ${scoreLabel(selected.score)}` : '—'}
+              </span>
+            </div>
+            <div className="meta-row">
+              <span className="meta-k">Dark Hours</span>
+              <span className="meta-v">{formatHm(selected.dark_hours)}</span>
+            </div>
+            <div className="meta-row">
+              <span className="meta-k">Lunar Conditions</span>
+              <span className="meta-v">{selected.phase_name} · {selected.illumination_pct.toFixed(0)}% illuminated</span>
+            </div>
+            {!selected.weather_informed && (
+              <p className="sat-notice">Astronomy-only estimate — beyond the 7-day forecast horizon</p>
+            )}
+            {sc && (
+              <div className="telemetry-mini-bars">
+                {sc.bortle != null && <ScoreBar label="Dark Sky" value={sc.bortle} />}
+                {sc.moon   != null && <ScoreBar label="Lunar"    value={sc.moon} />}
+                {sc.dark   != null && <ScoreBar label="Dark Hours" value={sc.dark} />}
+                {selected.weather_informed && sc.weather != null && <ScoreBar label="Weather" value={sc.weather} />}
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="sat-notice">No data</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react'
-import type { NightReport, SkyEvent, WeatherPoint, VisibleTarget, TargetWindow, MilkyWaySummary, NearbyResult, NearbyPlace, LightDomeSummary, Direction } from './types'
+import type { NightReport, SkyEvent, WeatherPoint, VisibleTarget, TargetWindow, MilkyWaySummary, NearbyResult, NearbyPlace, LightDomeSummary, Direction, CalendarResult } from './types'
 import {
   formatTime, formatDayTime, formatHm, tzAbbr, tzTitle,
   cardinal, rateConditions, fmtTemp, fmtWind, fmtDist, lpString,
-  scoreBand, scoreLabel, moonWashSeverity, moonUpAt,
+  scoreBand, scoreLabel, moonWashSeverity, moonUpAt, tonightIso,
 } from './format'
-import { fetchNearby, ApiRequestError } from './api'
+import { fetchNearby, fetchCalendar, ApiRequestError } from './api'
+import OutlookTelemetryRibbon from './OutlookTelemetryRibbon'
+import CalendarRangePicker, { type CalendarPickerState } from './CalendarRangePicker'
+import { MoonPhaseSvg, ScoreBar } from './shared'
 import {
   Sunrise, Sunset, Moon, Star, Stars,
   MoonStar, CloudMoon, Cloudy, CloudFog, CloudDrizzle, CloudHail,
@@ -13,6 +16,54 @@ import {
   Droplet, Wind, TriangleAlert, Navigation,
   type LucideIcon,
 } from 'lucide-react'
+
+// Mirrors apps/api/main.py's _MAX_CALENDAR_DAYS — the outlook auto-loads at the
+// full cap so the user never has to open the range picker just to see it.
+const AUTO_CALENDAR_DAYS = 30
+
+// ReportCard fully unmounts and remounts on every /night fetch, including
+// same-location day navigation (App.tsx only renders it once `report` is set
+// and `loading` is false — see the `report && !loading` gate). Without this,
+// the effect below would re-hit /calendar on every single day-nav click. Cache
+// the in-flight promise (not just the settled result) at module scope, keyed
+// by location, so remounts for a location already loading/loaded reuse it —
+// this also collapses React StrictMode's dev-mode double-invoke into one call.
+const _autoCalendarCache = new Map<string, Promise<CalendarResult>>()
+
+function autoFetchCalendar(lat: number, lon: number): Promise<CalendarResult> {
+  const key = `${lat},${lon}`
+  let p = _autoCalendarCache.get(key)
+  if (!p) {
+    p = fetchCalendar(lat, lon, tonightIso(), AUTO_CALENDAR_DAYS)
+    p.catch(() => _autoCalendarCache.delete(key)) // don't cache failures — allow retry on next mount
+    _autoCalendarCache.set(key, p)
+  }
+  return p
+}
+
+// Same remount problem as the calendar cache above, applied to Find Sky Nearby.
+// Nearby search stays manual/opt-in (no auto-fire) — this only restores a
+// search the user already ran for this location, instead of dropping back to
+// the two radius buttons on every day-nav click. Keyed by lat,lon,radius for
+// the fetch cache; lat,lon alone for "which radius did they last pick here".
+const _nearbyFetchCache = new Map<string, Promise<NearbyResult>>()
+const _nearbyLastRadius = new Map<string, number>()
+
+function nearbyLocKey(lat: number, lon: number) {
+  return `${lat},${lon}`
+}
+
+function fetchNearbyCached(lat: number, lon: number, radius: number): Promise<NearbyResult> {
+  const key = `${lat},${lon},${radius}`
+  let p = _nearbyFetchCache.get(key)
+  if (!p) {
+    p = fetchNearby(lat, lon, radius)
+    p.catch(() => _nearbyFetchCache.delete(key))
+    _nearbyFetchCache.set(key, p)
+  }
+  _nearbyLastRadius.set(nearbyLocKey(lat, lon), radius)
+  return p
+}
 
 // ── WMO weather code icons ───────────────────────────────────────────────────
 
@@ -61,37 +112,6 @@ function WmoIcon({ code, cloudCover, moonUp = false, size = 19 }: { code: number
 // first, then altitude — e.g. "Az 195° S · Alt 42°".
 function fmtPos(altDeg: number, azDeg: number): string {
   return `Az ${Math.round(azDeg)}° ${cardinal(azDeg)} · Alt ${Math.round(altDeg)}°`
-}
-
-// ── Moon phase image (NASA SVS) ──────────────────────────────────────────────
-// Uses NASA Scientific Visualization Studio 1024×1024 phase images
-// (public domain, downloaded to /moon-phases/).
-
-function MoonPhaseSvg({ phaseName, size = 22 }: {
-  phaseName: string
-  illuminationPct?: number   // kept for API compat; image handles accuracy
-  size?: number
-}) {
-  const p   = phaseName.toLowerCase()
-  const src = p.includes('new')                               ? '/moon-phases/new.jpg'
-            : p.includes('waxing') && p.includes('crescent') ? '/moon-phases/waxing-crescent.jpg'
-            : p.includes('first')                             ? '/moon-phases/first-quarter.jpg'
-            : p.includes('waxing') && p.includes('gibbous')  ? '/moon-phases/waxing-gibbous.jpg'
-            : p.includes('full')                              ? '/moon-phases/full.jpg'
-            : p.includes('waning') && p.includes('gibbous')  ? '/moon-phases/waning-gibbous.jpg'
-            : p.includes('last') || p.includes('third')      ? '/moon-phases/last-quarter.jpg'
-            : p.includes('waning') && p.includes('crescent') ? '/moon-phases/waning-crescent.jpg'
-            : '/moon-phases/full.jpg'
-
-  return (
-    <img
-      src={src}
-      alt={phaseName}
-      width={size}
-      height={size}
-      style={{ borderRadius: '50%', display: 'inline-block', verticalAlign: 'middle', flexShrink: 0 }}
-    />
-  )
 }
 
 // ── Weather table ────────────────────────────────────────────────────────────
@@ -302,21 +322,6 @@ function WeatherTable({ points, events = [], tz, imperial, darkIntervals, moonri
         </table>
       </div>
     </details>
-  )
-}
-
-// ── Score bar ────────────────────────────────────────────────────────────────
-
-function ScoreBar({ label, value }: { label: string; value: number }) {
-  const pct = Math.max(0, Math.min(100, value * 10))
-  return (
-    <div className="bar-row">
-      <span className="bar-label">{label}</span>
-      <span className="bar-track">
-        <span className={`bar-fill band-${scoreBand(value)}`} style={{ width: `${pct}%` }} />
-      </span>
-      <span className="bar-value">{value.toFixed(1)}</span>
-    </div>
   )
 }
 
@@ -2295,12 +2300,15 @@ export default function ReportCard({
     | { phase: 'loading'; radius: number }
     | { phase: 'done'; data: NearbyResult }
     | { phase: 'error'; message: string }
-  >({ phase: 'idle' })
+  >(() => {
+    const radius = _nearbyLastRadius.get(nearbyLocKey(report.lat, report.lon))
+    return radius != null ? { phase: 'loading', radius } : { phase: 'idle' }
+  })
 
   async function handleFindNearby(radius: number) {
     setNearbyState({ phase: 'loading', radius })
     try {
-      const data = await fetchNearby(report.lat, report.lon, radius)
+      const data = await fetchNearbyCached(report.lat, report.lon, radius)
       setNearbyState({ phase: 'done', data })
     } catch (err) {
       setNearbyState({
@@ -2309,6 +2317,74 @@ export default function ReportCard({
       })
     }
   }
+
+  // Restores a previously-run nearby search across the remount that same-location
+  // day navigation causes (see the calendar auto-load effect below). No-ops if the
+  // user hasn't searched nearby for this location yet — nearbyState stays idle,
+  // same as today.
+  useEffect(() => {
+    const radius = _nearbyLastRadius.get(nearbyLocKey(report.lat, report.lon))
+    if (radius == null) return
+    let cancelled = false
+    fetchNearbyCached(report.lat, report.lon, radius).then(data => {
+      if (!cancelled) setNearbyState({ phase: 'done', data })
+    }).catch(err => {
+      if (!cancelled) {
+        setNearbyState({
+          phase: 'error',
+          message: err instanceof ApiRequestError ? err.message : 'Nearby search failed.',
+        })
+      }
+    })
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [report.lat, report.lon])
+
+  const [calendarState, setCalendarState] = useState<CalendarPickerState>({ phase: 'idle' })
+  // Sidesteps a race: if the user opens the picker and applies a range before the
+  // auto-load below resolves, the auto-load's eventual result must not clobber
+  // their explicit choice.
+  const manualCalendarRef = useRef(false)
+
+  async function handleFindCalendar(start: string, days: number) {
+    manualCalendarRef.current = true
+    setCalendarState({ phase: 'loading', start, days })
+    try {
+      const data = await fetchCalendar(report.lat, report.lon, start, days)
+      setCalendarState({ phase: 'done', data, days })
+    } catch (err) {
+      setCalendarState({
+        phase: 'error',
+        message: err instanceof ApiRequestError ? err.message : 'Calendar search failed.',
+      })
+    }
+  }
+
+  // Auto-load the outlook as soon as a location's report is up, instead of waiting
+  // for the user to open the range picker — the calendar's own backend cost is
+  // already cheap (dark-cycle window is cached/deduped per location). [lat, lon]
+  // rather than [report] limits this to firing once per distinct location; the
+  // module-level cache in autoFetchCalendar handles dedup across the remounts
+  // that same-location day navigation still causes.
+  useEffect(() => {
+    manualCalendarRef.current = false
+    let cancelled = false
+    setCalendarState({ phase: 'loading', start: tonightIso(), days: AUTO_CALENDAR_DAYS })
+    autoFetchCalendar(report.lat, report.lon).then(data => {
+      if (!cancelled && !manualCalendarRef.current) {
+        setCalendarState({ phase: 'done', data, days: AUTO_CALENDAR_DAYS })
+      }
+    }).catch(err => {
+      if (!cancelled && !manualCalendarRef.current) {
+        setCalendarState({
+          phase: 'error',
+          message: err instanceof ApiRequestError ? err.message : 'Calendar search failed.',
+        })
+      }
+    })
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [report.lat, report.lon])
 
   const r   = report
   const tz  = r.tz_name
@@ -2482,24 +2558,42 @@ export default function ReportCard({
       </div>
 
 
-        <details className="nearby-section" open>
-        <summary>Find Sky Nearby</summary>
-        <div className="nearby-body">
-          {nearbyState.phase === 'idle' && (
-            <div className="nearby-radius-toggle">
-              <button className="nearby-trigger" onClick={() => handleFindNearby(60)}>{fmtDist(60 * 1.60934, imperial)}</button>
-              <button className="nearby-trigger" onClick={() => handleFindNearby(120)}>{fmtDist(120 * 1.60934, imperial)}</button>
+        <details className="planning-tools-section" open>
+        <summary>Planning Tools</summary>
+        <div className="planning-tools-body">
+          <div className="planning-tool">
+            <h4 className="planning-tool-title">Find Sky Nearby</h4>
+            <div className="nearby-body">
+              {nearbyState.phase === 'idle' && (
+                <div className="nearby-radius-toggle">
+                  <button className="nearby-trigger" onClick={() => handleFindNearby(60)}>{fmtDist(60 * 1.60934, imperial)}</button>
+                  <button className="nearby-trigger" onClick={() => handleFindNearby(120)}>{fmtDist(120 * 1.60934, imperial)}</button>
+                </div>
+              )}
+              {nearbyState.phase === 'loading' && (
+                <p className="sat-notice">Scanning within {fmtDist(nearbyState.radius * 1.60934, imperial)}…</p>
+              )}
+              {nearbyState.phase === 'error' && (
+                <p className="sat-notice">{nearbyState.message}</p>
+              )}
+              {nearbyState.phase === 'done' && (
+                <NearbyResults data={nearbyState.data} imperial={imperial} originLat={report.lat} originLon={report.lon} />
+              )}
             </div>
-          )}
-          {nearbyState.phase === 'loading' && (
-            <p className="sat-notice">Scanning within {fmtDist(nearbyState.radius * 1.60934, imperial)}…</p>
-          )}
-          {nearbyState.phase === 'error' && (
-            <p className="sat-notice">{nearbyState.message}</p>
-          )}
-          {nearbyState.phase === 'done' && (
-            <NearbyResults data={nearbyState.data} imperial={imperial} originLat={report.lat} originLon={report.lon} />
-          )}
+          </div>
+
+          <div className="planning-tool">
+            <h4 className="planning-tool-title">Calendar — Next Good Night</h4>
+            <div className="nearby-body">
+              <CalendarRangePicker state={calendarState} onApply={handleFindCalendar} />
+              {calendarState.phase === 'error' && (
+                <p className="sat-notice">{calendarState.message}</p>
+              )}
+              {calendarState.phase === 'done' && (
+                <OutlookTelemetryRibbon data={calendarState.data} days={calendarState.days} />
+              )}
+            </div>
+          </div>
         </div>
       </details>
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { ApiError, NightReport, NearbyResult, NearbyJobRecord } from './types'
+import type { ApiError, NightReport, NearbyResult, NearbyJobRecord, CalendarResult, CalendarJobRecord } from './types'
 
 export interface NightQuery {
   location?: string
@@ -41,7 +41,7 @@ const NEARBY_TIMEOUT_MS = 120_000
 
 /**
  * Submit a nearby dark-sky search and poll until complete.
- * Uses the same async SQS+job pattern as /calendar and /trip.
+ * Uses the same async SQS+job pattern as /calendar.
  */
 export async function fetchNearby(lat: number, lon: number, radius = 60): Promise<NearbyResult> {
   const p = new URLSearchParams({ lat: String(lat), lon: String(lon), radius: String(radius) })
@@ -77,6 +77,51 @@ export async function fetchNearby(lat: number, lon: number, radius = 60): Promis
     if (rec.status === 'error') throw new ApiRequestError(500, rec.error)
   }
   throw new ApiRequestError(0, 'Nearby search timed out. Try a smaller radius.')
+}
+
+// A calendar job can cover up to 30 location-nights (vs /nearby's fixed single-point
+// scan), so give it more headroom before giving up; same backoff shape otherwise.
+const CALENDAR_POLL_BACKOFF_MS = [500, 1_000, 2_000, 3_000]
+const CALENDAR_TIMEOUT_MS = 180_000
+
+/**
+ * Submit a multi-night outlook search for one location and poll until complete.
+ * Uses the same async SQS+job pattern as /nearby.
+ */
+export async function fetchCalendar(lat: number, lon: number, start: string, days: number): Promise<CalendarResult> {
+  const p = new URLSearchParams({ lat: String(lat), lon: String(lon), start, days: String(days) })
+  let res: Response
+  try {
+    res = await fetch(`/calendar?${p}`)
+  } catch {
+    throw new ApiRequestError(0, 'Could not reach the API. Check your connection and try again.')
+  }
+  if (res.status !== 202) {
+    let detail = `Calendar request failed (${res.status}).`
+    try {
+      const b = (await res.json()) as ApiError
+      if (b?.detail) detail = b.detail
+    } catch { /* non-JSON error body */ }
+    throw new ApiRequestError(res.status, detail)
+  }
+  const { job_id } = (await res.json()) as { job_id: string }
+
+  const deadline = Date.now() + CALENDAR_TIMEOUT_MS
+  for (let attempt = 0; Date.now() < deadline; attempt++) {
+    const wait = CALENDAR_POLL_BACKOFF_MS[Math.min(attempt, CALENDAR_POLL_BACKOFF_MS.length - 1)]
+    await new Promise(r => setTimeout(r, wait))
+    let poll: Response
+    try {
+      poll = await fetch(`/jobs/${job_id}`)
+    } catch {
+      throw new ApiRequestError(0, 'Lost connection while waiting for calendar results.')
+    }
+    if (!poll.ok) throw new ApiRequestError(poll.status, `Poll failed (${poll.status}).`)
+    const rec = (await poll.json()) as CalendarJobRecord
+    if (rec.status === 'done')  return rec.result
+    if (rec.status === 'error') throw new ApiRequestError(500, rec.error)
+  }
+  throw new ApiRequestError(0, 'Calendar search timed out. Try a shorter range.')
 }
 
 /**

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -249,3 +249,16 @@ export function tonightIso(): string {
   }
   return toIsoDate(now)
 }
+
+export function addDaysIso(iso: string, days: number): string {
+  const d = new Date(iso + 'T00:00:00')
+  d.setDate(d.getDate() + days)
+  return toIsoDate(d)
+}
+
+// Inclusive night count spanning [startIso, endIso].
+export function daySpan(startIso: string, endIso: string): number {
+  const s = new Date(startIso + 'T00:00:00')
+  const e = new Date(endIso + 'T00:00:00')
+  return Math.round((e.getTime() - s.getTime()) / 86_400_000) + 1
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -69,8 +69,8 @@
   --accent: #4A5EA8;       /* Sun blue */
 
   /* ── Semantic Data ──────────────────────────────────────────── */
-  --excellent: #4A5EA8;    /* Sun blue */
-  --good: #5CB85C;         /* Success green */
+  --excellent: #5CB85C;    /* Success green */
+  --good: #4A5EA8;         /* Sun blue */
   --fair: #F0AD4E;         /* Warning amber */
   --poor: #D9534F;         /* Danger red */
 

--- a/apps/web/src/shared.tsx
+++ b/apps/web/src/shared.tsx
@@ -1,0 +1,47 @@
+import { scoreBand } from './format'
+
+// ── Moon phase image (NASA SVS) ──────────────────────────────────────────────
+// Uses NASA Scientific Visualization Studio 1024×1024 phase images
+// (public domain, downloaded to /moon-phases/).
+
+export function MoonPhaseSvg({ phaseName, size = 22 }: {
+  phaseName: string
+  illuminationPct?: number   // kept for API compat; image handles accuracy
+  size?: number
+}) {
+  const p   = phaseName.toLowerCase()
+  const src = p.includes('new')                               ? '/moon-phases/new.jpg'
+            : p.includes('waxing') && p.includes('crescent') ? '/moon-phases/waxing-crescent.jpg'
+            : p.includes('first')                             ? '/moon-phases/first-quarter.jpg'
+            : p.includes('waxing') && p.includes('gibbous')  ? '/moon-phases/waxing-gibbous.jpg'
+            : p.includes('full')                              ? '/moon-phases/full.jpg'
+            : p.includes('waning') && p.includes('gibbous')  ? '/moon-phases/waning-gibbous.jpg'
+            : p.includes('last') || p.includes('third')      ? '/moon-phases/last-quarter.jpg'
+            : p.includes('waning') && p.includes('crescent') ? '/moon-phases/waning-crescent.jpg'
+            : '/moon-phases/full.jpg'
+
+  return (
+    <img
+      src={src}
+      alt={phaseName}
+      width={size}
+      height={size}
+      style={{ borderRadius: '50%', display: 'inline-block', verticalAlign: 'middle', flexShrink: 0 }}
+    />
+  )
+}
+
+// ── Score bar ────────────────────────────────────────────────────────────────
+
+export function ScoreBar({ label, value }: { label: string; value: number }) {
+  const pct = Math.max(0, Math.min(100, value * 10))
+  return (
+    <div className="bar-row">
+      <span className="bar-label">{label}</span>
+      <span className="bar-track">
+        <span className={`bar-fill band-${scoreBand(value)}`} style={{ width: `${pct}%` }} />
+      </span>
+      <span className="bar-value">{value.toFixed(1)}</span>
+    </div>
+  )
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -275,3 +275,33 @@ export type NearbyJobRecord =
   | { status: 'pending' }
   | { status: 'done'; result: NearbyResult }
   | { status: 'error'; error: string }
+
+// ── Calendar / "next good night" outlook ───────────────────────────────────────
+
+export interface CalendarNight {
+  date: string // YYYY-MM-DD
+  score: number | null
+  score_components: ScoreComponents
+  phase_name: string
+  illumination_pct: number
+  dark_hours: number
+  bortle_score: number | null
+  weather_score: number | null
+  // False beyond the calendar tool's 7-day weather-trust cutoff — score is
+  // astronomy-only for that night (moon + dark hours + bortle, weights redistribute).
+  weather_informed: boolean
+  wx_pending: boolean
+  wx_no_data: boolean
+}
+
+export interface CalendarResult {
+  date_start: string
+  date_end: string
+  nights: CalendarNight[]
+  ranked: CalendarNight[] // sorted best → worst by score
+}
+
+export type CalendarJobRecord =
+  | { status: 'pending' }
+  | { status: 'done'; result: CalendarResult }
+  | { status: 'error'; error: string }

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -234,10 +234,10 @@ class LambdaApiStack(Stack):
         fn.add_to_role_policy(route_policy)
 
         # --- async jobs: SQS queue + zip-Lambda worker (M6.3) ---
-        # Long async computes (/nearby) run off the request path. The API enqueues a
-        # job; this worker runs find_nearby and writes the result into the cache, where
-        # /jobs/{id} reads it. visibility_timeout must exceed the worker timeout; a DLQ
-        # catches messages that can't be processed.
+        # Long async computes (/nearby, /calendar) run off the request path. The API
+        # enqueues a job; this worker runs find_nearby or plan_trip and writes the
+        # result into the cache, where /jobs/{id} reads it. visibility_timeout must
+        # exceed the worker timeout; a DLQ catches messages that can't be processed.
         #
         # The worker is a zip Lambda (not a container): with rasterio/GDAL, pyarrow and
         # scipy removed from the runtime, the deps fit the 250 MB zip limit (~169 MB
@@ -413,11 +413,24 @@ class LambdaApiStack(Stack):
         #                                (~200 WCU). Low false-positive risk on a JSON API.
         #   2  RateLimitNearbyPerIp    — block any IP exceeding 10 /nearby requests / 5 min.
         #                                Each /nearby spawns an SQS job; this caps worker cost.
-        #   3  RateLimitPerIp          — block any single IP exceeding 60 requests / 5 min
-        #                                across all endpoints. A human uses the app a handful
-        #                                of times per session; 60 throttles scripted abuse.
-        # Total ~229 WCU, well under the 1500-WCU default WebACL capacity. Managed groups use
-        # override_action=none so each group's own block/count actions apply unchanged.
+        #   3  RateLimitCalendarPerIp  — block any IP exceeding 30 /calendar requests / 5 min.
+        #                                One /calendar call = one SQS job, bounded to <=30
+        #                                location-nights (_MAX_CALENDAR_DAYS). The web client
+        #                                now auto-fires this once per distinct location viewed
+        #                                (not just on manual range-picker use), so the limit is
+        #                                sized for someone actively comparing several spots in
+        #                                one session rather than a single opt-in click.
+        #   4  RateLimitPerIp          — block any single IP exceeding 150 requests / 5 min
+        #                                across all endpoints. Raised alongside the calendar
+        #                                auto-fire above: each location view now costs ~1
+        #                                /night + 1 /calendar submit + a few /jobs/{id} polls
+        #                                (polls aren't covered by the per-endpoint rules, only
+        #                                this global one), plus typeahead /suggest calls. Still
+        #                                well below anything a scripted scraper needs seconds,
+        #                                not minutes, to exceed.
+        # Total ~231 WCU, well under the 1500-WCU default WebACL capacity (rate-based rule cost
+        # doesn't scale with the numeric limit). Managed groups use override_action=none so each
+        # group's own block/count actions apply unchanged.
         managed = lambda name, vendor="AWS": wafv2.CfnWebACL.StatementProperty(
             managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
                 vendor_name=vendor, name=name,
@@ -471,12 +484,34 @@ class LambdaApiStack(Stack):
                     visibility_config=vis("RateLimitNearbyPerIp"),
                 ),
                 wafv2.CfnWebACL.RuleProperty(
-                    name="RateLimitPerIp",
+                    name="RateLimitCalendarPerIp",
                     priority=3,
                     action=wafv2.CfnWebACL.RuleActionProperty(block={}),
                     statement=wafv2.CfnWebACL.StatementProperty(
                         rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
-                            limit=60,                  # requests per IP per 5-min window
+                            limit=30,                  # /calendar per IP per 5-min window
+                            aggregate_key_type="IP",
+                            scope_down_statement=wafv2.CfnWebACL.StatementProperty(
+                                byte_match_statement=wafv2.CfnWebACL.ByteMatchStatementProperty(
+                                    field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(uri_path={}),
+                                    positional_constraint="STARTS_WITH",
+                                    search_string="/calendar",
+                                    text_transformations=[wafv2.CfnWebACL.TextTransformationProperty(
+                                        priority=0, type="NONE",
+                                    )],
+                                ),
+                            ),
+                        ),
+                    ),
+                    visibility_config=vis("RateLimitCalendarPerIp"),
+                ),
+                wafv2.CfnWebACL.RuleProperty(
+                    name="RateLimitPerIp",
+                    priority=4,
+                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                            limit=150,                 # requests per IP per 5-min window
                             aggregate_key_type="IP",
                         ),
                     ),
@@ -518,6 +553,7 @@ class LambdaApiStack(Stack):
                 "/suggest":  api_cached,   # autocomplete: edge-cache by query string
                 "/healthz":  open_cached,
                 "/nearby":   no_cache,
+                "/calendar": no_cache,
                 "/jobs/*":   no_cache,
             },
         )

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -153,13 +153,44 @@ class LambdaApiStack(Stack):
         )
 
         # --- Scheduled warmup ping — keeps one container alive, prevents cold starts ---
-        # EventBridge invokes Lambda directly every 4 minutes; LWA converts to POST /warmup.
+        # EventBridge invokes Lambda directly every 4 minutes with a synthetic Function URL
+        # v2.0 payload so Mangum can infer the HTTPGateway handler (raw EB events have no
+        # requestContext and crash Mangum before any code runs).
         # Cost: ~10,800 invocations/month + ~1,620 GB-s — both within Lambda free tier.
         warmup_rule = events.Rule(
             self, "WarmupRule",
             schedule=events.Schedule.rate(Duration.minutes(4)),
         )
-        warmup_rule.add_target(targets.LambdaFunction(fn))
+        warmup_rule.add_target(targets.LambdaFunction(
+            fn,
+            event=events.RuleTargetInput.from_object({
+                "version": "2.0",
+                "routeKey": "POST /warmup",
+                "rawPath": "/warmup",
+                "rawQueryString": "",
+                "headers": {
+                    "host": "warmup.internal",
+                    "x-forwarded-proto": "https",
+                },
+                "requestContext": {
+                    "accountId": "warmup",
+                    "apiId": "warmup",
+                    "domainName": "warmup.internal",
+                    "http": {
+                        "method": "POST",
+                        "path": "/warmup",
+                        "protocol": "HTTP/1.1",
+                        "sourceIp": "127.0.0.1",
+                        "userAgent": "EventBridge/warmup",
+                    },
+                    "requestId": "warmup",
+                    "routeKey": "$default",
+                    "stage": "$default",
+                    "timeEpoch": 0,
+                },
+                "isBase64Encoded": False,
+            }),
+        ))
 
         # least-privilege data access (reference foundational resources)
         bucket = s3.Bucket.from_bucket_name(self, "RasterBucket", raster_bucket)

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -234,8 +234,8 @@ class LambdaApiStack(Stack):
         fn.add_to_role_policy(route_policy)
 
         # --- async jobs: SQS queue + zip-Lambda worker (M6.3) ---
-        # Long /calendar+/trip computes run off the request path. The API enqueues a
-        # job; this worker runs plan_trip and writes the result into the cache, where
+        # Long async computes (/nearby) run off the request path. The API enqueues a
+        # job; this worker runs find_nearby and writes the result into the cache, where
         # /jobs/{id} reads it. visibility_timeout must exceed the worker timeout; a DLQ
         # catches messages that can't be processed.
         #
@@ -326,7 +326,7 @@ class LambdaApiStack(Stack):
             enable_accept_encoding_gzip=True,
         )
 
-        # The async endpoints must NOT be cached: /trip + /calendar return a fresh
+        # The async endpoints must NOT be cached: /nearby and /jobs return a fresh
         # job_id each call, and /jobs/{id} status changes as the job runs. Disable
         # caching but still forward the query string to the origin.
         fwd_qs = cloudfront.OriginRequestPolicy(
@@ -411,10 +411,12 @@ class LambdaApiStack(Stack):
         #                                (cheapest reject; ~25 WCU).
         #   1  KnownBadInputs          — block request patterns tied to known exploits/probes
         #                                (~200 WCU). Low false-positive risk on a JSON API.
-        #   2  RateLimitPerIp          — block any single IP exceeding 200 requests / 5 min.
-        #                                Most legit /night hits are CloudFront cache hits and
-        #                                never reach this count; this throttles scripted abuse.
-        # Total ~227 WCU, well under the 1500-WCU default WebACL capacity. Managed groups use
+        #   2  RateLimitNearbyPerIp    — block any IP exceeding 10 /nearby requests / 5 min.
+        #                                Each /nearby spawns an SQS job; this caps worker cost.
+        #   3  RateLimitPerIp          — block any single IP exceeding 60 requests / 5 min
+        #                                across all endpoints. A human uses the app a handful
+        #                                of times per session; 60 throttles scripted abuse.
+        # Total ~229 WCU, well under the 1500-WCU default WebACL capacity. Managed groups use
         # override_action=none so each group's own block/count actions apply unchanged.
         managed = lambda name, vendor="AWS": wafv2.CfnWebACL.StatementProperty(
             managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
@@ -447,12 +449,34 @@ class LambdaApiStack(Stack):
                     visibility_config=vis("KnownBadInputs"),
                 ),
                 wafv2.CfnWebACL.RuleProperty(
-                    name="RateLimitPerIp",
+                    name="RateLimitNearbyPerIp",
                     priority=2,
                     action=wafv2.CfnWebACL.RuleActionProperty(block={}),
                     statement=wafv2.CfnWebACL.StatementProperty(
                         rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
-                            limit=200,                 # requests per IP per 5-min window
+                            limit=10,                  # /nearby per IP per 5-min window
+                            aggregate_key_type="IP",
+                            scope_down_statement=wafv2.CfnWebACL.StatementProperty(
+                                byte_match_statement=wafv2.CfnWebACL.ByteMatchStatementProperty(
+                                    field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(uri_path={}),
+                                    positional_constraint="STARTS_WITH",
+                                    search_string="/nearby",
+                                    text_transformations=[wafv2.CfnWebACL.TextTransformationProperty(
+                                        priority=0, type="NONE",
+                                    )],
+                                ),
+                            ),
+                        ),
+                    ),
+                    visibility_config=vis("RateLimitNearbyPerIp"),
+                ),
+                wafv2.CfnWebACL.RuleProperty(
+                    name="RateLimitPerIp",
+                    priority=3,
+                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                            limit=60,                  # requests per IP per 5-min window
                             aggregate_key_type="IP",
                         ),
                     ),
@@ -493,8 +517,6 @@ class LambdaApiStack(Stack):
                 "/night":    api_cached,
                 "/suggest":  api_cached,   # autocomplete: edge-cache by query string
                 "/healthz":  open_cached,
-                "/calendar": no_cache,
-                "/trip":     no_cache,
                 "/nearby":   no_cache,
                 "/jobs/*":   no_cache,
             },

--- a/scripts/profile_calendar.py
+++ b/scripts/profile_calendar.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Profiling harness for the /calendar (trip.plan_trip) multi-night path.
+
+Wraps the four sub-calls assemble_night() makes per night — bortle lookup,
+per-night sky events, the 30-night lunar-cycle dark-hours window, and the
+weather forecast — to show which dominates wall-clock time for a calendar-
+scale (multi-night) request, cold vs warm. Written to check whether
+lunar_cycle_dark_analysis()'s per-night 30-night rolling window (each one
+overlapping the last by 29/30 nights, no shared cache across adjacent
+nights — see sky_events.py:290) is actually the bottleneck it looks like
+on paper, before doing anything about it.
+
+Usage:
+    .venv/bin/python scripts/profile_calendar.py                # 30 nights
+    .venv/bin/python scripts/profile_calendar.py --days 7
+    .venv/bin/python scripts/profile_calendar.py --lat 44.0 --lon -110.5
+"""
+import argparse
+import functools
+import sys
+import time
+from collections import defaultdict
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PyNightSkyPredictor import darksky, sky_events as se, weather as wx, trip as _trip  # noqa: E402
+
+_timings: dict[str, list[float]] = defaultdict(lambda: [0.0, 0])  # name -> [total_ms, calls]
+_percall: dict[str, list[float]] = defaultdict(list)  # name -> [ms, ms, ...] in call order
+
+
+def _wrap(module, name):
+    orig = getattr(module, name)
+
+    @functools.wraps(orig)
+    def wrapped(*args, **kwargs):
+        t0 = time.perf_counter()
+        try:
+            return orig(*args, **kwargs)
+        finally:
+            ms = (time.perf_counter() - t0) * 1000.0
+            _timings[name][0] += ms
+            _timings[name][1] += 1
+            _percall[name].append(round(ms, 1))
+
+    setattr(module, name, wrapped)
+
+
+def _reset():
+    _timings.clear()
+    _percall.clear()
+
+
+def _report(label: str):
+    print(f"\n--- {label} ---")
+    total = sum(v[0] for v in _timings.values()) or 1.0
+    for name, (ms, calls) in sorted(_timings.items(), key=lambda kv: -kv[1][0]):
+        print(f"  {name:28s} {ms:9.1f} ms  ({calls:3d} calls, {ms / max(calls, 1):6.1f} ms/call)  {ms / total * 100:4.1f}%")
+    print(f"  {'sum of wrapped calls':28s} {total:9.1f} ms")
+
+
+def _report_distribution(name: str):
+    calls = _percall.get(name, [])
+    if not calls:
+        return
+    slow = [c for c in calls if c > 200]
+    fast = [c for c in calls if c <= 200]
+    print(f"\n  {name} per-call (call order): {calls}")
+    print(f"  -> {len(slow)} calls > 200ms (full compute), {len(fast)} calls <= 200ms (cache/overlap hit)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=int, default=30)
+    ap.add_argument("--lat", type=float, default=44.0)
+    ap.add_argument("--lon", type=float, default=-110.5)
+    args = ap.parse_args()
+
+    _wrap(darksky, "lookup")
+    _wrap(se, "sky_events")
+    _wrap(se, "lunar_cycle_dark_analysis")
+    _wrap(wx, "forecast")
+
+    loc = {"lat": args.lat, "lon": args.lon, "display_name": "Profile Site", "tz_name": "America/Denver"}
+    start = date.today()
+    end = start + timedelta(days=args.days - 1)
+
+    print(f"plan_trip: {args.days} nights at ({args.lat}, {args.lon}), weather_horizon_days=7")
+
+    t0 = time.perf_counter()
+    report = _trip.plan_trip([loc], start, end, fetch_weather=True, weather_horizon_days=7)
+    wall_cold = (time.perf_counter() - t0) * 1000.0
+    print(f"\nCOLD wall clock: {wall_cold:.1f} ms  ({len(report.nights)} nights, 20-way threaded)")
+    _report("COLD (first run)")
+    _report_distribution("lunar_cycle_dark_analysis")
+
+    _reset()
+    t0 = time.perf_counter()
+    report2 = _trip.plan_trip([loc], start, end, fetch_weather=True, weather_horizon_days=7)
+    wall_warm = (time.perf_counter() - t0) * 1000.0
+    print(f"\nWARM wall clock: {wall_warm:.1f} ms  ({len(report2.nights)} nights, repeat request)")
+    _report("WARM (repeat, in-process + disk cache hot)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -153,6 +153,68 @@ def test_nearby_raw_coords_skip_geocoding(monkeypatch, _nearby_mocks):
     assert "job_id" in r.json()
 
 
+# ── /calendar endpoint ────────────────────────────────────────────────────────
+
+_CALENDAR_RESULT = {
+    "date_start": "2026-07-02", "date_end": "2026-07-08",
+    "locations": [], "nights": [], "ranked": [],
+}
+
+
+@pytest.fixture
+def _calendar_mocks(monkeypatch):
+    """Patch geocoding + run_job so /calendar tests need no rasters or network."""
+    store: dict = {}
+    monkeypatch.setattr(jobs._cache, "set",
+                        lambda k, v, ttl_seconds=None: store.__setitem__(k, v))
+    monkeypatch.setattr(jobs._cache, "get", lambda k: store.get(k))
+    monkeypatch.delenv("PYNIGHTSKY_JOBS_QUEUE_URL", raising=False)
+    monkeypatch.setattr(jobs, "run_job", lambda p: _CALENDAR_RESULT)
+    return store
+
+
+def test_calendar_returns_202(monkeypatch, _calendar_mocks):
+    r = TestClient(app).get("/calendar", params={"lat": 35.2, "lon": -111.6, "days": 7})
+    assert r.status_code == 202
+    body = r.json()
+    assert "job_id" in body
+    assert body["poll"].startswith("/jobs/")
+
+
+def test_calendar_job_polls_to_done(monkeypatch, _calendar_mocks):
+    c = TestClient(app)
+    r = c.get("/calendar", params={"lat": 35.2, "lon": -111.6, "days": 14})
+    jid = r.json()["job_id"]
+    poll = c.get(f"/jobs/{jid}")
+    assert poll.status_code == 200
+    assert poll.json()["status"] == "done"
+    assert poll.json()["result"]["date_start"] == "2026-07-02"
+
+
+def test_calendar_days_too_large_422():
+    assert client.get("/calendar", params={"lat": 35.2, "lon": -111.6, "days": 31}).status_code == 422
+
+
+def test_calendar_days_too_small_422():
+    assert client.get("/calendar", params={"lat": 35.2, "lon": -111.6, "days": 0}).status_code == 422
+
+
+def test_calendar_days_at_max_boundary_202(monkeypatch, _calendar_mocks):
+    """days=30 (_MAX_CALENDAR_DAYS) is the largest still-accepted range — the
+    cap is exclusive on 31, not on 30 itself."""
+    r = client.get("/calendar", params={"lat": 35.2, "lon": -111.6, "days": 30})
+    assert r.status_code == 202
+
+
+def test_calendar_invalid_start_400():
+    r = client.get("/calendar", params={"lat": 35.2, "lon": -111.6, "start": "not-a-date"})
+    assert r.status_code == 400
+
+
+def test_calendar_requires_location_or_coords():
+    assert client.get("/calendar", params={"days": 7}).status_code == 400
+
+
 @pytest.mark.eph
 @requires_rasters
 def test_night_by_coords_matches_baseline():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,16 +69,6 @@ def test_night_bad_date_returns_400():
     assert r.status_code == 400
 
 
-def test_calendar_bad_month_returns_400():
-    r = client.get("/calendar", params={"lat": 35.2, "lon": -111.6, "month": "2026-13"})
-    assert r.status_code == 400
-
-
-def test_trip_missing_params_returns_422():
-    # locations/start/end are required query params → FastAPI validation error
-    assert client.get("/trip").status_code == 422
-
-
 # ── input bounds (data sanity + abuse/DoS guards) — all hermetic ─────────────
 
 def test_night_lat_out_of_range_422():
@@ -96,21 +86,6 @@ def test_night_date_outside_ephemeris_400():
 
 def test_night_location_too_long_422():
     assert client.get("/night", params={"location": "x" * 201}).status_code == 422
-
-
-def test_trip_range_too_large_400():
-    r = client.get("/trip", params={"locations": "x", "start": "2026-01-01", "end": "2026-12-31"})
-    assert r.status_code == 400
-
-
-def test_trip_end_before_start_400():
-    r = client.get("/trip", params={"locations": "x", "start": "2026-06-10", "end": "2026-06-01"})
-    assert r.status_code == 400
-
-
-def test_trip_too_many_locations_400():
-    params = [("locations", f"loc{i}") for i in range(11)] + [("start", "2026-06-01"), ("end", "2026-06-02")]
-    assert client.get("/trip", params=params).status_code == 400
 
 
 # ── /nearby endpoint ──────────────────────────────────────────────────────────

--- a/tests/test_assemble_night_cycle_window.py
+++ b/tests/test_assemble_night_cycle_window.py
@@ -1,0 +1,159 @@
+"""Hermetic tests for assemble_night()'s use_cycle_window path — the calendar/
+trip lightweight branch that derives sunset/sunrise/night_start/night_end/
+dark_hours_tonight from lunar_cycle_dark_analysis()'s window instead of an
+independent sky_events() call (see PyNightSkyPredictor/sky_events.py). Mocks
+out darksky/light_dome/sky_events/moon_events entirely so this needs no
+rasters, ephemeris, or network — default pytest run stays offline.
+"""
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import PyNightSkyPredictor.predictor as predictor
+from PyNightSkyPredictor.moonlight import ks_moon_credit
+
+_BORTLE_INFO = {
+    "sqm": 21.5, "bortle_class": 3, "bortle_desc": "Rural",
+    "lp_zone": "2", "below_detection": False, "source": "VIIRS 2025",
+}
+_ILLUMINATION_PCT = 35.0
+_PHASE_NAME = "Waxing Crescent"
+
+
+def _tonight_record(sunset, sunrise, dark_hours):
+    return {
+        "sunset":      sunset,
+        "sunrise":     sunrise,
+        "night_start": sunset + timedelta(hours=1, minutes=30),
+        "night_end":   sunrise - timedelta(hours=1, minutes=30),
+        "dark_hours":  dark_hours,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _mocks(monkeypatch):
+    monkeypatch.setattr(predictor._ds, "lookup", lambda lat, lon: dict(_BORTLE_INFO))
+    monkeypatch.setattr(predictor._ld, "lightdome_lookup", lambda lat, lon: None)
+    monkeypatch.setattr(predictor.se, "moon_phase_info", lambda at_utc: (_PHASE_NAME, _ILLUMINATION_PCT))
+    monkeypatch.setattr(predictor._me, "moon_distance_km", lambda at_utc: 384_400.0)
+    monkeypatch.setattr(predictor._me, "classify_full_moon", lambda illum, dist: None)
+    monkeypatch.setattr(predictor._me, "eclipses_for_night", lambda sunset, sunrise: [])
+
+
+def test_use_cycle_window_skips_sky_events_and_moonrise_moonset(monkeypatch):
+    target  = date(2026, 7, 15)
+    sunset  = datetime(2026, 7, 15, 20, 0, tzinfo=timezone.utc)
+    sunrise = sunset + timedelta(hours=8)
+    tonight = _tonight_record(sunset, sunrise, dark_hours=4.0)
+
+    monkeypatch.setattr(
+        predictor.se, "lunar_cycle_dark_analysis",
+        lambda lat, lon, d, tz: {
+            "tonight_hours": 4.0, "mean_hours": 4.0, "stdev_hours": 0.0,
+            "score": 8.0, "tonight": tonight,
+        },
+    )
+
+    def _boom(*a, **kw):
+        raise AssertionError("use_cycle_window=True must not call sky_events()")
+    monkeypatch.setattr(predictor.se, "sky_events", _boom)
+
+    report = predictor.assemble_night(
+        40.0, -105.0, target, ZoneInfo("America/Denver"),
+        fetch_weather=False, use_cycle_window=True,
+    )
+
+    assert report.dark_score == 8.0
+    assert report.dark_hours == 4.0
+    assert report.events == []
+    assert report.moonrise is None and report.moonset is None
+
+
+def test_use_cycle_window_moon_score_matches_the_shared_formula(monkeypatch):
+    """The lightweight branch doesn't reimplement the moon_score formula — it
+    feeds the same shared code a different sunset/sunrise/dark_hours_tonight.
+    Verify the output actually matches what that formula computes for these
+    inputs, not just that it runs without error."""
+    target  = date(2026, 7, 15)
+    sunset  = datetime(2026, 7, 15, 20, 0, tzinfo=timezone.utc)
+    sunrise = sunset + timedelta(hours=8)
+    dark_hours_tonight = 4.0
+    tonight = _tonight_record(sunset, sunrise, dark_hours=dark_hours_tonight)
+    night_start, night_end = tonight["night_start"], tonight["night_end"]
+
+    monkeypatch.setattr(
+        predictor.se, "lunar_cycle_dark_analysis",
+        lambda lat, lon, d, tz: {
+            "tonight_hours": dark_hours_tonight, "mean_hours": dark_hours_tonight,
+            "stdev_hours": 0.0, "score": 7.5, "tonight": tonight,
+        },
+    )
+    monkeypatch.setattr(predictor.se, "sky_events",
+                        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("must not be called")))
+
+    report = predictor.assemble_night(
+        40.0, -105.0, target, ZoneInfo("America/Denver"),
+        fetch_weather=False, use_cycle_window=True,
+    )
+
+    total_astro_hours = (night_end - night_start).total_seconds() / 3600
+    moonlit_frac = 1.0 - (dark_hours_tonight / total_astro_hours)
+    expected_moon_score = round(10 * ((1 - moonlit_frac) + moonlit_frac * ks_moon_credit(_ILLUMINATION_PCT)), 1)
+
+    assert report.score_components["moon"] == expected_moon_score
+    assert report.dark_hours == dark_hours_tonight
+
+
+def test_use_cycle_window_raises_when_tonight_sunset_missing(monkeypatch):
+    """If the dark-cycle window couldn't resolve a sunset for this date (the
+    unresolvable-edge-case fallback), raise the same ValueError the
+    full-precision path raises today rather than let a broken record through."""
+    target = date(2026, 7, 15)
+    monkeypatch.setattr(
+        predictor.se, "lunar_cycle_dark_analysis",
+        lambda lat, lon, d, tz: {
+            "tonight_hours": 0.0, "mean_hours": 0.0, "stdev_hours": 0.0, "score": 0.0,
+            "tonight": {"sunset": None, "sunrise": None, "night_start": None,
+                        "night_end": None, "dark_hours": 0.0},
+        },
+    )
+
+    with pytest.raises(ValueError, match="No sunset found"):
+        predictor.assemble_night(
+            40.0, -105.0, target, ZoneInfo("America/Denver"),
+            fetch_weather=False, use_cycle_window=True,
+        )
+
+
+def test_default_use_cycle_window_false_still_calls_sky_events(monkeypatch):
+    """Byte-compatibility guard: every existing caller (/night, CLI) leaves
+    use_cycle_window at its False default and must still hit the full-precision
+    sky_events() path."""
+    called = {"sky_events": False}
+
+    def fake_sky_events(lat, lon, d):
+        called["sky_events"] = True
+        sunset  = datetime(2026, 7, 15, 20, 0, tzinfo=timezone.utc)
+        sunrise = sunset + timedelta(hours=8)
+        return [
+            {"time": sunset, "label": "Sunset"},
+            {"time": sunrise, "label": "Sunrise"},
+        ]
+
+    monkeypatch.setattr(predictor.se, "sky_events", fake_sky_events)
+    monkeypatch.setattr(
+        predictor.se, "lunar_cycle_dark_analysis",
+        lambda lat, lon, d, tz: {"tonight_hours": 0.0, "mean_hours": 0.0,
+                                  "stdev_hours": 0.0, "score": 0.0,
+                                  "tonight": {"sunset": None, "sunrise": None,
+                                              "night_start": None, "night_end": None,
+                                              "dark_hours": 0.0}},
+    )
+
+    predictor.assemble_night(
+        40.0, -105.0, date(2026, 7, 15), ZoneInfo("America/Denver"),
+        fetch_weather=False,
+    )
+
+    assert called["sky_events"] is True

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -73,18 +73,6 @@ def test_worker_handler_warmup_ping(monkeypatch):
     assert calls == {"prewarm": 1, "process": 0}
 
 
-def test_trip_endpoint_returns_202_then_done(monkeypatch, mem_cache):
-    monkeypatch.setattr(main_mod._loc, "resolve",
-                        lambda name: (40.0, -105.0, "Boulder", "America/Denver"))
-    monkeypatch.setattr(jobs, "run_job", lambda p: {"nights": [], "n": len(p["locs"])})
-    client = TestClient(main_mod.app)
-    r = client.get("/trip", params={"locations": "Boulder", "start": "2026-06-01", "end": "2026-06-03"})
-    assert r.status_code == 202
-    jid = r.json()["job_id"]
-    poll = client.get(f"/jobs/{jid}")
-    assert poll.status_code == 200 and poll.json()["status"] == "done"
-    assert poll.json()["result"]["n"] == 1
-
 
 def test_jobs_endpoint_unknown_returns_404(mem_cache):
     assert TestClient(main_mod.app).get("/jobs/doesnotexist").status_code == 404

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -101,8 +101,8 @@ def test_run_job_nearby_raises_when_none(monkeypatch):
         jobs.run_job({"type": "nearby", "lat": 0.0, "lon": 0.0})
 
 
-def test_run_job_defaults_to_trip_when_type_absent(monkeypatch):
-    """Existing calendar/trip jobs (no 'type' key) still reach plan_trip."""
+def test_run_job_defaults_to_calendar_when_type_absent(monkeypatch):
+    """Legacy calendar job records (no 'type' key) still reach plan_trip."""
     called = {}
 
     class _FakeReport:
@@ -112,7 +112,7 @@ def test_run_job_defaults_to_trip_when_type_absent(monkeypatch):
         nights     = []
         ranked     = []
 
-    def fake_plan_trip(locs, start, end, fetch_weather):
+    def fake_plan_trip(locs, start, end, fetch_weather, weather_horizon_days=None):
         called["ok"] = True
         return _FakeReport()
 
@@ -122,3 +122,26 @@ def test_run_job_defaults_to_trip_when_type_absent(monkeypatch):
     except Exception:
         pass   # serializer may fail on the fake report — what matters is plan_trip was called
     assert called.get("ok"), "plan_trip was not called for a job without 'type'"
+
+
+def test_run_job_calendar_threads_weather_horizon(monkeypatch):
+    """A calendar job's weather_horizon_days param reaches plan_trip unchanged."""
+    captured = {}
+
+    class _FakeReport:
+        date_start = __import__("datetime").date(2026, 6, 1)
+        date_end   = __import__("datetime").date(2026, 6, 2)
+        locations  = []
+        nights     = []
+        ranked     = []
+
+    def fake_plan_trip(locs, start, end, fetch_weather, weather_horizon_days=None):
+        captured["weather_horizon_days"] = weather_horizon_days
+        return _FakeReport()
+
+    monkeypatch.setattr(jobs._trip, "plan_trip", fake_plan_trip)
+    jobs.run_job({
+        "type": "calendar", "locs": [], "start": "2026-06-01", "end": "2026-06-02",
+        "weather": True, "weather_horizon_days": 7,
+    })
+    assert captured["weather_horizon_days"] == 7

--- a/tests/test_perf_changes.py
+++ b/tests/test_perf_changes.py
@@ -111,7 +111,7 @@ class TestPlanTripParallel:
         from PyNightSkyPredictor.trip import plan_trip, NightSummary, TripReport
         from datetime import date
 
-        def _fake_fetch_night(lat, lon, d, tz, display_name, fetch_weather):
+        def _fake_fetch_night(lat, lon, d, tz, display_name, fetch_weather, weather_horizon_days=None):
             return NightSummary(
                 date=d, display_name=display_name, lat=lat, lon=lon,
                 score=round(lat + lon + d.day, 1),

--- a/tests/test_sky_events.py
+++ b/tests/test_sky_events.py
@@ -5,7 +5,7 @@ Pure-math helpers (dark_moon_intervals, find_event, find_last_event) need no
 fixtures.  Ephemeris-dependent integration tests are marked @pytest.mark.eph.
 """
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -213,3 +213,150 @@ class TestSkyEventsIntegration:
         labels = {e["label"] for e in events}
         assert "Moonrise" in labels, "No Moonrise found for eclipse night"
         assert "Moonset"  in labels, "No Moonset found for eclipse night"
+
+
+# ---------------------------------------------------------------------------
+# lunar_cycle_dark_analysis — per-location lock (no ephemeris needed: the
+# Skyfield compute step itself is mocked out so these stay hermetic/fast)
+# ---------------------------------------------------------------------------
+
+def _fake_night(d: date, dark_hours: float = 5.0) -> dict:
+    """A plausible per-night dark-cycle record for a given calendar date, matching
+    the shape _compute_dark_hours_cycle() now returns (sunset/sunrise/night_start/
+    night_end/dark_hours) — used to mock it out without needing real Skyfield data."""
+    sunset  = datetime(d.year, d.month, d.day, 20, 0, tzinfo=timezone.utc)
+    sunrise = sunset + timedelta(hours=10)
+    return {
+        "sunset":      sunset,
+        "sunrise":     sunrise,
+        "night_start": sunset + timedelta(hours=1, minutes=30),
+        "night_end":   sunrise - timedelta(hours=1, minutes=30),
+        "dark_hours":  dark_hours,
+    }
+
+
+class TestLunarCycleDarkAnalysis:
+    """Regression coverage for the per-location lock that keeps concurrent
+    /calendar requests from each redundantly computing their own overlapping
+    30-night window (see scripts/profile_calendar.py: 20/30 calls paying the
+    full Skyfield cost before the lock, ~1-8/30 after), and for the per-night
+    record shape (sunset/sunrise/night_start/night_end/dark_hours) that
+    replaced a bare dark-hours float list."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, monkeypatch):
+        import PyNightSkyPredictor.sky_events as se
+        # Fresh in-process state per test, and no real cache/network I/O.
+        monkeypatch.setattr(se, "_mem_dark_cycle", {})
+        monkeypatch.setattr(se, "_dark_cycle_locks", {})
+        monkeypatch.setattr(se._cache, "get", lambda k: None)
+        monkeypatch.setattr(se._cache, "set", lambda k, v, **kw: None)
+
+    def test_overlapping_target_dates_reuse_one_computation(self, monkeypatch):
+        import PyNightSkyPredictor.sky_events as se
+        from datetime import timedelta
+
+        calls = []
+
+        def fake_compute(lat, lon, target_date, tz):
+            calls.append(target_date)
+            window_start = target_date - timedelta(days=14)
+            return [_fake_night(window_start + timedelta(days=i)) for i in range(30)]
+
+        monkeypatch.setattr(se, "_compute_dark_hours_cycle", fake_compute)
+
+        base = date(2026, 7, 2)
+        r1 = se.lunar_cycle_dark_analysis(40.0, -105.0, base, None)
+        r2 = se.lunar_cycle_dark_analysis(40.0, -105.0, base + timedelta(days=1), None)
+        r3 = se.lunar_cycle_dark_analysis(40.0, -105.0, base + timedelta(days=5), None)
+
+        assert len(calls) == 1, "second and third calls should reuse the first's cached window"
+        assert r1["tonight_hours"] == r2["tonight_hours"] == r3["tonight_hours"] == 5.0
+        assert r1["tonight"]["sunset"].date() == base
+        assert r2["tonight"]["sunset"].date() == base + timedelta(days=1)
+
+    def test_concurrent_overlapping_requests_dont_each_compute_independently(self, monkeypatch):
+        import threading
+        import time as _t
+        from datetime import timedelta
+        import PyNightSkyPredictor.sky_events as se
+
+        calls = []
+        calls_lock = threading.Lock()
+
+        def fake_compute(lat, lon, target_date, tz):
+            with calls_lock:
+                calls.append(target_date)
+            _t.sleep(0.05)  # long enough for concurrent callers to actually race
+            window_start = target_date - timedelta(days=14)
+            return [_fake_night(window_start + timedelta(days=i)) for i in range(30)]
+
+        monkeypatch.setattr(se, "_compute_dark_hours_cycle", fake_compute)
+
+        base = date(2026, 7, 2)
+        dates = [base + timedelta(days=i) for i in range(20)]  # all within one 30-night window
+        results: list = [None] * len(dates)
+
+        def worker(i, d):
+            results[i] = se.lunar_cycle_dark_analysis(40.0, -105.0, d, None)
+
+        threads = [threading.Thread(target=worker, args=(i, d)) for i, d in enumerate(dates)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Without the lock, all 20 concurrent callers would miss the empty
+        # cache and compute independently. With it, far fewer real computes
+        # are needed to cover all 20 (overlapping) nights.
+        assert len(calls) < len(dates)
+        assert all(r["tonight_hours"] == 5.0 for r in results)
+
+    def test_dynamodb_hit_roundtrips_iso_strings_to_datetimes(self, monkeypatch):
+        """json.dumps() (both cache backends — see cache.py) can't handle raw
+        datetimes, so the DynamoDB layer stores ISO strings (_nights_to_json)
+        and must parse them back (_nights_from_json) on a hit. A real
+        LocalFileCache-style round trip through json.dumps/loads, not just an
+        in-memory dict, so a missed conversion would actually surface here."""
+        import json as _json
+        import PyNightSkyPredictor.sky_events as se
+
+        base = date(2026, 7, 2)
+        window_start = base - timedelta(days=14)
+        nights = [_fake_night(window_start + timedelta(days=i), dark_hours=float(i)) for i in range(30)]
+        stored = {"window_start": window_start.isoformat(), "nights": se._nights_to_json(nights)}
+
+        # Round-trip through json.dumps/loads for real, like LocalFileCache/DynamoCache do.
+        db_backing = {se._dark_cycle_db_key(40.0, -105.0, window_start): _json.loads(_json.dumps(stored))}
+        monkeypatch.setattr(se._cache, "get", lambda k: db_backing.get(k))
+
+        result = se.lunar_cycle_dark_analysis(40.0, -105.0, base, None)
+
+        assert result["tonight_hours"] == 14.0  # index 14 == base itself
+        assert isinstance(result["tonight"]["sunset"], datetime)
+        assert result["tonight"]["sunset"].tzinfo is not None
+        assert result["tonight"]["sunset"].date() == base
+
+    def test_tonight_record_is_a_copy_not_a_cache_reference(self, monkeypatch):
+        """The returned 'tonight' dict must be safe to mutate — it's read from a
+        cache entry (_mem_dark_cycle) shared across every concurrent caller for
+        overlapping dates. Mutating it must not corrupt what the next caller sees."""
+        import PyNightSkyPredictor.sky_events as se
+
+        def fake_compute(lat, lon, target_date, tz):
+            window_start = target_date - timedelta(days=14)
+            return [_fake_night(window_start + timedelta(days=i)) for i in range(30)]
+
+        monkeypatch.setattr(se, "_compute_dark_hours_cycle", fake_compute)
+
+        base = date(2026, 7, 2)
+        r1 = se.lunar_cycle_dark_analysis(40.0, -105.0, base, None)
+        r1["tonight"]["sunset"] = "corrupted"
+        r1["tonight"]["dark_hours"] = -999
+        r1["tonight"]["new_key"] = "should not leak into the cache"
+
+        r2 = se.lunar_cycle_dark_analysis(40.0, -105.0, base + timedelta(days=1), None)
+
+        assert r2["tonight"]["sunset"] != "corrupted"
+        assert r2["tonight"]["dark_hours"] == 5.0
+        assert "new_key" not in r2["tonight"]


### PR DESCRIPTION
## Summary
- Re-enables `/calendar` (disabled in #76) as a hardened, rate-limited endpoint: 30-day cap, astronomy-only scoring beyond a 7-day weather horizon, WAF-throttled like `/nearby`.
- Calendar scoring now derives sunset/sunrise/dark-hours from the already-cached dark-cycle window instead of an independent per-night `sky_events()` call — cuts Skyfield work ~30x for a full 30-day range.
- New calendar-heatmap outlook panel (replaces the old bar-list UI): auto-loads 30 days as soon as a report is up, with a hero "best night" metric, moon-phase icon + mini score bars on the selected night, and red-mode-safe band coloring.
- Both the outlook panel and Find Sky Nearby now cache results per-location at module scope, so same-location date navigation reuses prior results instead of re-fetching (`ReportCard` fully remounts on every `/night` fetch, including day-nav — the cache survives that).
- WAF `RateLimitCalendarPerIp` raised 10→30/IP/5min and the global `RateLimitPerIp` raised 60→150/IP/5min to fit the new auto-fire request pattern (calendar now fires once per location viewed, not just on manual picker use; `/jobs/{id}` polls only count against the global rule).

## Test plan
- [x] `pytest -q` — 569 passed, 7 skipped
- [x] `npx tsc -b --force` — clean
- [x] Live-verified in browser against the local API: calendar auto-load, red-mode heatmap differentiation, hero metric, nearby-search persistence across day-nav, network log confirms no redundant `/calendar`/`/nearby` calls on date-only navigation
- [ ] `cdk synth` / real deploy validation (covered by CI's deploy gate on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)