### PR TITLE
feat: collapse calendar outlook and improve report displays

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -1771,6 +1771,68 @@ def _extract_poi_candidates(
     return candidates
 
 
+def _poi_h3_lookup(
+    lat: float,
+    lon: float,
+    index: "_PoiIndex",
+) -> "tuple[str, str] | None":
+    """Return (name, poi_type) for the H3 res-7 cell at (lat, lon), or None.
+
+    Point-lookup mirror of _padus_h3_lookup, binary-searching the same sorted uint64
+    cell array _extract_poi_candidates scans by bbox. Used to verify/derive a display
+    name for an arbitrary (lat, lon) — e.g. a coordinate a user navigated straight to —
+    against the trusted, offline-built POI index rather than trusting client input.
+    """
+    import numpy as np
+    cell  = _h3_lib.str_to_int(_h3_lib.latlng_to_cell(lat, lon, 7))
+    cells = index.cells
+    i = int(np.searchsorted(cells, np.uint64(cell)))
+    if i < cells.size and cells[i] == cell:
+        return (index.names[int(index.name_codes[i])], _POI_TYPE_LABELS[int(index.poi_types[i])])
+    return None
+
+
+def _poi_reverse_name(lat: float, lon: float) -> "str | None":
+    """Resolve (lat, lon) to a verified "POI, Area" display name, or None if no POI
+    covers this point.
+
+    Both the POI and the area name come from local, offline-built indexes (the same
+    ones find_nearby uses) — never from client input — so the result can't be spoofed
+    by a crafted URL. A POI on PAD-US-blacklisted (military/tribal/restricted) land is
+    discarded, matching _offline_tier_name's rule for surfaced results.
+    """
+    if not _is_in_us(lat, lon):
+        return None
+    poi_index = _load_poi_h3_index()
+    if poi_index is None:
+        return None
+    try:
+        hit = _poi_h3_lookup(lat, lon, poi_index)
+    except Exception as exc:
+        log.debug("POI H3 lookup failed for (%.4f, %.4f): %s", lat, lon, exc)
+        return None
+    if hit is None:
+        return None
+    name, _poi_type = hit
+
+    area_name = None
+    padus_index = _load_padus_h3_index()
+    if padus_index is not None:
+        try:
+            padus_hit = _padus_h3_lookup(lat, lon, padus_index)
+        except Exception as exc:
+            log.debug("PAD-US H3 lookup failed for (%.4f, %.4f): %s", lat, lon, exc)
+            padus_hit = None
+        if padus_hit is not None:
+            unit_nm, is_blacklisted = padus_hit
+            if is_blacklisted:
+                return None  # never surface a name for restricted land
+            if _is_good_padus_name(unit_nm):
+                area_name = unit_nm
+
+    return f"{name}, {area_name}" if area_name else name
+
+
 def _is_good_padus_name(unit_nm: "str | None") -> bool:
     """Return True if unit_nm is a meaningful display name for a PAD-US unit.
 

--- a/PyNightSkyPredictor/location.py
+++ b/PyNightSkyPredictor/location.py
@@ -301,12 +301,20 @@ def timezone_for(lat: float, lon: float) -> ZoneInfo:
 
 
 def reverse_geocode(lat: float, lon: float) -> str | None:
-    """Reverse-geocode (lat, lon) to a human-readable city/town name.
+    """Reverse-geocode (lat, lon) to a human-readable name.
 
-    Returns "City, ST" for US locations, "City" elsewhere, or None if
-    the point is over water or the geocoder is unavailable.
+    Prefers a verified named POI from the local OSM/PAD-US index (see
+    darksky._poi_reverse_name) over the network settlement lookup — it's more specific
+    ("Nineteenmile Campground, Wenatchee National Forest" beats "Chelan, WA"), needs no
+    network call, and — unlike a client-supplied name — can't be spoofed by a crafted
+    URL since it's derived only from the coordinate against a trusted, offline index.
+    Falls back to "City, ST" for US locations, "City" elsewhere, or None if the point
+    is over water or the geocoder is unavailable.
     """
     from . import darksky
+    poi_name = darksky._poi_reverse_name(lat, lon)
+    if poi_name:
+        return poi_name
     return darksky._settlement(lat, lon)
 
 

--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -61,6 +61,20 @@ def _wx_deserialize(cached: dict) -> tuple:
     return points, cached["source"], cached.get("fetched_at")
 
 
+def _scope_wx_source(source: str | None, night_points: list) -> str | None:
+    """Re-scope a fetch-wide source label to the night being reported.
+
+    wx.forecast() labels the source over the whole ~16-day fetch, so it says
+    "+ 7Timer" whenever any day in the series got seeing data — but 7Timer
+    only covers ~3 days. Keep the suffix only if this night's points actually
+    carry seeing; otherwise the provenance badge would credit 7Timer on nights
+    it never reached.
+    """
+    if source and "+ 7Timer" in source and not any(p.seeing_arcsec is not None for p in night_points):
+        return source.replace(" + 7Timer", "")
+    return source
+
+
 @dataclass
 class NightReport:
     # Location & date
@@ -762,6 +776,7 @@ def assemble_night(
                         weather_score = scoring.weighted_weather_score(
                             night_points, night_start, night_end, wx.rate_conditions
                         )
+                        wx_source = _scope_wx_source(wx_source, night_points)
                     else:
                         wx_no_data    = True
                         wx_source     = None

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -193,7 +193,11 @@ def _parse_date(s: str | None, field: str = "date") -> date:
 
 
 def _resolve(location: str | None, lat: float | None, lon: float | None):
-    """Resolve a request's place to (lat, lon, display_name, ZoneInfo)."""
+    """Resolve a request's place to (lat, lon, display_name, ZoneInfo).
+
+    For a lat/lon request, `_loc.reverse_geocode` itself checks the local POI/PAD-US
+    index before falling back to the network settlement lookup — see its docstring.
+    """
     if location:
         try:
             la, lo, disp, tz_name = _loc.resolve(location)
@@ -273,9 +277,12 @@ def night(
     if date_only:
         # Location-keyed, not date-keyed — the client already has these from
         # the initial full fetch for this location and doesn't need them again.
+        # display_name is included here too, avoiding a wasted reverse-geocode/
+        # POI-index lookup on every "View Details" date-only click.
         d.pop("light_pollution", None)
         d.pop("bortle_score", None)
         d.pop("light_dome", None)
+        d.pop("display_name", None)
     return d
 
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -56,7 +56,7 @@ export default function App() {
     if (link) {
       const svg = redMode
         ? `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#000" rx="4"/><rect x="4" y="5" width="14" height="4" fill="none" stroke="#F00" stroke-width="1.5" rx="1"/><rect x="4" y="11" width="20" height="4" fill="#F00" fill-opacity=".4" rx="1"/><rect x="4" y="17" width="10" height="4" fill="#F00" fill-opacity=".7" rx="1"/><rect x="4" y="23" width="24" height="4" fill="#F00" rx="1"/></svg>`
-        : `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#1e1e1e" rx="4"/><rect x="4" y="5" width="14" height="4" fill="#D9534F" rx="1"/><rect x="4" y="11" width="20" height="4" fill="#F0AD4E" rx="1"/><rect x="4" y="17" width="10" height="4" fill="#5CB85C" rx="1"/><rect x="4" y="23" width="24" height="4" fill="#5BC0DE" rx="1"/></svg>`
+        : `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="#1e1e1e" rx="4"/><rect x="4" y="5" width="14" height="4" fill="#C85656" rx="1"/><rect x="4" y="11" width="20" height="4" fill="#D99B41" rx="1"/><rect x="4" y="17" width="10" height="4" fill="#3A8772" rx="1"/><rect x="4" y="23" width="24" height="4" fill="#5BC0DE" rx="1"/></svg>`
       link.href = `data:image/svg+xml;base64,${btoa(svg)}`
     }
   }, [redMode])
@@ -287,9 +287,9 @@ export default function App() {
 
         <h1>
           <span className="masthead-logo" aria-hidden="true">
-            <span className="masthead-logo-cell" style={{background:'#D9534F', width:'14px'}} />
-            <span className="masthead-logo-cell" style={{background:'#F0AD4E', width:'20px'}} />
-            <span className="masthead-logo-cell" style={{background:'#5CB85C', width:'10px'}} />
+            <span className="masthead-logo-cell" style={{background:'#C85656', width:'14px'}} />
+            <span className="masthead-logo-cell" style={{background:'#D99B41', width:'20px'}} />
+            <span className="masthead-logo-cell" style={{background:'#3A8772', width:'10px'}} />
             <span className="masthead-logo-cell" style={{background:'#5BC0DE', width:'24px'}} />
           </span>
           DarkHours

--- a/apps/web/src/CalendarRangePicker.tsx
+++ b/apps/web/src/CalendarRangePicker.tsx
@@ -24,15 +24,17 @@ function fmtShort(iso: string): string {
  */
 export default function CalendarRangePicker({
   state,
+  anchor,
   onApply,
 }: {
   state: CalendarPickerState
+  anchor: string
   onApply: (start: string, days: number) => void
 }) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
-  const [draftStart, setDraftStart] = useState(() => tonightIso())
-  const [draftEnd, setDraftEnd] = useState(() => addDaysIso(tonightIso(), 6))
+  const [draftStart, setDraftStart] = useState(anchor)
+  const [draftEnd, setDraftEnd] = useState(() => addDaysIso(anchor, 6))
 
   useEffect(() => {
     if (!open) return
@@ -60,7 +62,7 @@ export default function CalendarRangePicker({
   }
 
   function applyPreset(days: number) {
-    onApply(tonightIso(), days)
+    onApply(anchor, days)
     setOpen(false)
   }
 
@@ -78,7 +80,7 @@ export default function CalendarRangePicker({
     : 'Select range'
 
   const isActivePreset = (days: number) =>
-    state.phase === 'done' && state.days === days && state.data.date_start === tonightIso()
+    state.phase === 'done' && state.days === days && state.data.date_start === anchor
 
   return (
     <div className="crp-wrap" ref={wrapRef}>

--- a/apps/web/src/OutlookTelemetryRibbon.tsx
+++ b/apps/web/src/OutlookTelemetryRibbon.tsx
@@ -34,10 +34,11 @@ function cellAlpha(score: number): number {
  * factor in.
  */
 export default function OutlookTelemetryRibbon({
-  data, days, onViewDetails, isFetchingDetails, viewDetailsError,
+  data, days, startExpanded, onViewDetails, isFetchingDetails, viewDetailsError,
 }: {
   data: CalendarResult
   days: number
+  startExpanded?: boolean
   onViewDetails: (date: string) => void
   isFetchingDetails?: boolean
   viewDetailsError?: string | null
@@ -45,6 +46,7 @@ export default function OutlookTelemetryRibbon({
   const nights = useMemo(() => [...data.nights].sort((a, b) => a.date.localeCompare(b.date)), [data.nights])
   const best = data.ranked[0] as CalendarNight | undefined
   const [selectedDate, setSelectedDate] = useState<string | null>(best?.date ?? nights[0]?.date ?? null)
+  const [expanded, setExpanded] = useState(startExpanded ?? false)
   const selected = nights.find(n => n.date === selectedDate) ?? nights[0] ?? null
   const today = tonightIso()
 
@@ -78,98 +80,106 @@ export default function OutlookTelemetryRibbon({
         </div>
       )}
 
-      <div className="heatmap-body">
-        <div className="heatmap-dow-row" aria-hidden="true">
-          {DOW_SHORT.map((d, i) => <span key={i}>{d}</span>)}
-        </div>
-        <div className="heatmap-grid">
-          {cells.map((n, i) => {
-            if (!n) return <span key={`pad-${i}`} className="heatmap-cell heatmap-cell-empty" />
-            const band = n.score != null ? scoreBand(n.score) : null
-            const isPast = n.date < today
-            const isMuted = isPast || n.score == null
-            const isSelected = n.date === selectedDate
-            const isBest = n.date === best?.date
-            const { dow, mmdd } = dateParts(n.date)
-            const dayNum = Number(n.date.slice(8, 10))
-            return (
-              <button
-                key={n.date}
-                type="button"
-                className={[
-                  'heatmap-cell',
-                  band ? `hm-${band}` : '',
-                  isMuted ? 'muted' : '',
-                  isSelected ? 'selected' : '',
-                  isBest ? 'best' : '',
-                ].filter(Boolean).join(' ')}
-                style={n.score != null ? ({ '--cell-alpha': cellAlpha(n.score) } as CSSProperties) : undefined}
-                onClick={() => setSelectedDate(n.date)}
-                aria-pressed={isSelected}
-                title={`${dow} ${mmdd} — ${n.score != null ? n.score.toFixed(1) : 'N/A'}${isBest ? ' (best night)' : ''}`}
-                aria-label={`${dow} ${mmdd}, score ${n.score != null ? n.score.toFixed(1) : 'unavailable'}${isBest ? ', best night' : ''}${isSelected ? ', currently selected' : ''}`}
-              >
-                <span className="hm-day">{dayNum}</span>
-                <span className="hm-score">{n.score != null ? n.score.toFixed(1) : '—'}</span>
-              </button>
-            )
-          })}
-        </div>
-      </div>
+      <details
+        className="telemetry-collapse"
+        open={expanded}
+        onToggle={e => setExpanded(e.currentTarget.open)}
+      >
+        <summary>Calendar &amp; Next Best Night</summary>
 
-      <div className="telemetry-readout">
-        {selected ? (
-          <>
-            <div className="telemetry-selected-head">
-              <MoonPhaseSvg phaseName={selected.phase_name} illuminationPct={selected.illumination_pct} size={30} />
-              <div className="telemetry-selected-date">{dateParts(selected.date).long}</div>
-            </div>
-            <div className="meta-row">
-              <span className="meta-k">Score</span>
-              <span className={`meta-v${selectedBand ? ` telemetry-score-${selectedBand}` : ''}`}>
-                {selected.score != null ? `${selected.score.toFixed(1)} · ${scoreLabel(selected.score)}` : '—'}
-              </span>
-            </div>
-            <div className="meta-row">
-              <span className="meta-k">Dark Hours</span>
-              <span className="meta-v">{formatHm(selected.dark_hours)}</span>
-            </div>
-            <div className="meta-row">
-              <span className="meta-k">Lunar Conditions</span>
-              <span className="meta-v">{selected.phase_name} · {selected.illumination_pct.toFixed(0)}% illuminated</span>
-            </div>
-            {!selected.weather_informed && (
-              <p className="sat-notice">
-                Astronomy-only estimate —{' '}
-                {selected.wx_pending
-                  ? 'forecast not yet available for this date'
-                  : selected.wx_no_data
-                  ? 'weather provider returned no data for this date'
-                  : 'beyond the 16-day forecast horizon'}
-              </p>
-            )}
-            {sc && (
-              <div className="telemetry-mini-bars">
-                {sc.bortle != null && <ScoreBar label="Dark Sky" value={sc.bortle} />}
-                {sc.moon   != null && <ScoreBar label="Lunar"    value={sc.moon} />}
-                {sc.dark   != null && <ScoreBar label="Dark Hours" value={sc.dark} />}
-                {selected.weather_informed && sc.weather != null && <ScoreBar label="Weather" value={sc.weather} />}
+        <div className="heatmap-body">
+          <div className="heatmap-dow-row" aria-hidden="true">
+            {DOW_SHORT.map((d, i) => <span key={i}>{d}</span>)}
+          </div>
+          <div className="heatmap-grid">
+            {cells.map((n, i) => {
+              if (!n) return <span key={`pad-${i}`} className="heatmap-cell heatmap-cell-empty" />
+              const band = n.score != null ? scoreBand(n.score) : null
+              const isPast = n.date < today
+              const isMuted = isPast || n.score == null
+              const isSelected = n.date === selectedDate
+              const isBest = n.date === best?.date
+              const { dow, mmdd } = dateParts(n.date)
+              const dayNum = Number(n.date.slice(8, 10))
+              return (
+                <button
+                  key={n.date}
+                  type="button"
+                  className={[
+                    'heatmap-cell',
+                    band ? `hm-${band}` : '',
+                    isMuted ? 'muted' : '',
+                    isSelected ? 'selected' : '',
+                    isBest ? 'best' : '',
+                  ].filter(Boolean).join(' ')}
+                  style={n.score != null ? ({ '--cell-alpha': cellAlpha(n.score) } as CSSProperties) : undefined}
+                  onClick={() => setSelectedDate(n.date)}
+                  aria-pressed={isSelected}
+                  title={`${dow} ${mmdd} — ${n.score != null ? n.score.toFixed(1) : 'N/A'}${isBest ? ' (best night)' : ''}`}
+                  aria-label={`${dow} ${mmdd}, score ${n.score != null ? n.score.toFixed(1) : 'unavailable'}${isBest ? ', best night' : ''}${isSelected ? ', currently selected' : ''}`}
+                >
+                  <span className="hm-day">{dayNum}</span>
+                  <span className="hm-score">{n.score != null ? n.score.toFixed(1) : '—'}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="telemetry-readout">
+          {selected ? (
+            <>
+              <div className="telemetry-selected-head">
+                <MoonPhaseSvg phaseName={selected.phase_name} illuminationPct={selected.illumination_pct} size={30} />
+                <div className="telemetry-selected-date">{dateParts(selected.date).long}</div>
               </div>
-            )}
-            <button
-              type="button"
-              className="telemetry-view-details submit"
-              disabled={isFetchingDetails}
-              onClick={() => onViewDetails(selected.date)}
-            >
-              {isFetchingDetails ? 'Loading…' : 'View Details'}
-            </button>
-            {viewDetailsError && <p className="sat-notice">{viewDetailsError}</p>}
-          </>
-        ) : (
-          <p className="sat-notice">No data</p>
-        )}
-      </div>
+              <div className="meta-row">
+                <span className="meta-k">Score</span>
+                <span className={`meta-v${selectedBand ? ` telemetry-score-${selectedBand}` : ''}`}>
+                  {selected.score != null ? `${selected.score.toFixed(1)} · ${scoreLabel(selected.score)}` : '—'}
+                </span>
+              </div>
+              <div className="meta-row">
+                <span className="meta-k">Dark Hours</span>
+                <span className="meta-v">{formatHm(selected.dark_hours)}</span>
+              </div>
+              <div className="meta-row">
+                <span className="meta-k">Lunar Conditions</span>
+                <span className="meta-v">{selected.phase_name} · {selected.illumination_pct.toFixed(0)}% illuminated</span>
+              </div>
+              {!selected.weather_informed && (
+                <p className="sat-notice">
+                  Astronomy-only estimate —{' '}
+                  {selected.wx_pending
+                    ? 'forecast not yet available for this date'
+                    : selected.wx_no_data
+                    ? 'weather provider returned no data for this date'
+                    : 'beyond the 16-day forecast horizon'}
+                </p>
+              )}
+              {sc && (
+                <div className="telemetry-mini-bars">
+                  {sc.bortle != null && <ScoreBar label="Dark Sky" value={sc.bortle} />}
+                  {sc.moon   != null && <ScoreBar label="Lunar"    value={sc.moon} />}
+                  {sc.dark   != null && <ScoreBar label="Dark Hours" value={sc.dark} />}
+                  {selected.weather_informed && sc.weather != null && <ScoreBar label="Weather" value={sc.weather} />}
+                </div>
+              )}
+              <button
+                type="button"
+                className="telemetry-view-details submit"
+                disabled={isFetchingDetails}
+                onClick={() => onViewDetails(selected.date)}
+              >
+                {isFetchingDetails ? 'Loading…' : 'View Details'}
+              </button>
+              {viewDetailsError && <p className="sat-notice">{viewDetailsError}</p>}
+            </>
+          ) : (
+            <p className="sat-notice">No data</p>
+          )}
+        </div>
+      </details>
     </div>
   )
 }

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -29,11 +29,11 @@ const AUTO_CALENDAR_DAYS = 30
 const _AUTO_CALENDAR_TTL_MS = 30 * 60 * 1000
 const _autoCalendarCache = new Map<string, { promise: Promise<CalendarResult>; at: number }>()
 
-function autoFetchCalendar(lat: number, lon: number): Promise<CalendarResult> {
-  const key = `${lat},${lon}`
+function autoFetchCalendar(lat: number, lon: number, start: string): Promise<CalendarResult> {
+  const key = `${lat},${lon},${start}`
   const cached = _autoCalendarCache.get(key)
   if (cached && Date.now() - cached.at < _AUTO_CALENDAR_TTL_MS) return cached.promise
-  const p = fetchCalendar(lat, lon, tonightIso(), AUTO_CALENDAR_DAYS)
+  const p = fetchCalendar(lat, lon, start, AUTO_CALENDAR_DAYS)
   p.catch(() => _autoCalendarCache.delete(key)) // don't cache failures — allow retry on next mount
   _autoCalendarCache.set(key, { promise: p, at: Date.now() })
   return p
@@ -139,11 +139,17 @@ export default function ReportCard({
     }
   }
 
+  // Anchor the default outlook on the date picker's selection, not always
+  // tonight — someone planning 3 months out wants the 30-day window to start
+  // around that date, not reset to today. Clamped to today because the
+  // outlook is forecast-only and can't look backward.
+  const calendarAnchor = report.date > tonightIso() ? report.date : tonightIso()
+
   useEffect(() => {
     manualCalendarRef.current = false
     let cancelled = false
-    setCalendarState({ phase: 'loading', start: tonightIso(), days: AUTO_CALENDAR_DAYS })
-    autoFetchCalendar(report.lat, report.lon).then(data => {
+    setCalendarState({ phase: 'loading', start: calendarAnchor, days: AUTO_CALENDAR_DAYS })
+    autoFetchCalendar(report.lat, report.lon, calendarAnchor).then(data => {
       if (!cancelled && !manualCalendarRef.current) {
         setCalendarState({ phase: 'done', data, days: AUTO_CALENDAR_DAYS })
       }
@@ -156,7 +162,7 @@ export default function ReportCard({
       }
     })
     return () => { cancelled = true }
-  }, [report.lat, report.lon])
+  }, [report.lat, report.lon, calendarAnchor])
 
   // Verdict-layer chip: the first upcoming night in the outlook that scores
   // "good" (≥6); when none does, fall back to the best upcoming night that
@@ -553,7 +559,7 @@ export default function ReportCard({
           <div className="planning-tool">
             <h4 className="planning-tool-title">Calendar — Next Good Night</h4>
             <div className="nearby-body">
-              <CalendarRangePicker state={calendarState} onApply={handleFindCalendar} />
+              <CalendarRangePicker state={calendarState} anchor={calendarAnchor} onApply={handleFindCalendar} />
               {calendarState.phase === 'error' && (
                 <p className="sat-notice">{calendarState.message}</p>
               )}
@@ -561,6 +567,7 @@ export default function ReportCard({
                 <OutlookTelemetryRibbon
                   data={calendarState.data}
                   days={calendarState.days}
+                  startExpanded={manualCalendarRef.current}
                   onViewDetails={handleViewDetails}
                   isFetchingDetails={isFetchingDetails}
                   viewDetailsError={dateFetch.phase === 'error' ? dateFetch.message : null}

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import type { NightReport, NearbyResult, CalendarResult } from './types'
 import { formatTime, formatHm, tzAbbr, tzTitle, fmtDist, lpString, scoreBand, scoreLabel, tonightIso, availabilityFor, nightVerdict } from './format'
-import { MoonPhaseSvg, ScoreBar, InfoTip } from './shared'
+import { MoonPhaseSvg, InfoTip } from './shared'
 import { fetchNearby, fetchCalendar, fetchNightDateOnly, ApiRequestError } from './api'
 import OutlookTelemetryRibbon from './OutlookTelemetryRibbon'
 import CalendarRangePicker, { type CalendarPickerState } from './CalendarRangePicker'
@@ -446,6 +446,7 @@ export default function ReportCard({
       )}
 
       <div className={`overall band-${scoreBand(r.score)}`}>
+        <div className="overall-left">
         <div className="overall-score-block">
           <div className="overall-score-header">
             <div className="overall-num">{r.score.toFixed(1)}</div>
@@ -481,6 +482,8 @@ export default function ReportCard({
             k="Light Pollution"
             v={shortLps}
             tip={<>Bortle class 1 (pristine) to 9 (inner city), derived from satellite radiance{lp?.source ? ` (${lp.source})` : ''}. SQM is zenith sky brightness in mag/arcsec² — each +1 is ~2.5× darker; 21.7+ is a genuinely dark site.</>}
+            score={r.score_components.bortle}
+            scoreTip={<>10% of the composite — the Bortle class at this location. Fixed for the spot; the only lever is going somewhere darker (see Find Sky Nearby).</>}
           />
         )}
 
@@ -495,40 +498,28 @@ export default function ReportCard({
           k="Clear Dark Sky"
           v={darkStrCard}
           tip={<>Hours you can actually shoot: astronomical darkness (sun ≥18° below the horizon), minus moon interference, minus hours clouded over (&gt;50% cover).</>}
+          score={r.score_components.dark}
+          scoreTip={<>25% of the composite — tonight's moon-free dark hours measured against this lunar cycle's average, so the score reflects what this month can actually offer.</>}
         />
         {showWeather && r.weather_score != null && (
           <MetaRow
             k="Weather"
             v={`${r.weather_score.toFixed(1)}/10${r.wx_source ? `  ·  ${r.wx_source}` : ''}`}
+            score={r.score_components.weather}
+            scoreTip={<>40% of the composite — hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, wind, and humidity.</>}
           />
         )}
         {showWeather && r.wx_pending && <MetaRow k="Weather" v="Pending  (beyond the ~16-day forecast horizon)" />}
         {showWeather && r.wx_no_data && <MetaRow k="Weather" v="No data  (not covered for this location/date)" />}
         {showWeather && r.wx_error && !(r.weather_points?.length) && <MetaRow k="Weather" v="Temporarily unavailable: weather providers are down" />}
         <MetaRow k="Lunar Conditions" v={moonStrCard}
-          icon={<MoonPhaseSvg phaseName={r.phase_name} illuminationPct={r.illumination_pct} size={30} />}
+          icon={<MoonPhaseSvg phaseName={r.phase_name} illuminationPct={r.illumination_pct} size={20} />}
+          score={r.score_components.moon}
+          scoreTip={<>25% of the composite — Krisciunas &amp; Schaefer scattered-moonlight model: phase, moon altitude, and hours above the horizon, distance-corrected. A bright moon that sets early can still score well.</>}
         />
         </div>
+        </div>
         {r.light_dome && <LightDomePanel summary={r.light_dome} imperial={imperial} />}
-      </div>
-
-      <div className="bars">
-        {r.score_components.bortle != null && (
-          <ScoreBar label="Dark Sky" value={r.score_components.bortle}
-            tip={<>10% of the composite — the Bortle class at this location. Fixed for the spot; the only lever is going somewhere darker (see Find Sky Nearby).</>} />
-        )}
-        {r.score_components.moon != null && (
-          <ScoreBar label="Lunar" value={r.score_components.moon}
-            tip={<>25% of the composite — Krisciunas &amp; Schaefer scattered-moonlight model: phase, moon altitude, and hours above the horizon, distance-corrected. A bright moon that sets early can still score well.</>} />
-        )}
-        {r.score_components.dark != null && (
-          <ScoreBar label="Dark Hours" value={r.score_components.dark}
-            tip={<>25% of the composite — tonight's moon-free dark hours measured against this lunar cycle's average, so the score reflects what this month can actually offer.</>} />
-        )}
-        {showWeather && r.score_components.weather != null && (
-          <ScoreBar label="Weather" value={r.score_components.weather}
-            tip={<>40% of the composite — hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, wind, and humidity.</>} />
-        )}
       </div>
 
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17,10 +17,10 @@
   --accent: #4A5EA8;       /* Sun blue */
 
   /* ── Semantic Data ──────────────────────────────────────────── */
-  --excellent: #5CB85C;    /* Success green */
-  --good: #4A5EA8;         /* Sun blue */
-  --fair: #F0AD4E;         /* Warning amber */
-  --poor: #D9534F;         /* Danger red */
+  --excellent: #3A8772;    /* Success teal */
+  --good: #5B7BB2;         /* Sun blue */
+  --fair: #D99B41;         /* Warning amber */
+  --poor: #C85656;         /* Danger red */
 
   /* ── Typography Scale ───────────────────────────────────────── */
   --sans: 'IBM Plex Sans', system-ui, 'Segoe UI', Roboto, sans-serif;

--- a/apps/web/src/report/LightDomePanel.tsx
+++ b/apps/web/src/report/LightDomePanel.tsx
@@ -16,8 +16,8 @@ import { LD_DIRS, LD_THETA_K, LD_THETA_FLOOR_DEG, LD_THETA_DEFAULT_DEG, LD_SIZE,
 export function LightDomePanel({ summary, imperial }: { summary: LightDomeSummary; imperial: boolean }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
-  // Disk size; matched to the score card's content (the meta block) so the panel
-  // doesn't make the card taller. Capped at LD_SIZE; falls back to it pre-measure.
+  // Disk size; fills the panel's grid column (title + caption sit above/below it,
+  // not beside it), capped at LD_SIZE. Falls back to LD_SIZE pre-measure.
   const [size, setSize] = useState(LD_SIZE)
   const { sky_state, scores, darkest_direction, domes } = summary
   // The darkest horizon is only a meaningful "point here" call when a darker side exists.
@@ -26,17 +26,11 @@ export function LightDomePanel({ summary, imperial }: { summary: LightDomeSummar
   useEffect(() => {
     const panel = panelRef.current
     if (!panel) return
-    // ResizeObserver on the panel itself (flex: 0 0 100% — outer size is CSS-controlled,
+    // ResizeObserver on the panel itself (grid-column: 3 — outer size is CSS-controlled,
     // not affected by canvas content changes, so no feedback loop).
     let rafId = 0
     const measure = () => {
-      const body = panel.querySelector('.ld-body') as HTMLElement | null
-      const isRow = !!body && getComputedStyle(body).flexDirection === 'row'
-      const caption = panel.querySelector('.ld-caption') as HTMLElement | null
-      const captionW = isRow ? (caption?.offsetWidth ?? 130) : 0
-      const gap     = isRow ? 18 : 0
-      const avail   = panel.clientWidth - captionW - gap
-      setSize(Math.max(88, Math.min(LD_SIZE, Math.round(avail))))
+      setSize(Math.max(88, Math.min(LD_SIZE, Math.round(panel.clientWidth))))
     }
     // Debounce ResizeObserver: skip intermediate firings during layout reflow,
     // coalescing them into one rAF-deferred measurement per animation frame.
@@ -132,16 +126,10 @@ export function LightDomePanel({ summary, imperial }: { summary: LightDomeSummar
 
   return (
     <div className="lightdome-panel" ref={panelRef}>
-      <div className="ld-title">Horizon Glow</div>
       <div className="ld-body">
       <canvas ref={canvasRef} className="ld-canvas" role="img" aria-label={aria} />
+      <div className="ld-title">Horizon Glow</div>
       <div className="ld-caption">
-        <span className={`ld-state ld-state-${sky_state}`}>
-          {sky_state === 'dark' ? 'Dark sky'
-            : sky_state === 'domed' ? 'Light dome'
-            : sky_state === 'bright' ? 'Bright sky'
-            : 'Urban sky'}
-        </span>
         {sky_state === 'domed' && (
           <>
             <span className={`ld-line${top?.severity ? ` ld-dome-${top.severity}` : ''}`}>{top?.label}{topDist}</span>

--- a/apps/web/src/report/Nearby.tsx
+++ b/apps/web/src/report/Nearby.tsx
@@ -50,6 +50,9 @@ export function NearbyResults(
   // Render a place name with a category badge (routable POIs) or a "Remote" tag (off-road
   // fallbacks), plus a Google Maps driving-directions link on every result.
   const placeNode = (p: NearbyPlace) => {
+    // No name/area passed here — the destination report re-derives the same POI name
+    // itself from lat/lon against the trusted local index (PyNightSkyPredictor.location
+    // .reverse_geocode → darksky._poi_reverse_name), not from anything in the URL.
     const appLink = `?lat=${p.lat.toFixed(5)}&lon=${p.lon.toFixed(5)}`
     return (
       <>

--- a/apps/web/src/report/Satellites.tsx
+++ b/apps/web/src/report/Satellites.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { NightReport } from '../types'
 import { formatTime, cardinal, rateConditions, scoreBand } from '../format'
 import { WmoIcon } from './icons'
@@ -9,6 +10,9 @@ import { wxAtTime } from './Targets'
 
 export function SatellitePasses({ report, isFetching = false, cathodeSnap = false }: { report: NightReport; isFetching?: boolean; cathodeSnap?: boolean }) {
   const tz = report.tz_name
+  // Clouded-out passes collapse to one summary row by default — on a bad
+  // night a wall of identical "Clouded out" rows is noise, not signal.
+  const [showBlocked, setShowBlocked] = useState(false)
 
   // Unavailability notices
   if (report.sat_network_error) {
@@ -47,6 +51,68 @@ export function SatellitePasses({ report, isFetching = false, cathodeSnap = fals
   }
 
   const az = (deg: number) => `${deg.toFixed(0)}° ${cardinal(deg)}`
+
+  // Split passes into clear vs. clouded-out so a bad night doesn't render as
+  // a wall of blank "Clouded out" rows — mirrors the Targets unviable rollup.
+  const passInfo = display.map(p => {
+    const wxAtPeak  = wxAtTime(report.weather_points || [], p.peak_time)
+    const satCloudy = wxAtPeak != null && wxAtPeak.cloud_cover_pct != null && wxAtPeak.cloud_cover_pct > 70
+    return { p, wxAtPeak, satCloudy }
+  })
+  const clearPasses  = passInfo.filter(x => !x.satCloudy)
+  const cloudyPasses = passInfo.filter(x => x.satCloudy)
+  const colCount = 12 + (report.light_dome ? 1 : 0)
+
+  // Pass geometry (rise/peak/set) is astronomical fact, unaffected by weather —
+  // clouded rows still show it, just flagged, rather than blanked out.
+  function renderPassRow(p: typeof display[number], wxAtPeak: ReturnType<typeof wxAtTime>, i: number, cloudy: boolean) {
+    const label    = p.satellite_name + (!p.sky_dark ? ' †' : '')
+    const setAlt   = `${p.set_alt_deg.toFixed(0)}°${p.ends_in_shadow ? '*' : ''}`
+    const moonSepLow = !p.moon_transit && p.moon_sep_deg != null && p.moon_sep_deg < 5
+    const moonStr  = p.moon_transit
+      ? `TRANSIT ${p.moon_transit_sep_deg?.toFixed(3)}°`
+      : p.moon_sep_deg != null
+        ? `${p.moon_sep_deg.toFixed(1)}°`
+        : '—'
+    const satGlow = report.light_dome
+      ? glowToward(report.light_dome, p.peak_az_deg, p.peak_alt_deg)
+      : null
+    return (
+      <tr key={i} className={cloudy ? 'tg-row-blocked' : undefined}>
+        <td>
+          {cell(isFetching, <>
+            {label}
+            {cloudy && <span className="mw-moon-badge badge-poor sat-cloudy-badge"> Clouded out</span>}
+          </>)}
+        </td>
+        <td className="wx-num">{cell(isFetching, formatTime(p.rise_time, tz))}</td>
+        <td className="wx-num">{cell(isFetching, `${p.rise_alt_deg.toFixed(0)}°`)}</td>
+        <td className="wx-num">{cell(isFetching, az(p.rise_az_deg))}</td>
+        <td className="wx-num">
+          {cell(isFetching, <>
+            {formatTime(p.peak_time, tz)}
+            {wxAtPeak && (
+              <span className={`tg-wx-inline wx-rating-${scoreBand(rateConditions(wxAtPeak))}`}>
+                <WmoIcon code={wxAtPeak.weather_code} size={12} />
+              </span>
+            )}
+          </>)}
+        </td>
+        <td className="wx-num">{cell(isFetching, `${p.peak_alt_deg.toFixed(0)}°`)}</td>
+        <td className="wx-num sat-peak-az-col">{cell(isFetching, az(p.peak_az_deg))}</td>
+        <td className="wx-num sat-set-col">{cell(isFetching, formatTime(p.set_time, tz))}</td>
+        <td className="wx-num sat-set-col">{cell(isFetching, setAlt)}</td>
+        <td className="wx-num sat-set-col">{cell(isFetching, az(p.set_az_deg))}</td>
+        <td className="wx-num sat-dur-col">{cell(isFetching, `${p.duration_min.toFixed(0)}m`)}</td>
+        <td className="wx-num" style={moonSepLow ? {color: 'var(--excellent)', fontWeight: 700, fontSize: '1rem'} : undefined}>{cell(isFetching, moonStr)}</td>
+        {report.light_dome && (
+          <td className="wx-num cond-glow" style={satGlow != null && satGlow >= 0.03 ? glowStyle(satGlow) : undefined}>
+            {cell(isFetching, satGlow != null && satGlow >= 0.03 ? glowLabel(satGlow) : '—')}
+          </td>
+        )}
+      </tr>
+    )
+  }
 
   return (
     <>
@@ -98,59 +164,27 @@ export function SatellitePasses({ report, isFetching = false, cathodeSnap = fals
               </tr>
             </thead>
             <tbody>
-              {display.map((p, i) => {
-                const label    = p.satellite_name + (!p.sky_dark ? ' †' : '')
-                const setAlt   = `${p.set_alt_deg.toFixed(0)}°${p.ends_in_shadow ? '*' : ''}`
-                const moonSepLow = !p.moon_transit && p.moon_sep_deg != null && p.moon_sep_deg < 5
-                const moonStr  = p.moon_transit
-                  ? `TRANSIT ${p.moon_transit_sep_deg?.toFixed(3)}°`
-                  : p.moon_sep_deg != null
-                    ? `${p.moon_sep_deg.toFixed(1)}°`
-                    : '—'
-                const satGlow = report.light_dome
-                  ? glowToward(report.light_dome, p.peak_az_deg, p.peak_alt_deg)
-                  : null
-                const wxAtPeak = wxAtTime(report.weather_points || [], p.peak_time)
-                const satCloudy = wxAtPeak != null && wxAtPeak.cloud_cover_pct != null && wxAtPeak.cloud_cover_pct > 70
-                if (satCloudy) return (
-                  <tr key={i} className="tg-row-blocked">
-                    <td>{cell(isFetching, label)}</td>
-                    <td className="wx-num" colSpan={11 + (satGlow != null ? 1 : 0)}>
-                      {cell(isFetching, <span className="mw-moon-badge badge-poor">Clouded out</span>)}
+              {clearPasses.map(({ p, wxAtPeak }, i) => renderPassRow(p, wxAtPeak, i, false))}
+
+              {cloudyPasses.length > 0 && (
+                <>
+                  <tr className="tg-unviable-hdr">
+                    <td colSpan={colCount}>
+                      <button
+                        type="button"
+                        className="tg-blocked-toggle"
+                        aria-expanded={showBlocked}
+                        onClick={() => setShowBlocked(v => !v)}
+                      >
+                        <span className="tg-blocked-caret" aria-hidden="true">{showBlocked ? '▾' : '▸'}</span>
+                        {`Unavailable Tonight (${cloudyPasses.length})`}
+                        <span className="tg-blocked-counts">{' — '}Clouded out</span>
+                      </button>
                     </td>
                   </tr>
-                )
-                return (
-                  <tr key={i}>
-                    <td>{cell(isFetching, label)}</td>
-                    <td className="wx-num">{cell(isFetching, formatTime(p.rise_time, tz))}</td>
-                    <td className="wx-num">{cell(isFetching, `${p.rise_alt_deg.toFixed(0)}°`)}</td>
-                    <td className="wx-num">{cell(isFetching, az(p.rise_az_deg))}</td>
-                    <td className="wx-num">
-                      {cell(isFetching, <>
-                        {formatTime(p.peak_time, tz)}
-                        {wxAtPeak && (
-                          <span className={`tg-wx-inline wx-rating-${scoreBand(rateConditions(wxAtPeak))}`}>
-                            <WmoIcon code={wxAtPeak.weather_code} size={12} />
-                          </span>
-                        )}
-                      </>)}
-                    </td>
-                    <td className="wx-num">{cell(isFetching, `${p.peak_alt_deg.toFixed(0)}°`)}</td>
-                    <td className="wx-num sat-peak-az-col">{cell(isFetching, az(p.peak_az_deg))}</td>
-                    <td className="wx-num sat-set-col">{cell(isFetching, formatTime(p.set_time, tz))}</td>
-                    <td className="wx-num sat-set-col">{cell(isFetching, setAlt)}</td>
-                    <td className="wx-num sat-set-col">{cell(isFetching, az(p.set_az_deg))}</td>
-                    <td className="wx-num sat-dur-col">{cell(isFetching, `${p.duration_min.toFixed(0)}m`)}</td>
-                    <td className="wx-num" style={moonSepLow ? {color: 'var(--excellent)', fontWeight: 700, fontSize: '1rem'} : undefined}>{cell(isFetching, moonStr)}</td>
-                    {report.light_dome && (
-                      <td className="wx-num cond-glow" style={satGlow != null && satGlow >= 0.03 ? glowStyle(satGlow) : undefined}>
-                        {cell(isFetching, satGlow != null && satGlow >= 0.03 ? glowLabel(satGlow) : '—')}
-                      </td>
-                    )}
-                  </tr>
-                )
-              })}
+                  {showBlocked && cloudyPasses.map(({ p, wxAtPeak }, i) => renderPassRow(p, wxAtPeak, i, true))}
+                </>
+              )}
             </tbody>
           </table>
         </div>

--- a/apps/web/src/report/common.tsx
+++ b/apps/web/src/report/common.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { cardinal } from '../format'
+import { cardinal, scoreBand } from '../format'
 import { InfoTip } from '../shared'
 
 // first, then altitude — e.g. "Az 195° S · Alt 42°".
@@ -23,14 +23,39 @@ export function cell(isFetching: boolean, value: React.ReactNode): React.ReactNo
 }
 
 // ── Metadata row ─────────────────────────────────────────────────────────────
+// `score` ties the row to its composite-score factor (Bortle → Light Pollution,
+// dark hours → Clear Dark Sky, etc.) via an inline bar; `scoreTip` carries the
+// weighting/methodology explainer that used to live on the standalone score
+// bars, now surfaced through a small "?" badge so it isn't lost.
 
-export function MetaRow({ k, v, icon, tip }: { k: string; v: string; icon?: React.ReactNode; tip?: React.ReactNode }) {
+export function MetaRow({ k, v, icon, tip, score, scoreTip }: {
+  k: string; v: string; icon?: React.ReactNode; tip?: React.ReactNode
+  score?: number | null; scoreTip?: React.ReactNode
+}) {
+  const pct = score != null ? Math.max(0, Math.min(100, score * 10)) : 0
   return (
-    <div className="meta-row">
-      <span className="meta-k">{tip ? <InfoTip tip={tip}>{k}</InfoTip> : k}:</span>
-      <span className="meta-v" style={icon ? { display: 'inline-flex', alignItems: 'center', gap: 6 } : undefined}>
-        {icon}{v}
-      </span>
+    <div className="meta-row-wrap">
+      <div className="meta-row">
+        <span className="meta-k">{tip ? <InfoTip tip={tip}>{k}</InfoTip> : k}:</span>
+        <span className="meta-v" style={icon ? { display: 'inline-flex', alignItems: 'center', gap: 6 } : undefined}>
+          {icon}{v}
+        </span>
+      </div>
+      {score != null && (
+        <div className="meta-bar">
+          <span className="bar-track">
+            <span className={`bar-fill band-${scoreBand(score)}`} style={{ width: `${pct}%` }} />
+          </span>
+          <span className="bar-value-cell">
+            <span className="bar-value">{score.toFixed(1)}</span>
+            {scoreTip && (
+              <InfoTip tip={scoreTip}>
+                <span className="score-help" aria-label="How this score is calculated">?</span>
+              </InfoTip>
+            )}
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/report/glow.tsx
+++ b/apps/web/src/report/glow.tsx
@@ -12,14 +12,14 @@ export const LD_MINOR = 0.25
 export const LD_MAJOR = 3.0
 // Log-interpolated colour stops (RGB), keyed on the thresholds, using the app's own
 // quality ramp (excellent → good → fair → poor). The darkest end fades to BLACK — the
-// "excellent of excellent" = true darkness. Glow rises: black → green → blue → lilac → rose.
+// "excellent of excellent" = true darkness. Glow rises: black → teal → blue → amber → rose.
 export const LD_STOPS: [number, [number, number, number]][] = [
   [0,        [0, 0, 0]],        // darkness — the best (excellent-of-excellent)
-  [0.03,     [74, 94, 168]],    // --excellent blue
-  [0.12,     [92, 184, 92]],    // --good green
-  [LD_MINOR, [240, 173, 78]],   // --fair amber — a minor dome
-  [0.9,      [217, 83, 79]],    // --poor red
-  [LD_MAJOR, [150, 40, 40]],    // deep --poor — a major dome
+  [0.03,     [58, 135, 114]],   // --excellent teal
+  [0.12,     [91, 123, 178]],   // --good blue
+  [LD_MINOR, [217, 155, 65]],   // --fair amber — a minor dome
+  [0.9,      [200, 86, 86]],    // --poor rose
+  [LD_MAJOR, [140, 55, 55]],    // deep --poor — a major dome
 ]
 // Bloom-legibility transform: real dome heights are ~1° (a sub-pixel rim sliver), so
 // for *display* we scale them up and floor them. This shapes the on-screen bloom, not
@@ -27,7 +27,7 @@ export const LD_STOPS: [number, [number, number, number]][] = [
 export const LD_THETA_K = 5
 export const LD_THETA_FLOOR_DEG = 6
 export const LD_THETA_DEFAULT_DEG = 4
-export const LD_SIZE = 300            // CSS px; disk + room for N/E/S/W labels
+export const LD_SIZE = 282            // CSS px; disk + room for N/E/S/W labels
 
 export function ldColor(v: number): [number, number, number] {
   if (v <= LD_STOPS[0][0]) return LD_STOPS[0][1]

--- a/apps/web/src/styles/04-report-core.css
+++ b/apps/web/src/styles/04-report-core.css
@@ -161,13 +161,22 @@ html.red-mode .report-nav-link {
   text-align: center;
 }
 .overall {
-  display: flex;
-  flex-wrap: wrap; /* FIXED: Allows the meta block to wrap under the score */
-  align-items: center;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: start;
+  gap: 24px;
   padding: 22px 24px;
   border-radius: 3px;
   border: 1px solid var(--card-border);
+}
+/* Left column: score block stacked above the meta list, sharing the left
+   half of the card with the dome balanced opposite it. */
+.overall-left {
+  grid-column: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
 }
 .overall-num {
   font-size: 64px;
@@ -202,12 +211,8 @@ html.red-mode .report-nav-link {
   gap: 12px;
   flex-wrap: wrap;
 }
-/* Give meta block all remaining space so values don't wrap */
-.overall .meta {
-  flex: 1 1 260px; /* FIXED: Trigger wrapping if the available width drops below 260px */
-  min-width: 0;
-}
-/* Tighter label column inside the score card */
+/* Tighter label column inside the score card, sized to leave the value
+   column room so it doesn't wrap. */
 .overall .meta-k {
   min-width: 112px;
 }
@@ -217,7 +222,7 @@ html.red-mode .report-nav-link {
   font-size: 12.5px;
   line-height: 1.45;
   color: var(--text);
-  max-width: 300px;
+  max-width: 100%;
   margin-top: 6px;
 }
 .next-good-chip {
@@ -258,23 +263,24 @@ html.red-mode .next-good-chip {
 
 /* ── Light dome panel (all-sky fisheye) ─────────────────────── */
 .lightdome-panel {
-  flex: 0 0 100%;
+  grid-column: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  margin-top: -8px;
 }
 .ld-title {
   /* Removed local font-family, font-size, font-weight, text-transform, letter-spacing so it defers to the shared Rule 2 */
   text-align: center;
 }
+/* Dome disk on top, title, then caption text + legend below — sized to use
+   the column's spare horizontal/vertical room rather than sit small in it. */
 .ld-body {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 14px;
+  gap: 8px;
 }
 .ld-canvas {
   display: block;
@@ -282,32 +288,20 @@ html.red-mode .next-good-chip {
 .ld-caption {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 3px;
-  text-align: left;
+  align-items: center;
+  gap: 4px;
+  text-align: center;
 }
-.ld-state {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  padding: 2px 8px;
-  border-radius: 2px;
-  border: 1px solid transparent;
-}
-.ld-state-dark   { color: var(--excellent); border-color: rgba(74, 94, 168, 0.35); }
-.ld-state-domed  { color: var(--good);      border-color: rgba(92, 184, 92, 0.35); }
-.ld-state-bright { color: var(--fair);      border-color: rgba(240, 173, 78, 0.35); }
-.ld-state-urban  { color: var(--poor);      border-color: rgba(217, 83, 79, 0.40); }
 .ld-line {
-  font-size: 12px;
-  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-h);
 }
 .ld-line.ld-dome-minor { color: var(--good); }
 .ld-line.ld-dome-major { color: var(--fair); }
 .ld-sub {
-  font-size: 11.5px;
-  color: var(--text-dim);
+  font-size: 12.5px;
+  color: var(--text);
 }
 .ld-line b, .ld-sub b {
   color: var(--text-h);
@@ -316,29 +310,21 @@ html.red-mode .next-good-chip {
 .ld-legend {
   display: flex;
   align-items: center;
-  gap: 5px;
-  margin-top: 3px;
-  font-size: 9.5px;
+  gap: 6px;
+  margin-top: 4px;
+  font-size: 10.5px;
   color: var(--text-dim);
 }
 .ld-legend-bar {
-  width: 64px;
-  height: 6px;
+  width: 80px;
+  height: 7px;
   border-radius: 1px;
   background: linear-gradient(90deg, #000 0%, var(--excellent) 22%, var(--good) 45%, var(--fair) 65%, var(--poor) 100%);
 }
 /* Red/night-vision mode: the canvas bakes literal RGB (CSS vars can't reach
-   getImageData), so recolour it with the same luminance→red matrix used on <img>.
-   The legend bar and state pills use literal greens/ambers — re-tint to pure red. */
+   getImageData), so recolour it with the same luminance→red matrix used on <img>. */
 html.red-mode .ld-canvas { filter: url(#red-night); }
 html.red-mode .ld-legend-bar { background: #6a0000; }
-html.red-mode .ld-state-dark,
-html.red-mode .ld-state-domed,
-html.red-mode .ld-state-bright,
-html.red-mode .ld-state-urban {
-  color: var(--accent);
-  border-color: rgba(255, 0, 0, 0.4);
-}
 
 .band-excellent {
   border-color: var(--excellent);
@@ -382,11 +368,6 @@ html.red-mode .ld-state-urban {
   color: var(--poor);
 }
 
-.bars {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
 .bar-row {
   display: grid;
   grid-template-columns: 120px 1fr 36px;
@@ -437,16 +418,16 @@ html.red-mode .ld-state-urban {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 6px;
+  gap: 7px;
   padding-bottom: 8px;
   font-size: 13px;
   width: 100%;
 }
 .meta-row {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
-  line-height: 1.5;
+  line-height: 1.4;
   font-size: 13px;
 }
 .meta-k {
@@ -457,9 +438,11 @@ html.red-mode .ld-state-urban {
   font-weight: 500;
   font-family: var(--mono);
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.06em;
 }
 .meta-v {
+  flex: 1;
+  min-width: 0;
   color: var(--text);
   font-variant-numeric: tabular-nums;
   word-break: break-word;
@@ -469,6 +452,51 @@ html.red-mode .ld-state-urban {
 }
 html.red-mode .meta-row img {
   border-color: rgba(255, 0, 0, 0.20);
+}
+/* Score bar tucked under its meta row, indented to align with the value
+   column — ties each factor's number directly to the fact it explains. */
+.meta-row-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+}
+.meta-bar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+  margin-left: 156px;
+}
+.overall .meta-bar {
+  margin-left: 120px;
+}
+.bar-value-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+/* The "?" badge replaces the score-weighting tooltip that used to live on
+   the standalone bar's label — same InfoTip mechanism, just an icon target
+   instead of underlined text. */
+.score-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1px solid var(--text-dim);
+  color: var(--text-dim);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+}
+.score-help:hover {
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 details summary {

--- a/apps/web/src/styles/04-report-core.css
+++ b/apps/web/src/styles/04-report-core.css
@@ -475,7 +475,7 @@ details summary {
   cursor: pointer;
   color: var(--text-dim);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 700;
   font-family: var(--mono);
   text-transform: uppercase;
   letter-spacing: 0.07em;

--- a/apps/web/src/styles/06-planning.css
+++ b/apps/web/src/styles/06-planning.css
@@ -237,6 +237,9 @@
 .telemetry-hero-label {
   color: var(--text-h);
 }
+.telemetry-collapse > summary {
+  margin: 0;
+}
 .heatmap-body {
   padding: 8px 10px;
   border-bottom: 1px solid var(--card-border);

--- a/apps/web/src/styles/11-responsive.css
+++ b/apps/web/src/styles/11-responsive.css
@@ -39,6 +39,15 @@
   .report-head {
     flex-wrap: wrap;
   }
+  /* Score card: collapse the 2-column grid (score+meta | dome) to a single
+     column, matching the Milky Way card's own grid→stack breakpoint. */
+  .overall {
+    grid-template-columns: 1fr;
+  }
+  .overall-left,
+  .lightdome-panel {
+    grid-column: 1;
+  }
 
   /* Report head: properly scales down location name on mobile */
   .report-head .place {
@@ -207,16 +216,10 @@
   .dp-today-btn {
     padding: 7px 0;
   }
-  /* Score card: tighter padding, flex-start so long sub-text doesn't mis-align number */
+  /* Score card: tighter padding on narrow phones */
   .overall {
     padding: 14px 16px;
     gap: 14px;
-    align-items: flex-start;
-    flex-direction: column;
-    /*width: 100%;*/
-  }
-  .overall .meta {
-    flex: 0 0 auto; /* column mode: flex-basis becomes height — reset to natural */
   }
   .overall-num {
     font-size: 3rem;
@@ -240,7 +243,7 @@
     gap: 6px;
     flex-wrap: wrap;
   }
-  .meta-row + .meta-row {
+  .meta-row-wrap + .meta-row-wrap {
     border-top: 1px solid rgba(var(--hairline-rgb), 0.25);
     padding-top: 6px;
   }
@@ -248,18 +251,10 @@
     flex: 1;
     padding-left: 0;
   }
-  /* Light dome stacks below the score, centered and full-width; the caption
-     stacks under the disk again (too little width to sit beside it). */
+  /* Light dome stacks below the score, full-width; centering and column
+     stacking of title/canvas/caption are the unconditional defaults now. */
   .lightdome-panel {
     width: 100%;
-    align-items: center;
-  }
-  .ld-body {
-    flex-direction: column;
-  }
-  .ld-caption {
-    align-items: center;
-    text-align: center;
   }
   input[type=range] {
     accent-color: var(--accent);

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -243,7 +243,7 @@ export interface ApiError {
 
 // Fields NightReport carries that are location-keyed, not date-keyed — never
 // re-fetched/re-merged by the date-only ("View Details") drill-in flow.
-export type LocationFields = 'light_pollution' | 'bortle_score' | 'light_dome'
+export type LocationFields = 'light_pollution' | 'bortle_score' | 'light_dome' | 'display_name'
 
 export type DateOnlyNightReport = Omit<NightReport, LocationFields>
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -249,6 +249,26 @@ def test_night_date_only_omits_location_fields():
     assert "light_pollution" not in d
     assert "bortle_score" not in d
     assert "light_dome" not in d
+    # display_name too — it's location-keyed like the others, and stripping it avoids
+    # a wasted reverse-geocode lookup on every "View Details" click.
+    assert "display_name" not in d
     # Date-dependent fields are still present.
     assert isinstance(d["sunset"], str)
     assert d["phase_name"] and d["score"] is not None
+
+
+@pytest.mark.eph
+@requires_rasters
+def test_night_ignores_client_supplied_name_param(monkeypatch):
+    # A previous version of this endpoint accepted a `name` param and used it verbatim
+    # as display_name — anyone could craft a URL that put arbitrary text in another
+    # user's report header. `name` is no longer a declared query param, so FastAPI
+    # silently drops it; display_name always comes from the server-side resolver.
+    monkeypatch.setattr(main_mod._loc, "reverse_geocode", lambda lat, lon: "Trusted Name")
+    r = client.get("/night", params={
+        "lat": 35.1983, "lon": -111.6513, "date": "2026-06-15",
+        "weather": "false", "targets": "false", "satellites": "false",
+        "name": "Anything The Client Wants To Inject",
+    })
+    assert r.status_code == 200
+    assert r.json()["display_name"] == "Trusted Name"

--- a/tests/test_poi_index.py
+++ b/tests/test_poi_index.py
@@ -206,3 +206,53 @@ def test_offline_tier_name_poi_discarded_on_blacklist():
     poi = {"lat": 38.5, "lon": -120.1, "name": "Base Lot", "is_poi": True}
     with patch.object(ds, "_padus_h3_lookup", return_value=("Fort Example", True)):
         assert ds._offline_tier_name(poi, object(), None) == ("discard", None)
+
+
+# ── _poi_h3_lookup / _poi_reverse_name ────────────────────────────────────────
+# These back PyNightSkyPredictor.location.reverse_geocode's POI-aware naming for an
+# arbitrary (lat, lon) — e.g. a coordinate a user navigates straight to via the URL.
+# The name always comes from this trusted, offline-built index, never from client
+# input, so a crafted URL can't put arbitrary text in another user's report header.
+
+def test_poi_h3_lookup_hit_and_miss(tmp_path, monkeypatch):
+    pois = [(38.5, -120.1, "Shriner Lake Campground", "camp_site")]
+    monkeypatch.setenv("PYNIGHTSKY_POI_H3_PATH", str(_write_index(tmp_path, pois)))
+    idx = ds._load_poi_h3_index()
+
+    assert ds._poi_h3_lookup(38.5, -120.1, idx) == ("Shriner Lake Campground", "camp_site")
+    assert ds._poi_h3_lookup(10.0, -50.0, idx) is None  # far away → different H3 cell
+
+
+def test_poi_reverse_name_poi_only_when_no_padus_hit(tmp_path, monkeypatch):
+    pois = [(38.5, -120.1, "Shriner Lake Campground", "camp_site")]
+    monkeypatch.setenv("PYNIGHTSKY_POI_H3_PATH", str(_write_index(tmp_path, pois)))
+    with patch.object(ds, "_load_padus_h3_index", return_value=None):
+        assert ds._poi_reverse_name(38.5, -120.1) == "Shriner Lake Campground"
+
+
+def test_poi_reverse_name_combines_padus_area(tmp_path, monkeypatch):
+    pois = [(38.5, -120.1, "Shriner Lake Campground", "camp_site")]
+    monkeypatch.setenv("PYNIGHTSKY_POI_H3_PATH", str(_write_index(tmp_path, pois)))
+    with patch.object(ds, "_load_padus_h3_index", return_value=object()), \
+         patch.object(ds, "_padus_h3_lookup", return_value=("Wenatchee National Forest", False)):
+        assert ds._poi_reverse_name(38.5, -120.1) == \
+            "Shriner Lake Campground, Wenatchee National Forest"
+
+
+def test_poi_reverse_name_discarded_on_padus_blacklist(tmp_path, monkeypatch):
+    pois = [(38.5, -120.1, "Base Lot", "parking")]
+    monkeypatch.setenv("PYNIGHTSKY_POI_H3_PATH", str(_write_index(tmp_path, pois)))
+    with patch.object(ds, "_load_padus_h3_index", return_value=object()), \
+         patch.object(ds, "_padus_h3_lookup", return_value=("Fort Example", True)):
+        assert ds._poi_reverse_name(38.5, -120.1) is None
+
+
+def test_poi_reverse_name_no_poi_hit_returns_none(tmp_path, monkeypatch):
+    pois = [(38.5, -120.1, "Shriner Lake Campground", "camp_site")]
+    monkeypatch.setenv("PYNIGHTSKY_POI_H3_PATH", str(_write_index(tmp_path, pois)))
+    assert ds._poi_reverse_name(40.0, -121.0) is None  # no POI at this point
+
+
+def test_poi_reverse_name_outside_us_returns_none():
+    # Paris, France — short-circuits on _is_in_us before touching any index.
+    assert ds._poi_reverse_name(48.8566, 2.3522) is None

--- a/tests/test_predictor_formulas.py
+++ b/tests/test_predictor_formulas.py
@@ -112,3 +112,51 @@ class TestBortleScoreConversion:
         for b in range(1, 10):
             s = _bortle_score(b)
             assert 0.0 <= s <= 10.0
+
+
+# ---------------------------------------------------------------------------
+# Provenance re-scoping — _scope_wx_source()
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timezone
+
+from PyNightSkyPredictor.predictor import _scope_wx_source
+from PyNightSkyPredictor.weather import WeatherPoint
+
+
+def _pt(seeing):
+    return WeatherPoint(
+        time=datetime(2026, 7, 20, 3, 0, tzinfo=timezone.utc),
+        cloud_cover_pct=10, seeing_arcsec=seeing, transparency=None,
+        humidity_pct=None, wind_speed_ms=None, wind_direction_deg=None,
+        lifted_index=None, precip_type=None, temperature_c=None,
+        dew_point_c=None, feels_like_c=None, precip_probability_pct=None,
+        weather_code=None, aerosol_optical_depth=None, pm2_5=None,
+        cloud_cover_low_pct=None, cloud_cover_mid_pct=None,
+        cloud_cover_high_pct=None, visibility_m=None, wind_gust_ms=None,
+    )
+
+
+class TestScopeWxSource:
+    """The fetch-wide label says "+ 7Timer" if ANY day of the ~16-day series got
+    seeing, but 7Timer covers ~3 days — nights beyond its range must not credit it."""
+
+    def test_strips_7timer_when_night_has_no_seeing(self):
+        assert _scope_wx_source("Open-Meteo + 7Timer", [_pt(None), _pt(None)]) == "Open-Meteo"
+
+    def test_keeps_7timer_when_night_has_seeing(self):
+        assert _scope_wx_source("Open-Meteo + 7Timer", [_pt(None), _pt(1.2)]) == "Open-Meteo + 7Timer"
+
+    def test_plain_primary_untouched(self):
+        assert _scope_wx_source("Open-Meteo", [_pt(None)]) == "Open-Meteo"
+
+    def test_7timer_full_primary_untouched(self):
+        # Fallback mode: 7Timer IS the primary — its points are 7Timer data
+        # regardless of seeing, so the bare label must survive.
+        assert _scope_wx_source("7Timer", [_pt(None)]) == "7Timer"
+
+    def test_none_source_passthrough(self):
+        assert _scope_wx_source(None, [_pt(None)]) is None
+
+    def test_empty_points_strips_suffix(self):
+        assert _scope_wx_source("Open-Meteo + 7Timer", []) == "Open-Meteo"


### PR DESCRIPTION
This PR includes:

- Collapse calendar outlook by default, anchor it on the selected date, and bold section titles
- Scope the forecast provenance badge to the night being reported  
- Derive report display names from the local POI index, not client input
- Keep satellite pass geometry visible for clouded-out passes

Commits:
- f2bcff0: fix: keep satellite pass geometry visible for clouded-out passes
- 3573d29: fix: derive report display names from the local POI index, not client input
- 79b49a9: feat: collapse calendar outlook by default, anchor it on the selected date, bold section titles
- 538f878: fix: scope the forecast provenance badge to the night being reported