### PR TITLE
Simplify outlook hero line, link each heatmap day to its own report

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1448,42 +1448,15 @@ details summary {
 .telemetry-ribbon {
   border: 1px solid var(--card-border);
 }
-/* Best-night hero metric — same pattern as .overall-num/.overall-label/
-   .overall-sub on the main score card, scaled down for this compact panel. */
+/* Best-night line — plain text, colored/bolded via .telemetry-score-* (same
+   classes the selected-night score below uses), not a separate hero number. */
 .telemetry-hero {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--card-border);
-}
-.telemetry-hero-num {
-  font-size: 32px;
-  font-weight: 500;
-  line-height: 1;
-  letter-spacing: -0.01em;
-  color: var(--text-h);
-  font-family: var(--mono);
-  font-variant-numeric: tabular-nums;
-}
-.telemetry-hero-num.band-excellent { color: var(--excellent); }
-.telemetry-hero-num.band-good      { color: var(--good); }
-.telemetry-hero-num.band-fair      { color: var(--fair); }
-.telemetry-hero-num.band-poor      { color: var(--poor); }
-.telemetry-hero-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
+  font-size: 13px;
 }
 .telemetry-hero-label {
-  font-size: 14px;
-  font-weight: 600;
   color: var(--text-h);
-}
-.telemetry-hero-sub {
-  font-size: 12px;
-  color: var(--text-dim);
-  font-weight: 500;
 }
 .heatmap-body {
   padding: 8px 10px;
@@ -1509,12 +1482,14 @@ details summary {
   max-width: 220px;
 }
 .heatmap-cell {
+  display: block;
   width: 100%;
   aspect-ratio: 1;
   padding: 0;
   border: none;
   background: var(--text-dim);
   cursor: pointer;
+  text-decoration: none;
 }
 .heatmap-cell-empty {
   background: transparent;

--- a/apps/web/src/OutlookTelemetryRibbon.tsx
+++ b/apps/web/src/OutlookTelemetryRibbon.tsx
@@ -22,7 +22,12 @@ function dateParts(iso: string): { dow: string; mmdd: string; long: string } {
  * returned — moon + dark hours + weather + bortle only, satellites never
  * factor in.
  */
-export default function OutlookTelemetryRibbon({ data, days }: { data: CalendarResult; days: number }) {
+export default function OutlookTelemetryRibbon({ data, days, lat, lon }: {
+  data: CalendarResult
+  days: number
+  lat: number
+  lon: number
+}) {
   const nights = useMemo(() => [...data.nights].sort((a, b) => a.date.localeCompare(b.date)), [data.nights])
   const best = data.ranked[0] as CalendarNight | undefined
   const [selectedDate, setSelectedDate] = useState<string | null>(best?.date ?? nights[0]?.date ?? null)
@@ -41,11 +46,12 @@ export default function OutlookTelemetryRibbon({ data, days }: { data: CalendarR
     <div className="telemetry-ribbon">
       {best?.score != null && (
         <div className="telemetry-hero">
-          <div className={`telemetry-hero-num${bestBand ? ` band-${bestBand}` : ''}`}>{best.score.toFixed(1)}</div>
-          <div className="telemetry-hero-meta">
-            <div className="telemetry-hero-label">{scoreLabel(best.score)}</div>
-            <div className="telemetry-hero-sub">Best night, {days}-day outlook · {dateParts(best.date).long}</div>
-          </div>
+          <span className="telemetry-hero-label">
+            Best night, {days}-day outlook · {dateParts(best.date).long} -{' '}
+          </span>
+          <span className={bestBand ? `telemetry-score-${bestBand}` : undefined}>
+            {best.score.toFixed(1)}/10
+          </span>
         </div>
       )}
 
@@ -62,9 +68,11 @@ export default function OutlookTelemetryRibbon({ data, days }: { data: CalendarR
             const isSelected = n.date === selectedDate
             const { dow, mmdd } = dateParts(n.date)
             return (
-              <button
+              <a
                 key={n.date}
-                type="button"
+                href={`?lat=${lat.toFixed(5)}&lon=${lon.toFixed(5)}&date=${n.date}`}
+                target="_blank"
+                rel="noopener noreferrer"
                 className={[
                   'heatmap-cell',
                   band ? `hm-${band}` : '',
@@ -73,9 +81,8 @@ export default function OutlookTelemetryRibbon({ data, days }: { data: CalendarR
                 ].filter(Boolean).join(' ')}
                 onMouseEnter={() => setSelectedDate(n.date)}
                 onClick={() => setSelectedDate(n.date)}
-                aria-pressed={isSelected}
-                title={`${dow} ${mmdd} — ${n.score != null ? n.score.toFixed(1) : 'N/A'}`}
-                aria-label={`${dow} ${mmdd}, score ${n.score != null ? n.score.toFixed(1) : 'unavailable'}`}
+                title={`${dow} ${mmdd} — ${n.score != null ? n.score.toFixed(1) : 'N/A'} — opens in a new tab`}
+                aria-label={`${dow} ${mmdd}, score ${n.score != null ? n.score.toFixed(1) : 'unavailable'}, opens in a new tab`}
               />
             )
           })}

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -2590,7 +2590,7 @@ export default function ReportCard({
                 <p className="sat-notice">{calendarState.message}</p>
               )}
               {calendarState.phase === 'done' && (
-                <OutlookTelemetryRibbon data={calendarState.data} days={calendarState.days} />
+                <OutlookTelemetryRibbon data={calendarState.data} days={calendarState.days} lat={report.lat} lon={report.lon} />
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Outlook hero: replaced the large standalone score number with a single readable line — "Best night, 30-day outlook · date - X/10" — with the date in plain black text and the score colored/bolded via the same `.telemetry-score-*` classes the selected-night readout already uses. Background reverted to transparent (matches panel).
- Heatmap: each day square is now a real anchor link (`?lat=&lon=&date=`, matching the existing `NearbyResults` place-link pattern) that opens that specific date's report in a new tab (`target="_blank" rel="noopener noreferrer"`), while still updating the inline selected-night preview on hover/click in the current tab.

## Test plan
- [x] `pytest -q` — 569 passed, 7 skipped (frontend-only change, included for completeness)
- [x] `npx tsc -b --force` — clean
- [x] Live-verified in browser: hero line color/contrast in light + red mode, heatmap cell `href`/`target`/`rel` attributes, link navigates to the correct date/location, inline preview still updates on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)