### PR TITLE
Fix moon phase naming: principal phases only on the day of the event

### DIFF
--- a/PyNightSkyPredictor/sky_events.py
+++ b/PyNightSkyPredictor/sky_events.py
@@ -18,16 +18,31 @@ from . import cache as _cache
 
 log = logging.getLogger(__name__)
 
-PHASE_NAMES = [
+# The four principal phases are instants (phase angle exactly 0/90/180/270),
+# not 45°-wide spans. Label them only within ±half a day of the event —
+# ±6.1° at the mean synodic rate of 12.19°/day — matching the almanac
+# convention that "Third Quarter" is the day of the quarter, and every other
+# day between quarters is crescent/gibbous. (The previous table treated each
+# name as a band *starting at* the instant, so e.g. three days after the
+# quarter — an obvious waning crescent — still read "Third Quarter".)
+PRINCIPAL_PHASES = [
     (0,   "New Moon"),
-    (45,  "Waxing Crescent"),
     (90,  "First Quarter"),
-    (135, "Waxing Gibbous"),
     (180, "Full Moon"),
-    (225, "Waning Gibbous"),
     (270, "Third Quarter"),
-    (315, "Waning Crescent"),
+    (360, "New Moon"),
 ]
+INTERMEDIATE_NAMES = ["Waxing Crescent", "Waxing Gibbous", "Waning Gibbous", "Waning Crescent"]
+PRINCIPAL_WINDOW_DEG = 6.1
+
+
+def phase_name_from_angle(angle_deg: float) -> str:
+    """Phase name for a sun–moon elongation angle (0° = new, 180° = full)."""
+    a = angle_deg % 360.0
+    for p_angle, p_name in PRINCIPAL_PHASES:
+        if abs(a - p_angle) <= PRINCIPAL_WINDOW_DEG:
+            return p_name
+    return INTERMEDIATE_NAMES[int(a // 90.0)]
 
 
 _load = Loader(str(Path(__file__).resolve().parent))
@@ -466,7 +481,7 @@ def moon_phase_info(at_utc: object) -> tuple:
     t   = ts.from_datetime(at_utc)
     angle        = almanac.moon_phase(eph, t).degrees
     illumination = round((1 - math.cos(math.radians(angle))) / 2 * 100, 1)
-    phase_name   = next(name for thresh, name in reversed(PHASE_NAMES) if angle >= thresh)
+    phase_name   = phase_name_from_angle(angle)
     log.debug("Moon phase angle: %.2f°  →  %s  (%.1f%% illuminated)", angle, phase_name, illumination)
     return phase_name, illumination
 

--- a/tests/test_sky_events.py
+++ b/tests/test_sky_events.py
@@ -162,6 +162,40 @@ class TestFindLastEvent:
 
 
 # ---------------------------------------------------------------------------
+# Phase naming (pure angle math, no ephemeris)
+# ---------------------------------------------------------------------------
+
+class TestPhaseNameFromAngle:
+    """Principal phases are ±half-day windows around the instant; everything
+    between is crescent/gibbous. Regression: 2026-07-08..13 (angles ~274–342°)
+    must read Waning Crescent after the day of the quarter, not Third Quarter."""
+
+    @pytest.mark.parametrize("angle,expected", [
+        (0.0,   "New Moon"),
+        (6.0,   "New Moon"),
+        (6.2,   "Waxing Crescent"),
+        (45.0,  "Waxing Crescent"),
+        (83.8,  "Waxing Crescent"),
+        (84.0,  "First Quarter"),
+        (90.0,  "First Quarter"),
+        (96.2,  "Waxing Gibbous"),
+        (135.0, "Waxing Gibbous"),
+        (180.0, "Full Moon"),
+        (186.2, "Waning Gibbous"),
+        (225.0, "Waning Gibbous"),
+        (270.0, "Third Quarter"),
+        (273.9, "Third Quarter"),   # evening of the quarter day (2026-07-07/08)
+        (286.9, "Waning Crescent"), # one day later — the reported regression
+        (297.1, "Waning Crescent"), # 2026-07-10, illum ~25%
+        (341.9, "Waning Crescent"), # 2026-07-13, illum ~2.5%
+        (356.4, "New Moon"),        # day of new moon (2026-07-14)
+        (360.0, "New Moon"),
+    ])
+    def test_angle_bands(self, angle, expected):
+        from PyNightSkyPredictor.sky_events import phase_name_from_angle
+        assert phase_name_from_angle(angle) == expected
+
+
 # Ephemeris-based integration tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The phase table treated each name as a 45°-wide band **starting at** the instant, so the ~3.7 days after a quarter/new/full still carried the principal name — e.g. **2026-07-10 (25% illuminated, waning) read "Third Quarter"**, and even the day of new moon (Jul 14, 0.1%) read "Waning Crescent". The wrong name also selected the wrong NASA SVS phase icon in the web UI (`MoonPhaseSvg` maps by name; its mapping itself is correct for all eight names).

Fix: principal phases are instants — label them within ±6.1° of the event (half a day at the mean synodic rate), intermediate crescent/gibbous names everywhere between. This is the standard almanac convention. Extracted `phase_name_from_angle()` as a pure function.

## Ephemeris verification (2026-07-06 → 15, evening MST)
Waning Gibbous → Waning Gibbous → **Third Quarter (Jul 7)** → Waning Crescent ×5 → **New Moon (Jul 14)** → Waxing Crescent — matches timeanddate/USNO.

## Testing
- 19 new offline boundary tests for `phase_name_from_angle` incl. the July 2026 regression angles
- Full suite: 643 passed, 7 skipped
- Live API check: `/night?date=2026-07-10` now returns `Waning Crescent · 15.5%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)