### PR TITLE
Scope the forecast provenance badge to the reported night

### DIFF
--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -61,6 +61,20 @@ def _wx_deserialize(cached: dict) -> tuple:
     return points, cached["source"], cached.get("fetched_at")
 
 
+def _scope_wx_source(source: str | None, night_points: list) -> str | None:
+    """Re-scope a fetch-wide source label to the night being reported.
+
+    wx.forecast() labels the source over the whole ~16-day fetch, so it says
+    "+ 7Timer" whenever any day in the series got seeing data — but 7Timer
+    only covers ~3 days. Keep the suffix only if this night's points actually
+    carry seeing; otherwise the provenance badge would credit 7Timer on nights
+    it never reached.
+    """
+    if source and "+ 7Timer" in source and not any(p.seeing_arcsec is not None for p in night_points):
+        return source.replace(" + 7Timer", "")
+    return source
+
+
 @dataclass
 class NightReport:
     # Location & date
@@ -762,6 +776,7 @@ def assemble_night(
                         weather_score = scoring.weighted_weather_score(
                             night_points, night_start, night_end, wx.rate_conditions
                         )
+                        wx_source = _scope_wx_source(wx_source, night_points)
                     else:
                         wx_no_data    = True
                         wx_source     = None

--- a/tests/test_predictor_formulas.py
+++ b/tests/test_predictor_formulas.py
@@ -112,3 +112,51 @@ class TestBortleScoreConversion:
         for b in range(1, 10):
             s = _bortle_score(b)
             assert 0.0 <= s <= 10.0
+
+
+# ---------------------------------------------------------------------------
+# Provenance re-scoping — _scope_wx_source()
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timezone
+
+from PyNightSkyPredictor.predictor import _scope_wx_source
+from PyNightSkyPredictor.weather import WeatherPoint
+
+
+def _pt(seeing):
+    return WeatherPoint(
+        time=datetime(2026, 7, 20, 3, 0, tzinfo=timezone.utc),
+        cloud_cover_pct=10, seeing_arcsec=seeing, transparency=None,
+        humidity_pct=None, wind_speed_ms=None, wind_direction_deg=None,
+        lifted_index=None, precip_type=None, temperature_c=None,
+        dew_point_c=None, feels_like_c=None, precip_probability_pct=None,
+        weather_code=None, aerosol_optical_depth=None, pm2_5=None,
+        cloud_cover_low_pct=None, cloud_cover_mid_pct=None,
+        cloud_cover_high_pct=None, visibility_m=None, wind_gust_ms=None,
+    )
+
+
+class TestScopeWxSource:
+    """The fetch-wide label says "+ 7Timer" if ANY day of the ~16-day series got
+    seeing, but 7Timer covers ~3 days — nights beyond its range must not credit it."""
+
+    def test_strips_7timer_when_night_has_no_seeing(self):
+        assert _scope_wx_source("Open-Meteo + 7Timer", [_pt(None), _pt(None)]) == "Open-Meteo"
+
+    def test_keeps_7timer_when_night_has_seeing(self):
+        assert _scope_wx_source("Open-Meteo + 7Timer", [_pt(None), _pt(1.2)]) == "Open-Meteo + 7Timer"
+
+    def test_plain_primary_untouched(self):
+        assert _scope_wx_source("Open-Meteo", [_pt(None)]) == "Open-Meteo"
+
+    def test_7timer_full_primary_untouched(self):
+        # Fallback mode: 7Timer IS the primary — its points are 7Timer data
+        # regardless of seeing, so the bare label must survive.
+        assert _scope_wx_source("7Timer", [_pt(None)]) == "7Timer"
+
+    def test_none_source_passthrough(self):
+        assert _scope_wx_source(None, [_pt(None)]) is None
+
+    def test_empty_points_strips_suffix(self):
+        assert _scope_wx_source("Open-Meteo + 7Timer", []) == "Open-Meteo"


### PR DESCRIPTION
## Summary
The Night Timeline's provenance badge showed `SOURCE: OPEN-METEO + 7TIMER` for dates beyond 7Timer's ~3-day range. `wx.forecast()` computes the label over the entire ~16-day fetch — if *any* day got seeing data (days 1–3 always do), the whole series was labeled `+ 7Timer`, and the per-night report kept that fetch-wide label.

Fix: new `_scope_wx_source()` in predictor.py re-scopes the label after the night's points are sliced — the `+ 7Timer` suffix survives only if this night's points actually carry seeing data. The bare `7Timer` full-primary-fallback label is untouched, and cached fetches are covered (re-scoping runs after cache read).

## Testing
- 6 new unit tests (strip/keep/fallback/None/empty cases); suite: 649 passed, 7 skipped
- Live API: tonight → `Open-Meteo + 7Timer` (12 pts with seeing); +10 days → `Open-Meteo` (0 pts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)