### PR TITLE
Report explainers (InfoTip), sticky section nav, copy-link, heatmap rebalance

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -42,7 +42,10 @@
 }
 
 html, body {
-  overflow-x: hidden;
+  /* clip, not hidden: hidden turns body into a scroll container, which breaks
+     position:sticky (.report-nav). clip guards horizontal overflow the same
+     way without creating a scroll container. */
+  overflow-x: clip;
   width: 100%;
 }
 
@@ -726,6 +729,57 @@ html.red-mode .scope-details .scope-summary .scope-diag {
 html.red-mode .scope-brk {
   color: rgba(255, 0, 0, 0.55);
 }
+/* ── Info popover (InfoTip in shared.tsx) ─────────────────────
+   Term explainers: dotted underline marks the term; the bubble renders
+   through a body portal (position: fixed) so overflow-x:auto table wrappers
+   can't clip it. The bubble resets typography — hosts are often mono/uppercase
+   micro-labels, and the explanation should read as body prose. */
+.info-tip {
+  text-decoration: underline dotted;
+  text-decoration-color: rgba(var(--hairline-rgb), 0.45);
+  text-underline-offset: 3px;
+  cursor: help;
+  outline: none;
+}
+.info-tip:hover,
+.info-tip:focus-visible {
+  text-decoration-color: var(--accent);
+}
+.info-tip-bubble {
+  position: fixed;
+  transform: translate(-50%, calc(-100% - 8px));
+  z-index: 1000;
+  width: max-content;
+  max-width: 260px;
+  background: var(--pop-bg);
+  color: var(--text);
+  border: 1px solid var(--card-border);
+  border-radius: 2px;
+  padding: 7px 10px;
+  font-family: var(--sans);
+  font-size: 11.5px;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+  text-transform: none;
+  text-align: left;
+  white-space: normal;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+.info-tip-bubble.below {
+  transform: translate(-50%, 8px);
+}
+html.red-mode .info-tip {
+  text-decoration-color: rgba(255, 0, 0, 0.45);
+}
+html.red-mode .info-tip-bubble {
+  background: var(--pop-bg);
+  color: var(--text-h);
+  border-color: rgba(255, 0, 0, 0.22);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
 .toggle-tip-wrap {
   position: relative;
 }
@@ -864,6 +918,95 @@ html.red-mode .scope-brk {
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 16px;
+}
+.report-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+.report-head-actions .units-toggle {
+  margin-left: 0;
+}
+.copy-link-btn {
+  border: 1px solid var(--card-border);
+  background: transparent;
+  border-radius: 2px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.copy-link-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.copy-link-btn.copied {
+  color: var(--excellent);
+  border-color: var(--excellent);
+}
+html.red-mode .copy-link-btn {
+  border-color: rgba(255, 0, 0, 0.25);
+  color: var(--text-dim);
+}
+html.red-mode .copy-link-btn.copied,
+html.red-mode .copy-link-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ── Sticky report section nav ───────────────────────────────── */
+.report-nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 -18px 10px;
+  padding: 4px 12px;
+  background: var(--card);
+  border-top: 1px solid rgba(var(--hairline-rgb), 0.08);
+  border-bottom: 1px solid rgba(var(--hairline-rgb), 0.14);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.report-nav::-webkit-scrollbar {
+  display: none;
+}
+.report-nav-link {
+  background: none;
+  border: 0;
+  padding: 3px 7px;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.report-nav-link:hover {
+  color: var(--accent);
+}
+/* Jump targets land just below the sticky bar, not underneath it. */
+#report-planning, #report-timeline, #report-targets, #report-satellites {
+  scroll-margin-top: 34px;
+}
+html.red-mode .report-nav {
+  background: var(--card);
+  border-top-color: rgba(255, 0, 0, 0.10);
+  border-bottom-color: rgba(255, 0, 0, 0.18);
+}
+html.red-mode .report-nav-link {
+  color: var(--text-dim);
 }
 .report-head-meta {
   min-width: 0;
@@ -1578,6 +1721,14 @@ html.red-mode .sum-brief {
 .heatmap-body {
   padding: 8px 10px;
   border-bottom: 1px solid var(--card-border);
+}
+/* Cap the calendar's footprint: full-card-width cells read as the page's main
+   event; ~74px cells carry the same day number + score at a glanceable size. */
+.heatmap-dow-row,
+.heatmap-grid {
+  max-width: 520px;
+  margin-left: auto;
+  margin-right: auto;
 }
 .heatmap-dow-row {
   display: grid;

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -9,7 +9,7 @@ import {
 import { fetchNearby, fetchCalendar, fetchNightDateOnly, ApiRequestError } from './api'
 import OutlookTelemetryRibbon from './OutlookTelemetryRibbon'
 import CalendarRangePicker, { type CalendarPickerState } from './CalendarRangePicker'
-import { MoonPhaseSvg, ScoreBar } from './shared'
+import { MoonPhaseSvg, ScoreBar, InfoTip } from './shared'
 import {
   Star,
   Navigation,
@@ -204,7 +204,16 @@ function WmoIcon({ code, cloudCover, moonUp = false, size = 32, aod, pm25, visib
   const skyObscured = cloudCover != null && cloudCover > 25
   if (!skyObscured && (aloftConfirmed || surfaceHazy)) {
     const label = aloftConfirmed && surfaceHazy ? 'Haze' : aloftConfirmed ? 'Haze: Aloft' : 'Haze: Surface'
-    return <span className="wx-cond-word">{label}</span>
+    const readings = [
+      aod != null ? `AOD ${aod.toFixed(2)} (satellite column)` : null,
+      pm25 != null ? `PM2.5 ${Math.round(pm25)} µg/m³ (surface)` : null,
+      visibilityM != null ? `visibility ${Math.round(visibilityM / 1000)} km` : null,
+    ].filter(Boolean).join(' · ')
+    return (
+      <InfoTip tip={<>Smoke / aerosol haze — dims stars and flattens contrast even under a cloudless sky. {readings}. Penalized in the hourly rating past AOD 0.3 or PM2.5 35.</>}>
+        <span className="wx-cond-word">{label}</span>
+      </InfoTip>
+    )
   }
 
   // Wind/gust: only when there's no active precip (a rain/snow/fog icon already implies
@@ -411,7 +420,7 @@ function WeatherTable({ points, events = [], tz, imperial, moonrise, moonset, is
   })()
 
   return (
-    <details className="wx-details" open>
+    <details id="report-timeline" className="wx-details" open>
       <summary>
         Night Timeline
         {sunsetTs !== -Infinity && sunriseTs !== Infinity &&
@@ -431,7 +440,13 @@ function WeatherTable({ points, events = [], tz, imperial, moonrise, moonset, is
                 <th>Time</th>
                 <th className="wx-cond-col"></th>
                 <th className="wx-cloud-col wx-cloud-hdr">Cloud %<br />Low/Med/High</th>
-                {hasAtmos  && <th className="wx-atmos-col wx-atmos-hdr">Seeing /<br />Transp.</th>}
+                {hasAtmos  && (
+                  <th className="wx-atmos-col wx-atmos-hdr">
+                    <InfoTip tip={<>Seeing — turbulence blur in arcseconds: under 1.5″ is pin-sharp, over 2.5″ smears stars (matters most at long focal lengths). Transparency — how cleanly light passes the air column: Excellent → Poor. Both from 7Timer's astro forecast.</>}>
+                      Seeing /<br />Transp.
+                    </InfoTip>
+                  </th>
+                )}
                 {(hasTemp || hasDew) && <th className="wx-temp-col wx-temp-hdr">TEMP/<br />DEW PT</th>}
                 <th className="wx-wind-col">Wind</th>
               </tr>
@@ -628,10 +643,10 @@ function WxProvenanceBadge({ source, fetchedAt }: { source: string | null; fetch
 
 // ── Metadata row ─────────────────────────────────────────────────────────────
 
-function MetaRow({ k, v, icon }: { k: string; v: string; icon?: React.ReactNode }) {
+function MetaRow({ k, v, icon, tip }: { k: string; v: string; icon?: React.ReactNode; tip?: React.ReactNode }) {
   return (
     <div className="meta-row">
-      <span className="meta-k">{k}:</span>
+      <span className="meta-k">{tip ? <InfoTip tip={tip}>{k}</InfoTip> : k}:</span>
       <span className="meta-v" style={icon ? { display: 'inline-flex', alignItems: 'center', gap: 6 } : undefined}>
         {icon}{v}
       </span>
@@ -953,7 +968,11 @@ function WaypointsAccordion({ waypoints, summary, report }: {
 function MoonBadge({ type, severity }: { type: 'penalty' | 'limited'; severity?: string | null }) {
   const base = type === 'penalty' ? 'Moon interference' : 'Moon limited'
   const text = severity ? `${base}: ${severity}` : base
-  return <span className="mw-moon-badge">{text}</span>
+  return (
+    <InfoTip tip={<>Moon wash — scattered moonlight brightening the sky along this line of sight (Krisciunas &amp; Schaefer 1991). Severity comes from phase, moon altitude, and angular separation, not illumination % alone.</>}>
+      <span className="mw-moon-badge">{text}</span>
+    </InfoTip>
+  )
 }
 
 
@@ -1874,7 +1893,11 @@ function MeteorShowerCard({ target, zhr, report }: {
     <div className="ms-card">
       <div className="ms-header-row">
         <span className="ms-name">{target.name} Meteor Shower</span>
-        <span className="ms-zhr">Peak ZHR {zhr}</span>
+        <span className="ms-zhr">
+          <InfoTip tip={<>ZHR — zenithal hourly rate: meteors per hour for a single observer under a perfectly dark sky with the radiant overhead. Field counts run well below it.</>}>
+            Peak ZHR {zhr}
+          </InfoTip>
+        </span>
       </div>
       {target.note && <div className="ms-note">{target.note}</div>}
       {w.peak_time && w.peak_alt_deg != null && (
@@ -2879,6 +2902,48 @@ export default function ReportCard({
     return parts.join(' · ')
   })()
 
+  // Shareable permalink: the URL already tracks location + date (runQuery and
+  // handleDateDetail both replaceState), so copying it is the whole feature.
+  const [copied, setCopied] = useState(false)
+  async function copyLink() {
+    const url = window.location.href
+    let ok = false
+    try {
+      await navigator.clipboard.writeText(url)
+      ok = true
+    } catch {
+      // Async Clipboard needs a secure context + user activation — fall back to
+      // the legacy selection path (old Safari, embedded webviews).
+      const ta = document.createElement('textarea')
+      ta.value = url
+      ta.style.position = 'fixed'
+      ta.style.opacity = '0'
+      document.body.appendChild(ta)
+      ta.select()
+      try { ok = document.execCommand('copy') } catch { ok = false }
+      ta.remove()
+    }
+    if (ok) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1600)
+    }
+  }
+
+  // Sticky section nav — only sections actually rendered this query get links.
+  const hasTimeline = r.events.length > 0 || (showWeather && (r.weather_points?.length ?? 0) > 0)
+  const navSections: [string, string][] = [
+    ['report-planning', 'Planning'],
+    ...(hasTimeline ? [['report-timeline', 'Timeline'] as [string, string]] : []),
+    ...(showTargets ? [['report-targets', 'Sky Features'] as [string, string]] : []),
+    ...(showSatellites ? [['report-satellites', 'Satellites'] as [string, string]] : []),
+  ]
+  function jumpTo(id: string) {
+    const el = document.getElementById(id)
+    if (!el) return
+    if (el instanceof HTMLDetailsElement) el.open = true // jumping to a collapsed section expands it
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
   const placePrimary = r.display_name.split(',')[0].trim()
   const placeSecondary = r.display_name.includes(',')
     ? r.display_name.split(',').slice(1).join(',').trim()
@@ -2910,13 +2975,33 @@ export default function ReportCard({
             {formattedDate}  ·  {tzTitle(tz)}
           </p>
         </div>
-        {onToggleUnits && (
-          <div className="units-toggle" role="group" aria-label="Unit system">
-            <button type="button" className={!imperial ? 'active' : ''} onClick={() => onToggleUnits(false)}>°C / m/s</button>
-            <button type="button" className={imperial ? 'active' : ''} onClick={() => onToggleUnits(true)}>°F / mph</button>
-          </div>
-        )}
+        <div className="report-head-actions">
+          <button
+            type="button"
+            className={`copy-link-btn${copied ? ' copied' : ''}`}
+            onClick={copyLink}
+            title="Copy a shareable link to this report"
+          >
+            {copied ? 'Copied ✓' : 'Copy Link'}
+          </button>
+          {onToggleUnits && (
+            <div className="units-toggle" role="group" aria-label="Unit system">
+              <button type="button" className={!imperial ? 'active' : ''} onClick={() => onToggleUnits(false)}>°C / m/s</button>
+              <button type="button" className={imperial ? 'active' : ''} onClick={() => onToggleUnits(true)}>°F / mph</button>
+            </div>
+          )}
+        </div>
       </header>
+
+      {navSections.length > 1 && (
+        <nav className="report-nav" aria-label="Report sections">
+          {navSections.map(([id, label]) => (
+            <button key={id} type="button" className="report-nav-link" onClick={() => jumpTo(id)}>
+              {label}
+            </button>
+          ))}
+        </nav>
+      )}
 
       <div className={`overall band-${scoreBand(r.score)}`}>
         <div className="overall-score-block">
@@ -2924,7 +3009,11 @@ export default function ReportCard({
             <div className="overall-num">{r.score.toFixed(1)}</div>
             <div className="overall-label">{scoreLabel(r.score)}</div>
           </div>
-          <div className="overall-sub">0–10 composite score</div>
+          <div className="overall-sub">
+            <InfoTip tip={<>Weighted geometric mean of Weather 40% · Lunar 25% · Dark Hours 25% · Dark Sky 10% (weights redistribute when a factor is unavailable). Geometric means one hard zero — full overcast, full moon — zeroes the whole night, just like it does in the field.</>}>
+              0–10 composite score
+            </InfoTip>
+          </div>
           {verdict && <div className="overall-verdict">{verdict}</div>}
           {r.score < 6 && nextGoodNight && (
             <button
@@ -2945,15 +3034,26 @@ export default function ReportCard({
           )}
         </div>
           <div className="meta">
-        {shortLps && <MetaRow k="Light Pollution" v={shortLps} />}
+        {shortLps && (
+          <MetaRow
+            k="Light Pollution"
+            v={shortLps}
+            tip={<>Bortle class 1 (pristine) to 9 (inner city), derived from satellite radiance{lp?.source ? ` (${lp.source})` : ''}. SQM is zenith sky brightness in mag/arcsec² — each +1 is ~2.5× darker; 21.7+ is a genuinely dark site.</>}
+          />
+        )}
 
         {(r.active_showers?.length ?? 0) > 0 && (
           <MetaRow
             k="Meteor Showers"
             v={r.active_showers.map(s => `${s.name}  ·  ${s.note}  ·  ZHR ${s.zhr}`).join(',  ')}
+            tip={<>ZHR — zenithal hourly rate: meteors per hour for a single observer under a perfectly dark sky with the radiant overhead. Field counts run well below it; it's a comparison index, not a promise.</>}
           />
         )}
-        <MetaRow k="Clear Dark Sky" v={darkStrCard} />
+        <MetaRow
+          k="Clear Dark Sky"
+          v={darkStrCard}
+          tip={<>Hours you can actually shoot: astronomical darkness (sun ≥18° below the horizon), minus moon interference, minus hours clouded over (&gt;50% cover).</>}
+        />
         {showWeather && r.weather_score != null && (
           <MetaRow
             k="Weather"
@@ -2971,14 +3071,26 @@ export default function ReportCard({
       </div>
 
       <div className="bars">
-        {r.score_components.bortle  != null && <ScoreBar label="Dark Sky"      value={r.score_components.bortle} />}
-        {r.score_components.moon    != null && <ScoreBar label="Lunar"         value={r.score_components.moon} />}
-        {r.score_components.dark    != null && <ScoreBar label="Dark Hours"    value={r.score_components.dark} />}
-        {showWeather && r.score_components.weather != null && <ScoreBar label="Weather" value={r.score_components.weather} />}
+        {r.score_components.bortle != null && (
+          <ScoreBar label="Dark Sky" value={r.score_components.bortle}
+            tip={<>10% of the composite — the Bortle class at this location. Fixed for the spot; the only lever is going somewhere darker (see Find Sky Nearby).</>} />
+        )}
+        {r.score_components.moon != null && (
+          <ScoreBar label="Lunar" value={r.score_components.moon}
+            tip={<>25% of the composite — Krisciunas &amp; Schaefer scattered-moonlight model: phase, moon altitude, and hours above the horizon, distance-corrected. A bright moon that sets early can still score well.</>} />
+        )}
+        {r.score_components.dark != null && (
+          <ScoreBar label="Dark Hours" value={r.score_components.dark}
+            tip={<>25% of the composite — tonight's moon-free dark hours measured against this lunar cycle's average, so the score reflects what this month can actually offer.</>} />
+        )}
+        {showWeather && r.score_components.weather != null && (
+          <ScoreBar label="Weather" value={r.score_components.weather}
+            tip={<>40% of the composite — hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, wind, and humidity.</>} />
+        )}
       </div>
 
 
-        <details className="planning-tools-section" open>
+        <details id="report-planning" className="planning-tools-section" open>
         <summary>Planning Tools{planningBrief && <span className="sum-brief"> · {planningBrief}</span>}</summary>
         <div className="planning-tools-body">
           <div className="planning-tool">
@@ -3057,7 +3169,7 @@ export default function ReportCard({
         })()
 
         return (
-        <details className="targets" open>
+        <details id="report-targets" className="targets" open>
           <summary>
             Prominent Sky Features{targetsBrief && <span className="sum-brief"> · {targetsBrief}</span>}
           </summary>
@@ -3116,7 +3228,7 @@ export default function ReportCard({
       {showSatellites && (
         // Deliberately collapsed by default — reference material, not verdict.
         // The .sum-brief keeps the takeaway visible without expanding.
-        <details className="sat-section">
+        <details id="report-satellites" className="sat-section">
           <summary>Satellite Ephemeris{satBrief && <span className="sum-brief"> · {satBrief}</span>}</summary>
           <div className="sat-body">
             <SatellitePasses report={r} isFetching={isFetchingDetails} cathodeSnap={cathodeSnap} />

--- a/apps/web/src/shared.tsx
+++ b/apps/web/src/shared.tsx
@@ -1,3 +1,5 @@
+import { useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { scoreBand } from './format'
 
 // ── Moon phase image (NASA SVS) ──────────────────────────────────────────────
@@ -31,13 +33,63 @@ export function MoonPhaseSvg({ phaseName, size = 22 }: {
   )
 }
 
+// ── Info popover ─────────────────────────────────────────────────────────────
+// Hover/focus explainer for domain terms (Bortle, seeing, ZHR, score weights…).
+// The bubble renders through a portal with fixed positioning because several
+// hosts (Night Timeline, targets table) sit inside overflow-x:auto wrappers
+// that would clip an absolutely-positioned child. Focusable so it works on
+// keyboard and tap; pointer-events:none on the bubble keeps hover stable.
+
+const TIP_HALF_W = 140 // half of max bubble width + margin, for viewport clamping
+
+export function InfoTip({ tip, children }: { tip: ReactNode; children: ReactNode }) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [pos, setPos] = useState<{ x: number; y: number; below: boolean } | null>(null)
+
+  function show() {
+    const r = ref.current?.getBoundingClientRect()
+    if (!r) return
+    const below = r.top < 130 // no headroom above → open downward
+    setPos({
+      x: Math.max(TIP_HALF_W, Math.min(window.innerWidth - TIP_HALF_W, r.left + r.width / 2)),
+      y: below ? r.bottom : r.top,
+      below,
+    })
+  }
+  const hide = () => setPos(null)
+
+  return (
+    <span
+      ref={ref}
+      className="info-tip"
+      tabIndex={0}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {children}
+      {pos && createPortal(
+        <span
+          className={`info-tip-bubble${pos.below ? ' below' : ''}`}
+          role="tooltip"
+          style={{ left: pos.x, top: pos.y }}
+        >
+          {tip}
+        </span>,
+        document.body,
+      )}
+    </span>
+  )
+}
+
 // ── Score bar ────────────────────────────────────────────────────────────────
 
-export function ScoreBar({ label, value }: { label: string; value: number }) {
+export function ScoreBar({ label, value, tip }: { label: string; value: number; tip?: ReactNode }) {
   const pct = Math.max(0, Math.min(100, value * 10))
   return (
     <div className="bar-row">
-      <span className="bar-label">{label}</span>
+      <span className="bar-label">{tip ? <InfoTip tip={tip}>{label}</InfoTip> : label}</span>
       <span className="bar-track">
         <span className={`bar-fill band-${scoreBand(value)}`} style={{ width: `${pct}%` }} />
       </span>


### PR DESCRIPTION
## Summary
- **Trust layer**: reusable `InfoTip` popover (body-portal + fixed positioning so `overflow-x:auto` table wrappers can't clip it; focusable for keyboard/tap) attached to 14 spots on a live report: the composite score (weights + why geometric), each score bar (weight + driving inputs), Bortle/SQM, Clear Dark Sky, ZHR (meta row + meteor cards), the Seeing/Transp. column header, and moon-wash badges.
- **Haze promoted**: the timeline's `Haze / Haze: Aloft / Haze: Surface` words now expose their AOD / PM2.5 / visibility readings on hover — previously computed but invisible.
- **Sticky section nav**: `PLANNING · TIMELINE · SKY FEATURES · SATELLITES` pinned bar; jumping to a collapsed section expands it. Links render only for sections present in the query.
- **Copy Link**: shareable permalink button (URL was already query/drill-in synced); `execCommand` fallback for legacy webviews.
- **Heatmap rebalance**: 30-day grid capped at 520px and centered.
- **Fix**: `html/body` `overflow-x: hidden` → `clip` — `hidden` creates a scroll container on body which silently disables `position: sticky`; `clip` guards horizontal overflow identically without doing so.

## Testing
- `pytest -q`: 624 passed, 7 skipped
- `tsc --noEmit` + `vite build` clean
- Browser-verified: sticky pinned at 2,500px scroll; jump-expands collapsed satellites; copy-link flash confirmed via trusted click; red-mode measured pure-red-channel on all new elements; 375px mobile has no horizontal overflow and the nav fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)