### PR TITLE
Moon/star-aware partly-cloudy icons in the night timeline

### DIFF
--- a/apps/web/src/report/icons.tsx
+++ b/apps/web/src/report/icons.tsx
@@ -33,6 +33,28 @@ export const WI_PATHS: Record<string, string> = {
   "windy": "M4.65,15.5c0-0.22,0.08-0.41,0.23-0.56c0.16-0.15,0.35-0.22,0.57-0.22h12.08c0.22,0,0.4,0.07,0.54,0.22 c0.14,0.15,0.22,0.34,0.22,0.57c0,0.22-0.07,0.4-0.22,0.54c-0.14,0.14-0.32,0.22-0.54,0.22H5.45c-0.22,0-0.42-0.07-0.57-0.22 C4.72,15.9,4.65,15.72,4.65,15.5z M7.06,12.6c0-0.22,0.08-0.4,0.23-0.55c0.15-0.15,0.34-0.23,0.56-0.23h12.09 c0.21,0,0.39,0.08,0.54,0.23c0.15,0.15,0.22,0.33,0.22,0.55c0,0.22-0.07,0.4-0.22,0.56c-0.15,0.15-0.33,0.23-0.54,0.23H7.86 c-0.22,0-0.41-0.08-0.56-0.23S7.06,12.82,7.06,12.6z M8.68,18.34c0-0.21,0.08-0.39,0.24-0.54c0.14-0.14,0.32-0.22,0.54-0.22h12.1 c0.22,0,0.41,0.07,0.56,0.22c0.15,0.14,0.22,0.32,0.22,0.54s-0.08,0.41-0.23,0.56s-0.34,0.23-0.56,0.23H9.46 c-0.22,0-0.4-0.08-0.56-0.23S8.68,18.56,8.68,18.34z M19.26,15.5c0-0.23,0.07-0.42,0.22-0.57c0.15-0.15,0.34-0.22,0.57-0.22h4.52 c0.23,0,0.42,0.07,0.57,0.22c0.15,0.15,0.22,0.34,0.22,0.56c0,0.22-0.07,0.4-0.22,0.54c-0.15,0.14-0.34,0.22-0.56,0.22h-4.52 c-0.23,0-0.42-0.07-0.57-0.22C19.33,15.9,19.26,15.72,19.26,15.5z",
 }
 
+// wi-night-alt-cloudy — moon tucked behind the cloud (occluded part cut in the
+// path data, same as the vendored glyphs above). Kept out of WI_PATHS's
+// alphabetical block only to sit next to its composed star-sky counterpart.
+WI_PATHS['night-alt-cloudy'] = "M4.14,16.9c0-1.16,0.35-2.18,1.06-3.08s1.62-1.47,2.74-1.72c0.23-1.03,0.7-1.93,1.4-2.7c0.7-0.77,1.55-1.32,2.53-1.65 c0.62-0.21,1.26-0.32,1.93-0.32c0.81,0,1.6,0.16,2.35,0.48c0.28-0.47,0.61-0.88,0.99-1.22c0.38-0.34,0.77-0.61,1.17-0.79 c0.4-0.18,0.8-0.32,1.18-0.41s0.76-0.13,1.12-0.13c0.38,0,0.79,0.05,1.23,0.16l0.82,0.25c0.14,0.06,0.18,0.13,0.14,0.22l-0.14,0.6 c-0.07,0.31-0.1,0.6-0.1,0.86c0,0.31,0.05,0.63,0.15,0.95c0.1,0.32,0.24,0.63,0.44,0.94c0.19,0.31,0.46,0.58,0.8,0.83 c0.34,0.25,0.72,0.44,1.15,0.57l0.62,0.22c0.1,0.03,0.15,0.08,0.15,0.16c0,0.02-0.01,0.04-0.02,0.07l-0.18,0.67 c-0.27,1.08-0.78,1.93-1.5,2.57c0.4,0.7,0.62,1.45,0.65,2.24c0.01,0.05,0.01,0.12,0.01,0.23c0,0.89-0.22,1.72-0.67,2.48 c-0.44,0.76-1.05,1.36-1.8,1.8c-0.76,0.44-1.59,0.67-2.48,0.67H9.07c-0.89,0-1.72-0.22-2.48-0.67s-1.35-1.05-1.79-1.8 S4.14,17.8,4.14,16.9z M5.85,16.9c0,0.89,0.32,1.66,0.96,2.31c0.64,0.65,1.39,0.98,2.26,0.98h10.81c0.89,0,1.65-0.32,2.28-0.97 s0.95-1.42,0.95-2.32c0-0.88-0.32-1.63-0.96-2.26c-0.64-0.63-1.4-0.95-2.28-0.95h-1.78l-0.1-0.75c-0.1-1.01-0.52-1.88-1.26-2.59 s-1.62-1.11-2.63-1.2c-0.03,0-0.08,0-0.15-0.01c-0.07-0.01-0.11-0.01-0.15-0.01c-0.51,0-1.02,0.1-1.54,0.29V9.4 c-0.73,0.28-1.35,0.74-1.84,1.37c-0.5,0.63-0.8,1.35-0.9,2.17l-0.07,0.72l-0.68,0.03c-0.84,0.1-1.54,0.45-2.1,1.06 S5.85,16.07,5.85,16.9z M17.6,8.79c1.06,0.91,1.72,1.97,1.97,3.18h0.32c1.24,0,2.3,0.39,3.17,1.18c0.33-0.31,0.58-0.67,0.76-1.07 c-0.91-0.43-1.63-1.09-2.16-1.97c-0.52-0.88-0.79-1.81-0.79-2.78V7.09c-0.05-0.01-0.13-0.01-0.24-0.01 c-0.58-0.01-1.15,0.13-1.7,0.44C18.38,7.82,17.93,8.24,17.6,8.79z"
+
+// One four-point twinkle lifted from the `stars` glyph (its first subpath,
+// centred ~(7.7, 16.2)) — repositioned into clear sky by CloudStarIcon below.
+const STAR_SPARKLE = "M5.37,16.18c0.65-0.03,1.2-0.28,1.65-0.75c0.45-0.47,0.68-1.03,0.68-1.68c0,0.65,0.22,1.21,0.67,1.68 c0.45,0.47,1,0.72,1.65,0.75c-0.65,0.03-1.2,0.28-1.65,0.75c-0.45,0.47-0.67,1.03-0.67,1.68c0-0.65-0.22-1.21-0.68-1.68 C6.57,16.46,6.02,16.21,5.37,16.18z"
+
+// Cloud with a star in the clear sky above it — the moon-down counterpart of
+// wi-night-alt-cloudy (no stock weather-icons glyph pairs a star with a cloud;
+// composed from vendored subpaths, mirroring the old lucide CloudStar).
+export function CloudStarIcon({ size = 19, style }: { size?: number; style?: React.CSSProperties }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 30 30" fill="currentColor" style={{ flexShrink: 0, ...style }}>
+      <path d={WI_PATHS['cloud']} />
+      {/* sparkle moved from (7.7, 16.2) to the upper-right sky, clear of the cloud outline */}
+      <path d={STAR_SPARKLE} transform="translate(15.6, -10.4)" />
+    </svg>
+  )
+}
+
 export function WiIcon({ name, size = 19, style }: { name: string; size?: number; style?: React.CSSProperties }) {
   const d = WI_PATHS[name]
   if (!d) return null
@@ -45,13 +67,17 @@ export function WiIcon({ name, size = 19, style }: { name: string; size?: number
 
 // Sky-state icon from cloud cover % alone — shared by the WMO-code path (codes 0-3, where
 // cloud_cover_pct is more precise than the coarse API code) and the no-code fallback path
-// (providers, like 7Timer, that never supply a WMO code at all). Only the clear-sky tier
-// distinguishes moon visibility (wi-stars vs wi-night-clear) — once there's cloud cover,
-// the clouds already block star/moon visibility, so partly-cloudy/cloudy don't need a
-// separate moon-aware variant.
+// (providers, like 7Timer, that never supply a WMO code at all). Clear and partly-cloudy
+// tiers both distinguish moon state: moon up shows the moon (clear crescent / behind the
+// cloud), moon down shows stars — partly cloudy still leaves sky visible, so the icon
+// should say what's in it. Only overcast drops the distinction.
 export function skyIconFromCloudCover(cloudCover: number, moonUp: boolean, size: number) {
   if (cloudCover <= 25) return <WiIcon name={moonUp ? 'night-clear' : 'stars'} size={size} />
-  if (cloudCover <= 65) return <WiIcon name="cloud" size={size} />
+  if (cloudCover <= 65) {
+    return moonUp
+      ? <WiIcon name="night-alt-cloudy" size={size} />
+      : <CloudStarIcon size={size} />
+  }
   return <WiIcon name="cloudy" size={size} />
 }
 


### PR DESCRIPTION
## Summary
The icon migration in `800591f` collapsed the partly-cloudy tier (26–65% cloud) to a bare cloud glyph, dropping the moon/star context the old lucide `CloudMoon`/`CloudStar` pair conveyed. This restores the distinction in the vendored weather-icons language:

- **Moon up** → `wi-night-alt-cloudy` (moon tucked behind the cloud; genuine erikflowers path data, occlusion cut in the path)
- **Moon down / dark** → composed cloud-with-star (vendored `cloud` path + one twinkle lifted from the `stars` glyph placed in clear sky — the set has no stock star-behind-cloud)

## Testing
- Verified live on a San Antonio night spanning moonrise: 9 PM–12 AM (moon down, 29–56% cloud) render cloud+star; clear hours render stars; hours after the 1:17 AM moonrise divider render the crescent.
- Artwork checked at 64/32/12 px (12 px = targets-table size); `currentColor` fill so red mode inherits automatically.
- `tsc -b` + `vite build` clean; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)