### PR TITLE
fix: repair mangled CSS comment breaking the web build

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -803,11 +803,11 @@ html.red-mode .scope-brk {
   cursor: default;
 }
 
-* ── report ───────────────────────────────────────────────── */
-/*@keyframes report-in {
+/* ── report ───────────────────────────────────────────────── */
+@keyframes report-in {
   from { opacity: 0; transform: translateY(16px); }
   to   { opacity: 1; transform: translateY(0); }
-}*/
+}
 
 .report {
   display: flex;


### PR DESCRIPTION
## Summary
- The web build on `main` (commit 08a1b67) fails: `vite build` errors in `vite:css-post` because lightningcss's minifier can't parse `apps/web/src/App.css`.
- Root cause: that commit accidentally dropped the leading `/` from the `/* ── report ── */` section-header comment and prefixed `@keyframes report-in` with `/*`, producing invalid CSS — and silently disabling the `report-in` keyframes that `.report`'s `animation` property still references.
- Restored both to valid syntax (uncommented the keyframes, restored the comment).

## Test plan
- [x] `npm run build` in `apps/web` completes successfully (previously failed with `SyntaxError: [lightningcss minify] Unexpected token Delim('/')`)
- [x] Comment balance check (`/*` vs `*/` counts) confirms no other broken comments in `App.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)