### PR TITLE
Redesign Night Timeline weather readouts (Clarity/Seeing EQ, Sky Cover telemetry, cloud total under icon)

### DIFF
--- a/apps/web/src/report/NightTimeline.tsx
+++ b/apps/web/src/report/NightTimeline.tsx
@@ -44,7 +44,7 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
   const hasTransp = visiblePoints.some(p => p.transparency    != null)
   const hasAtmos  = hasSeeing || hasTransp
   const hasWx     = visiblePoints.length > 0
-  const totalCols = 5 + (hasAtmos ? 1 : 0) + ((hasTemp || hasDew) ? 1 : 0)
+  const totalCols = 4 + (hasAtmos ? 1 : 0) + ((hasTemp || hasDew) ? 1 : 0)
 
   // Astronomical night window (sun-based, matches the "ASTRO DARK BEGINS/ENDS"
   // divider rows below) — NOT darkIntervals/dark_intervals, which is a different
@@ -169,9 +169,8 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
             <thead>
               <tr>
                 <th>Time</th>
-                <th className="wx-cond-col"></th>
                 <th className="wx-cloud-col wx-cloud-hdr">
-                  <InfoTip tip={<>The big number is total cloud cover. The telemetry stack breaks it out by altitude — high (&gt;20kft / &gt;6km), mid (&gt;6kft / &gt;2km), low (&lt;6kft / &lt;2km) — with more filled blocks meaning more cloud at that layer.</>}>
+                  <InfoTip tip={<>The weather icon and total cloud-cover % hang to the left; the telemetry stack breaks cloud out by altitude — high (&gt;20kft / &gt;6km), mid (&gt;6kft / &gt;2km), low (&lt;6kft / &lt;2km) — with more filled blocks meaning more cloud at that layer.</>}>
                     Sky Cover
                   </InfoTip>
                 </th>
@@ -254,25 +253,25 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
               return (
                 <tr key={`wx-${i}`} className={astroShadeCls}>
                   <td className="wx-time">{formatTime(p.time, tz)}</td>
-                  <td className="wx-num wx-rating">
-                    {cell(isFetching, <div className="wx-cond-cell">
-                      <WmoIcon code={p.weather_code} cloudCover={p.cloud_cover_pct}
-                        moonUp={moonUpAt(p.time, moonrise ?? null, moonset ?? null)}
-                        aod={p.aerosol_optical_depth} pm25={p.pm2_5} visibilityM={p.visibility_m} precipType={p.precip_type}
-                        windSpeedMs={p.wind_speed_ms} windGustMs={p.wind_gust_ms} transparency={p.transparency} />
-                      {showCloudTotal({ code: p.weather_code, cloudCover: p.cloud_cover_pct, precipType: p.precip_type,
-                        windSpeedMs: p.wind_speed_ms, windGustMs: p.wind_gust_ms }) && (
-                        <span className="wx-cond-total">{p.cloud_cover_pct}%</span>
-                      )}
-                    </div>)}
-                  </td>
                   <td className="wx-num wx-cloud-col">
-                    {cell(isFetching, <SkyCover
-                      low={p.cloud_cover_low_pct}
-                      mid={p.cloud_cover_mid_pct}
-                      high={p.cloud_cover_high_pct}
-                      imperial={imperial}
-                    />)}
+                    {cell(isFetching, <div className="wx-sky-cell">
+                      <div className="wx-cond-cell">
+                        <WmoIcon code={p.weather_code} cloudCover={p.cloud_cover_pct}
+                          moonUp={moonUpAt(p.time, moonrise ?? null, moonset ?? null)}
+                          aod={p.aerosol_optical_depth} pm25={p.pm2_5} visibilityM={p.visibility_m} precipType={p.precip_type}
+                          windSpeedMs={p.wind_speed_ms} windGustMs={p.wind_gust_ms} transparency={p.transparency} />
+                        {showCloudTotal({ code: p.weather_code, cloudCover: p.cloud_cover_pct, precipType: p.precip_type,
+                          windSpeedMs: p.wind_speed_ms, windGustMs: p.wind_gust_ms }) && (
+                          <span className="wx-cond-total">{p.cloud_cover_pct}%</span>
+                        )}
+                      </div>
+                      <SkyCover
+                        low={p.cloud_cover_low_pct}
+                        mid={p.cloud_cover_mid_pct}
+                        high={p.cloud_cover_high_pct}
+                        imperial={imperial}
+                      />
+                    </div>)}
                   </td>
                   {hasAtmos && (
                     <td className="wx-num wx-atmos-col">

--- a/apps/web/src/report/NightTimeline.tsx
+++ b/apps/web/src/report/NightTimeline.tsx
@@ -3,7 +3,7 @@ import type { SkyEvent, WeatherPoint } from '../types'
 import { formatTime, formatDayTime, fmtTempValue, tempUnitLabel, fmtWindSpeed, windUnitLabel, moonUpAt, formatAge, formatIssuedUtc } from '../format'
 import { InfoTip } from '../shared'
 import { Star } from 'lucide-react'
-import { WiIcon, TRANSP_ABBR, seeingTier, WmoIcon } from './icons'
+import { WiIcon, TRANSP_ABBR, seeingTier, AtmosEq, SkyCover, WmoIcon, showCloudTotal } from './icons'
 import { cell } from './common'
 
 // ── Weather table ────────────────────────────────────────────────────────────
@@ -170,11 +170,15 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
               <tr>
                 <th>Time</th>
                 <th className="wx-cond-col"></th>
-                <th className="wx-cloud-col wx-cloud-hdr">Cloud %<br />Low/Med/High</th>
+                <th className="wx-cloud-col wx-cloud-hdr">
+                  <InfoTip tip={<>The big number is total cloud cover. The telemetry stack breaks it out by altitude — high (&gt;20kft / &gt;6km), mid (&gt;6kft / &gt;2km), low (&lt;6kft / &lt;2km) — with more filled blocks meaning more cloud at that layer.</>}>
+                    Sky Cover
+                  </InfoTip>
+                </th>
                 {hasAtmos  && (
                   <th className="wx-atmos-col wx-atmos-hdr">
-                    <InfoTip tip={<>Seeing — turbulence blur in arcseconds: under 1.5″ is pin-sharp, over 2.5″ smears stars (matters most at long focal lengths). Transparency — how cleanly light passes the air column: Excellent → Poor. Both from 7Timer's astro forecast.</>}>
-                      Seeing /<br />Transp.
+                    <InfoTip tip={<>A segmented readout — more bars is better (Full = Optimal). C — Clarity (transparency): how cleanly light passes the air column (Optimal → Poor). S — Seeing: turbulence blur, steadier is better (under 1.5″ is pin-sharp, over 2.5″ smears stars, matters most at long focal lengths). Both from 7Timer's astro forecast.</>}>
+                      Clarity /<br />Seeing
                     </InfoTip>
                   </th>
                 )}
@@ -251,55 +255,31 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
                 <tr key={`wx-${i}`} className={astroShadeCls}>
                   <td className="wx-time">{formatTime(p.time, tz)}</td>
                   <td className="wx-num wx-rating">
-                    {cell(isFetching, <WmoIcon code={p.weather_code} cloudCover={p.cloud_cover_pct}
-                      moonUp={moonUpAt(p.time, moonrise ?? null, moonset ?? null)}
-                      aod={p.aerosol_optical_depth} pm25={p.pm2_5} visibilityM={p.visibility_m} precipType={p.precip_type}
-                      windSpeedMs={p.wind_speed_ms} windGustMs={p.wind_gust_ms} transparency={p.transparency} />)}
+                    {cell(isFetching, <div className="wx-cond-cell">
+                      <WmoIcon code={p.weather_code} cloudCover={p.cloud_cover_pct}
+                        moonUp={moonUpAt(p.time, moonrise ?? null, moonset ?? null)}
+                        aod={p.aerosol_optical_depth} pm25={p.pm2_5} visibilityM={p.visibility_m} precipType={p.precip_type}
+                        windSpeedMs={p.wind_speed_ms} windGustMs={p.wind_gust_ms} transparency={p.transparency} />
+                      {showCloudTotal({ code: p.weather_code, cloudCover: p.cloud_cover_pct, precipType: p.precip_type,
+                        windSpeedMs: p.wind_speed_ms, windGustMs: p.wind_gust_ms }) && (
+                        <span className="wx-cond-total">{p.cloud_cover_pct}%</span>
+                      )}
+                    </div>)}
                   </td>
                   <td className="wx-num wx-cloud-col">
-                    {cell(isFetching, (() => {
-                      if (p.cloud_cover_low_pct == null && p.cloud_cover_mid_pct == null && p.cloud_cover_high_pct == null) {
-                        return p.cloud_cover_pct != null ? `${p.cloud_cover_pct}%` : '—'
-                      }
-                      const low = p.cloud_cover_low_pct ?? 0
-                      const mid = p.cloud_cover_mid_pct ?? 0
-                      const high = p.cloud_cover_high_pct ?? 0
-                      return (
-                        <div className="wx-cloud-readout" title={`Low: ${low}% | Mid: ${mid}% | High: ${high}%`}>
-                          <span className="wx-cloud-val">{p.cloud_cover_pct != null ? `${p.cloud_cover_pct}%` : '—'}</span>
-                          <div className="wx-cloud-eq">
-                            <div className="wx-eq-track"><div className="wx-eq-fill" style={{ height: `${low}%` }} /></div>
-                            <div className="wx-eq-track"><div className="wx-eq-fill" style={{ height: `${mid}%` }} /></div>
-                            <div className="wx-eq-track"><div className="wx-eq-fill" style={{ height: `${high}%` }} /></div>
-                          </div>
-                        </div>
-                      )
-                    })())}
+                    {cell(isFetching, <SkyCover
+                      low={p.cloud_cover_low_pct}
+                      mid={p.cloud_cover_mid_pct}
+                      high={p.cloud_cover_high_pct}
+                      imperial={imperial}
+                    />)}
                   </td>
                   {hasAtmos && (
                     <td className="wx-num wx-atmos-col">
-                      {cell(isFetching, <span className="wx-atmos-inner">
-                        {p.seeing_arcsec != null && (() => {
-                          const tier = seeingTier(p.seeing_arcsec!)
-                          return (
-                            <span
-                              className={`wx-atmos-seeing${(tier === 'Fair' || tier === 'Poor') ? ' wx-gate-warn' : ''}`}
-                              title={`Seeing: ${p.seeing_arcsec!.toFixed(2)}"`}
-                            >
-                              {tier}
-                            </span>
-                          )
-                        })()}
-                        {p.seeing_arcsec != null && p.transparency != null && (
-                          <span className="wx-atmos-sep">/</span>
-                        )}
-                        {p.transparency != null && (
-                          <span className={`wx-atmos-transp${(p.transparency === 'Fair' || p.transparency === 'Poor') ? ' wx-gate-warn' : ''}`}>
-                            {TRANSP_ABBR[p.transparency] ?? p.transparency}
-                          </span>
-                        )}
-                        {p.seeing_arcsec == null && p.transparency == null && '—'}
-                      </span>)}
+                      {cell(isFetching, <AtmosEq
+                        clarity={p.transparency != null ? (TRANSP_ABBR[p.transparency] ?? p.transparency) : null}
+                        seeing={p.seeing_arcsec != null ? seeingTier(p.seeing_arcsec) : null}
+                      />)}
                     </td>
                   )}
                   {(hasTemp || hasDew) && (

--- a/apps/web/src/report/icons.tsx
+++ b/apps/web/src/report/icons.tsx
@@ -105,6 +105,26 @@ export const PRECIP_TYPE_ICON_NAMES: Record<string, string> = {
   tstorm: 'thunderstorm',
 }
 
+// Whether to surface the total cloud-cover % under the Conditions icon. Shown only
+// when the icon reads as a meaningful, non-precipitating cloud amount: there is some
+// cloud, it isn't a clear sky, and it isn't rain/snow/thunderstorm/etc — a big "100%"
+// next to a rain icon would read as a 100% chance of rain. Fog and windy skies (both
+// non-precip) still qualify; partly-cloudy/cloudy qualify via the >25% threshold
+// skyIconFromCloudCover uses to leave "clear".
+export function showCloudTotal({ code, cloudCover, precipType, windSpeedMs, windGustMs }: {
+  code: number | null; cloudCover?: number | null; precipType?: string | null
+  windSpeedMs?: number | null; windGustMs?: number | null
+}): boolean {
+  if (cloudCover == null || cloudCover <= 0) return false
+  if (precipType === 'fog') return true                    // fog: non-precip, show
+  const isNoPrecip = precipType == null || precipType === 'none'
+  if (!isNoPrecip) return false                            // rain/snow/frzr/icep/tstorm
+  if (code != null && code >= 51) return false             // WMO precip codes
+  const wind = [windSpeedMs, windGustMs].filter((v): v is number => v != null)
+  if (wind.length && Math.max(...wind) >= 8.94) return true // windy (non-precip) icon
+  return cloudCover > 25                                    // clear (≤25) hides; cloudy shows
+}
+
 // Transparency label for the combined Seeing/Transp column — the standard label as-is
 // (not an abbreviation). Explicit map, not a passthrough, so any unexpected value from
 // the provider (transparency is a generic string, not a strict union) still falls back
@@ -123,6 +143,105 @@ export function seeingTier(arcsec: number): 'Optimal' | 'Good' | 'Fair' | 'Poor'
   if (arcsec <= 1.5) return 'Good'
   if (arcsec <= 2.0) return 'Fair'
   return 'Poor'
+}
+
+// ── Clarity / Seeing segmented EQ readout ────────────────────────────────────
+// A quality (not volume) meter: "Full = Optimal". Both seeing and transparency
+// normalize to the same 4-tier vocabulary upstream (Poor/Fair/Good/Optimal, via
+// seeingTier + TRANSP_ABBR), which maps 1:1 onto a contiguous 4-segment scale by
+// the named index below.
+const QUALITY_INDEX: Record<string, number> = {
+  Poor: 1, Fair: 2, Good: 3, Optimal: 4, Excellent: 4,
+}
+const EQ_SEGMENTS = 4
+
+// One row of EQ_SEGMENTS rounded boxes — the first `index` are filled (active),
+// the rest are empty tracks — mirroring the cloud-cover EQ meter's solid fill +
+// rounded corners (see .wx-eq2* in 08-weather-table.css).
+function EqRow({ label, tier }: { label: string; tier: string }) {
+  const index = Math.max(0, Math.min(EQ_SEGMENTS, QUALITY_INDEX[tier] ?? 0))
+  return (
+    <div className="wx-eq2-row">
+      <span className="wx-eq2-label">{label}</span>
+      <span className="wx-eq2-segs" title={tier}>
+        {Array.from({ length: EQ_SEGMENTS }, (_, i) => (
+          <span key={i} className={`wx-eq2-seg ${i < index ? 'wx-eq2-seg-on' : 'wx-eq2-seg-off'}`} />
+        ))}
+      </span>
+    </div>
+  )
+}
+
+// Two stacked EQ rows — C (Clarity/transparency) above S (Seeing) — read as one
+// consolidated instrument. A null half is omitted; an all-null cell em-dashes.
+export function AtmosEq({ clarity, seeing }: {
+  clarity: string | null; seeing: string | null
+}) {
+  if (clarity == null && seeing == null) return <>—</>
+  return (
+    <div className="wx-eq2">
+      {clarity != null && <EqRow label="C" tier={clarity} />}
+      {seeing  != null && <EqRow label="S" tier={seeing} />}
+    </div>
+  )
+}
+
+// ── Sky Cover — aviation-style telemetry readout ─────────────────────────────
+// A "big total" cloud-cover anchor on the left; a monospace telemetry stack of
+// three altitude tiers on the right, each mapping its pct to a bracketed
+// 4-segment EQ, rendered with the exact same rounded box segments as the
+// Clarity/Seeing readout (.wx-eq2-seg — filled --text-dim over a muted track),
+// framed by aviation-style brackets. Fill mapping per tier:
+//   0% → 0 · 1–25 → 1 · 26–50 → 2 · 51–75 → 3 · 76–100 → 4 segments
+function cloudTier(pct: number): number {
+  if (pct <= 0) return 0
+  if (pct <= 25) return 1
+  if (pct <= 50) return 2
+  if (pct <= 75) return 3
+  return 4
+}
+
+function SkyTierRow({ label, pct }: { label: string; pct: number }) {
+  const n = cloudTier(pct)
+  return (
+    <div className="wx-sky-row">
+      <span className="wx-sky-alt">{label}</span>
+      <span className="wx-sky-eq" title={`${label.trim()}: ${pct}%`}>
+        <span className="wx-eq2-segs">
+          {Array.from({ length: EQ_SEGMENTS }, (_, i) => (
+            <span key={i} className={`wx-eq2-seg ${i < n ? 'wx-eq2-seg-on' : 'wx-eq2-seg-off'}`} />
+          ))}
+        </span>
+      </span>
+    </div>
+  )
+}
+
+// Altitude tier labels — imperial feet (>20kft / >6kft / <6kft) or metric km
+// (>6km / >2km / <2km, rounded from the 20,000 ft ≈ 6 km and 6,500 ft ≈ 2 km
+// layer boundaries), chosen by the unit toggle.
+const SKY_LABELS = {
+  imperial: { high: '>20k', mid: '>6k', low: '<6k' },
+  metric:   { high: '>6km',   mid: '>2km',  low: '<2km' },
+} as const
+
+// Per-altitude telemetry stack, ordered high → low (aviation convention:
+// high/cirrus, mid, low). The total cloud-cover % now lives under the Conditions
+// icon (see showCloudTotal), so this column is the breakdown only; a cell with no
+// per-tier data em-dashes.
+export function SkyCover({ low, mid, high, imperial = true }: {
+  low?: number | null; mid?: number | null; high?: number | null
+  imperial?: boolean
+}) {
+  if (low == null && mid == null && high == null) return <>—</>
+  const labels = imperial ? SKY_LABELS.imperial : SKY_LABELS.metric
+  return (
+    <div className="wx-sky-stack">
+      <SkyTierRow label={labels.high} pct={high ?? 0} />
+      <SkyTierRow label={labels.mid}  pct={mid ?? 0} />
+      <SkyTierRow label={labels.low}  pct={low ?? 0} />
+    </div>
+  )
 }
 
 export function WmoIcon({ code, cloudCover, moonUp = false, size = 32, aod, pm25, visibilityM, precipType, windSpeedMs, windGustMs, transparency }: {

--- a/apps/web/src/styles/07-targets-milkyway.css
+++ b/apps/web/src/styles/07-targets-milkyway.css
@@ -443,15 +443,9 @@ html.red-mode .cond-glow { color: rgb(160, 0, 0) !important; }
   line-height: 1.15;
   vertical-align: bottom;
 }
-/* NOTE: the Clarity/Seeing segmented EQ readout (.wx-eq2*) lives in
-   08-weather-table.css alongside the rest of the weather-table cell styling. */
-/* Conditions column has no header label (icon-only) — pin a comfortable fixed width
-   instead of letting it auto-size to the icon alone. */
-.wx-table th.wx-cond-col,
-.wx-table td.wx-rating {
-  width: 1px;
-  min-width: 42px;
-}
+/* NOTE: the Clarity/Seeing segmented EQ readout (.wx-eq2*) and the merged Sky
+   Cover cell (.wx-sky-cell — icon + % + telemetry) live in 08-weather-table.css
+   alongside the rest of the weather-table cell styling. */
 /* Fog/Haze/Haze-Aloft/Haze-Surface — bold word instead of an icon (see WmoIcon).
    Stays single-line by default; narrow viewports override to wrap "Aloft"/"Surface"
    onto their own line below "Haze:" rather than widening the column (see the

--- a/apps/web/src/styles/07-targets-milkyway.css
+++ b/apps/web/src/styles/07-targets-milkyway.css
@@ -443,19 +443,8 @@ html.red-mode .cond-glow { color: rgb(160, 0, 0) !important; }
   line-height: 1.15;
   vertical-align: bottom;
 }
-.wx-atmos-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.wx-atmos-sep { display: none; }
-.wx-atmos-seeing,
-.wx-atmos-transp {
-  width: auto;
-  text-align: center;
-  font-family: var(--mono);
-  line-height: 1;
-}
+/* NOTE: the Clarity/Seeing segmented EQ readout (.wx-eq2*) lives in
+   08-weather-table.css alongside the rest of the weather-table cell styling. */
 /* Conditions column has no header label (icon-only) — pin a comfortable fixed width
    instead of letting it auto-size to the icon alone. */
 .wx-table th.wx-cond-col,
@@ -482,42 +471,8 @@ html.red-mode .cond-glow { color: rgb(160, 0, 0) !important; }
   line-height: 1.1;
   vertical-align: bottom;
 }
-/* Compact 3-channel EQ-meter readout for Low/Mid/High cloud in the Cloud cell */
-.wx-cloud-readout {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.wx-cloud-val {
-  font-family: var(--mono);
-  font-variant-numeric: tabular-nums;
-  min-width: 26px;
-  text-align: right;
-}
-.wx-cloud-eq {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  height: 12px;
-  border-bottom: 1px solid rgba(var(--hairline-rgb), 0.5);
-  padding-bottom: 1px;
-}
-.wx-eq-track {
-  width: 5.3px;
-  height: 10px;
-  background: rgba(var(--hairline-rgb), 0.15);
-  border-radius: 1px 1px 0 0;
-  position: relative;
-  overflow: hidden;
-}
-.wx-eq-fill {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  background: var(--text-dim);
-  transition: height 0.2s ease-out;
-}
+/* NOTE: the Sky Cover cell readout (.wx-sky*) lives in 08-weather-table.css
+   alongside the rest of the weather-table cell styling. */
 
 .tg-moon-note        { color: var(--text-dim); font-size: 12px; }
 /* Fixed-width blocks so every piece aligns across rows in Best Viewing / Astro Window */

--- a/apps/web/src/styles/08-weather-table.css
+++ b/apps/web/src/styles/08-weather-table.css
@@ -179,10 +179,10 @@ html.red-mode .wx-now-row td.wx-now-time {
   color: var(--text);
   white-space: nowrap;
 }
-/* Conditions and Wind cells hold a 32px icon — the tallest content in the row,
-   so it alone sets the row height for every cell. Tighter vertical padding here
-   brings the row back down without shrinking the icon itself. */
-.wx-table td.wx-rating,
+/* The Wind cell holds a 32px icon; the Sky Cover cell holds the 3-row telemetry
+   stack plus the condition icon. Both are among the tallest content in the row,
+   so tighter vertical padding here keeps rows compact without shrinking them. */
+.wx-table td.wx-cloud-col,
 .wx-table td.wx-wind-col {
   padding-top: 3px;
   padding-bottom: 3px;
@@ -231,9 +231,9 @@ html.red-mode .wx-now-row td.wx-now-time {
 /* Center every icon-headed column: the header icon and its data (which can be
    wider than the icon itself, e.g. the L/M/H cloud tiers) share one center
    point, so they align regardless of the data's rendered width — unlike
-   right-align, which only guarantees the shared edge lines up. */
-.wx-table th.wx-cond-col, .wx-table td.wx-rating,
-.wx-table th.wx-cloud-col, .wx-table td.wx-cloud-col,
+   right-align, which only guarantees the shared edge lines up. Sky Cover is the
+   exception: its header stays right-aligned (via .wx-num / th:not(:first-child))
+   so it sits over the telemetry while the icon+% hang off to the left. */
 .wx-table th.wx-wind-col, .wx-table td.wx-wind-col,
 .wx-table th.wx-atmos-col, .wx-table td.wx-atmos-col {
   text-align: center;
@@ -354,6 +354,15 @@ html.red-mode .recalc-overlay {
 }
 .wx-eq2-seg-on  { background: var(--text-dim); }
 .wx-eq2-seg-off { background: rgba(var(--hairline-rgb), 0.15); }
+
+/* Sky Cover cell — the condition icon + total % (left) and the altitude
+   telemetry stack (right), sharing one column. The header is right-aligned over
+   the telemetry, so the icon+% appear to hang off the left edge of the column. */
+.wx-sky-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
 
 /* ── Conditions cell — weather icon + total cloud-cover % ────────────────────
    The total % (formerly the Sky Cover "big total") now sits under the condition

--- a/apps/web/src/styles/08-weather-table.css
+++ b/apps/web/src/styles/08-weather-table.css
@@ -308,3 +308,103 @@ html.red-mode .recalc-overlay {
     color: inherit;
   }
 }
+
+/* ── Clarity / Seeing segmented EQ readout ──────────────────────────────────
+   Two stacked rows (C = Clarity/transparency, S = Seeing) with a tight 2px gap
+   so they read as one consolidated instrument. Rendered as real rounded boxes
+   (not ▇/░ glyphs): filled = --text-dim, empty = a faint hairline track wash.
+   Both are tokens, so red-mode flips to pure red automatically. The Sky Cover
+   readout below reuses this same colour scheme. The whole block is inline-flex,
+   so it centres in the centred cell while its rows stay left-aligned against a
+   rigid label. */
+.wx-eq2 {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  line-height: 1;
+  text-align: left;
+}
+.wx-eq2-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+/* Fixed-width label box → rigid left margin before the segments begin, so C and
+   S line up and the two bars share a common starting axis. Same mono font as the
+   rest of the table; unbold. */
+.wx-eq2-label {
+  width: 12px;
+  flex: none;
+  text-align: left;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 11px;
+}
+.wx-eq2-segs {
+  display: inline-flex;
+  gap: 2px;
+}
+/* Small rounded segment boxes — wider than tall (the ~20% "shorter" look), with
+   the same 1px corner radius as the cloud-cover track tops. */
+.wx-eq2-seg {
+  width: 7px;
+  height: 6px;
+  border-radius: 1px;
+}
+.wx-eq2-seg-on  { background: var(--text-dim); }
+.wx-eq2-seg-off { background: rgba(var(--hairline-rgb), 0.15); }
+
+/* ── Conditions cell — weather icon + total cloud-cover % ────────────────────
+   The total % (formerly the Sky Cover "big total") now sits under the condition
+   icon, but only for meaningful non-precipitating cloud (see showCloudTotal) so
+   a "100%" never reads as a 100% chance of rain. Styled like the time-column
+   digits: standard sans, normal weight, dim grey. */
+.wx-cond-cell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+.wx-cond-total {
+  font-family: var(--sans);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--text-dim);
+}
+
+/* ── Sky Cover — aviation-style telemetry readout ───────────────────────────
+   A monospace telemetry stack of three altitude tiers (high → low). Monospace
+   keeps every tier the same width regardless of data. Colours reuse the
+   Clarity/Seeing scheme (filled = --text-dim, empty = a muted hairline wash),
+   all tokens, so red-mode flips to pure red automatically. */
+.wx-sky-stack {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 1px;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.wx-sky-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+/* Fixed-width altitude label, right-aligned so the unit sits flush against the
+   segment blocks. Sized to the widest label (4 chars: ">20k" / ">6km"). */
+.wx-sky-alt {
+  width: 30px;
+  flex: none;
+  text-align: right;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+}
+/* EQ — the SAME rounded box segments as the Clarity/Seeing readout
+   (.wx-eq2-seg / .wx-eq2-segs, reused verbatim). */
+.wx-sky-eq {
+  display: inline-flex;
+  align-items: center;
+}

--- a/apps/web/src/styles/11-responsive.css
+++ b/apps/web/src/styles/11-responsive.css
@@ -279,26 +279,28 @@
     padding-right: 0;
   }
 
-  /* Conditions Icon Column */
-  .wx-table th.wx-cond-col,
-  .wx-table td.wx-rating {
-    min-width: 24px;
-    padding-left: 0;
-  }
-
-  /* Force the weather and wind icons to shrink and strip hardcoded margins */
-  .wx-table td.wx-rating svg,
+  /* Force the weather and wind icons to shrink and strip hardcoded margins.
+     The condition icon now lives inside the merged Sky Cover cell. */
+  .wx-cond-cell svg,
   .wx-table td.wx-wind-col svg {
     width: 20px !important;
     height: 20px !important;
     margin-left: 0 !important;
   }
+  /* Shrink the cloud % to sit better under the now-smaller icon. */
+  .wx-cond-total {
+    font-size: 9px;
+  }
 
-  /* Cloud Cover Column */
+  /* Sky Cover Column (icon + % + telemetry) */
   .wx-table th.wx-cloud-col,
   .wx-table td.wx-cloud-col {
     padding-left: 0;
     padding-right: 0;
+  }
+  /* Tighten the gap between the icon+% and the telemetry stack on mobile. */
+  .wx-sky-cell {
+    gap: 3px;
   }
 
   /* Clarity/Seeing Column */

--- a/apps/web/src/styles/11-responsive.css
+++ b/apps/web/src/styles/11-responsive.css
@@ -3,6 +3,7 @@
   .app {
     padding: 12px 4px max(48px, calc(48px + env(safe-area-inset-bottom)));
   }
+
   .masthead {
     margin-bottom: 10px;
   }
@@ -39,8 +40,8 @@
   .report-head {
     flex-wrap: wrap;
   }
-  /* Score card: collapse the 2-column grid (score+meta | dome) to a single
-     column, matching the Milky Way card's own grid→stack breakpoint. */
+
+  /* Score card: collapse to a single column */
   .overall {
     grid-template-columns: 1fr;
   }
@@ -49,72 +50,63 @@
     grid-column: 1;
   }
 
-  /* Report head: properly scales down location name on mobile */
   .report-head .place {
     font-size: 14px;
   }
-
   .report-head-coords {
     display: none;
   }
+
   /* Table bleed matches reduced card padding */
   .wx-table-wrap,
   .tg-table-wrap {
     margin-right: -8px;
     padding-right: 8px;
   }
+
   /* Satellite table: hide Set columns, Duration, and Peak Az to fit mobile */
   .sat-set-col,
   .sat-dur-col,
   .sat-peak-az-col {
     display: none;
   }
+
   /* MW card: collapse to single column so dome stacks below scores */
-  /* MW card: collapse to single column so dome stacks below scores */
-  .mw-layout {
+  .mw-layout,
+  .mw-top-section {
     grid-template-columns: 1fr;
+    gap: 16px;
   }
-  /* Center the dome SVG when stacked in single-column layout */
   .mw-dome-wrap {
     width: 100%;
     max-width: 420px;
     margin: 0 auto;
   }
-    /* MW card: collapse to single column so dome stacks below scores */
-  .mw-top-section {
-    grid-template-columns: 1fr;
-    gap: 16px;
-  }
-
   .mw-mid-section {
     flex-direction: column;
-    align-items: center;  /* Centers the graphic and the notes block */
-    gap: 16px;            /* Adds breathing room between the dome and the notes */
+    align-items: center;
+    gap: 16px;
+  }
+  .mw-dome-container {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+  .mw-notes-container {
+    align-items: center;
+    margin-top: 0;
+    max-width: 100%;
   }
 
-.mw-dome-container {
-  display: flex;
-  justify-content: center;
-  width: 100%;
-}
-
-/* Keep notes left-aligned in their own block below the dome */
-.mw-notes-container {
-    align-items: center;  /* Centers the badges horizontally */
-    margin-top: 0;        /* Resets the desktop nudge */
-    max-width: 100%;      /* Allows it to use the full width */
-  }
-  /* Restore nearby table layout for mobile, matching the Excel mockup */
+  /* Restore nearby table layout for mobile */
   .nearby-table {
     display: table;
     width: 100%;
     table-layout: auto;
   }
-
   .nearby-table thead {
-    display: table-header-group; /* Restores the missing column labels */
+    display: table-header-group;
   }
-
   .nearby-table th {
     white-space: normal;
     padding: 4px 2px;
@@ -124,31 +116,24 @@
     border-top: 1px solid rgba(255, 255, 255, 0.65);
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   }
-
   .nearby-table td {
     white-space: normal;
     padding: 6px 2px;
     vertical-align: top;
     border-bottom: 1px solid rgba(var(--hairline-rgb), 0.25);
   }
-
   .nearby-table tr:last-child td {
     border-bottom: none;
   }
-
-  /* Structure the Area column */
   .nearby-area-td {
     width: 100%;
   }
-
-  /* Flex container groups badge+icon so they don't split across lines */
   .nearby-area-inner {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
     gap: 0 4px;
   }
-
   .nearby-area-inner .poi-namelink {
     flex: 0 0 100%;
     margin-bottom: 3px;
@@ -156,12 +141,9 @@
     line-height: 1.25;
     white-space: normal;
   }
-
   .nearby-area-inner .poi-area {
     margin-left: 0;
   }
-
-  /* Data columns: higher specificity to override .nearby-table td white-space */
   .nearby-table td.nearby-bortle-col,
   .nearby-table td.nearby-sqm-col,
   .nearby-table td.nearby-dist-col,
@@ -171,7 +153,8 @@
     text-align: right;
     white-space: nowrap;
   }
-  /* Blocked target rows: allow badge text to wrap instead of clipping */
+
+  /* Blocked target rows: allow badge text to wrap */
   .tg-row-blocked td {
     white-space: normal;
   }
@@ -194,11 +177,11 @@
   .es-caps {
     grid-template-columns: 1fr;
   }
-
   .masthead h1 {
     font-size: 1.25rem;
   }
-    /* ── Date Picker Mobile Compression ── */
+
+  /* Date Picker Mobile Compression */
   .dp-popover {
     padding: 12px;
   }
@@ -207,7 +190,7 @@
   }
   .dp-day,
   .dp-cell-empty {
-    height: 34px; /* Reduced from 42px to save vertical space */
+    height: 34px;
   }
   .dp-footer {
     margin-top: 8px;
@@ -216,7 +199,8 @@
   .dp-today-btn {
     padding: 7px 0;
   }
-  /* Score card: tighter padding on narrow phones */
+
+  /* Score card */
   .overall {
     padding: 14px 16px;
     gap: 14px;
@@ -228,11 +212,13 @@
     font-size: 1.5rem;
     margin-top: 0;
   }
-  /* Bar chart: tighter columns */
+
+  /* Bar chart */
   .bar-row {
     grid-template-columns: 100px 1fr 32px;
   }
-  /* Meta rows: keep horizontal, give key a fixed lane */
+
+  /* Meta rows */
   .meta-k {
     min-width: 100px;
     flex-shrink: 0;
@@ -251,8 +237,8 @@
     flex: 1;
     padding-left: 0;
   }
-  /* Light dome stacks below the score, full-width; centering and column
-     stacking of title/canvas/caption are the unconditional defaults now. */
+
+  /* Light dome */
   .lightdome-panel {
     width: 100%;
   }
@@ -260,57 +246,116 @@
     accent-color: var(--accent);
     cursor: pointer;
   }
-  /* Night Timeline / Weather table: squeeze to fit all columns without horizontal scroll */
+
+  /* ── Night Timeline / Weather table ── */
   .wx-table {
     font-size: 10px;
   }
-  /* "Haze: Aloft" / "Haze: Surface" wrap onto a second line here rather than
-     widening the Conditions column — vertical space is cheaper than width on a
-     narrow viewport. Overrides the inherited nowrap from .wx-table td; max-width
-     forces the break instead of just permitting it (normal alone doesn't shrink
-     the box, it only allows wrapping once something else constrains the width). */
+
+  /* Force Haze to wrap */
   .wx-cond-word {
     display: inline-block;
     max-width: 46px;
     white-space: normal;
   }
+
+  /* Global mobile table cell padding and wrapping */
   .wx-table th {
-    padding: 2px 2px 3px;
+    padding: 2px 1px 3px; /* 1px L/R padding */
     font-size: 9px;
     letter-spacing: 0.03em;
     white-space: normal;
+    vertical-align: bottom; /* Clean bottom alignment */
   }
   .wx-table td {
-    padding: 3px 2px;
+    padding: 3px 1px; /* 1px L/R padding */
+    white-space: normal;
   }
-  /* Cloud % stacks above the EQ meter here instead of sitting beside it —
-     narrower footprint than the desktop side-by-side layout. */
-  .wx-cloud-readout {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-  }
+
+  /* Time Column */
   .wx-table td.wx-time,
   .wx-table th:first-child {
     min-width: 52px;
+    padding-right: 0;
   }
-  /* Targets table: reduce font/padding and allow target name to wrap */
+
+  /* Conditions Icon Column */
+  .wx-table th.wx-cond-col,
+  .wx-table td.wx-rating {
+    min-width: 24px;
+    padding-left: 0;
+  }
+
+  /* Force the weather and wind icons to shrink and strip hardcoded margins */
+  .wx-table td.wx-rating svg,
+  .wx-table td.wx-wind-col svg {
+    width: 20px !important;
+    height: 20px !important;
+    margin-left: 0 !important;
+  }
+
+  /* Cloud Cover Column */
+  .wx-table th.wx-cloud-col,
+  .wx-table td.wx-cloud-col {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  /* Clarity/Seeing Column */
+  .wx-table th.wx-atmos-col,
+  .wx-table td.wx-atmos-col {
+    padding-right: 0;
+  }
+  .wx-eq2-seg {
+    width: 4px; /* Narrower segments */
+  }
+  .wx-eq2-segs,
+  .wx-eq2 {
+    gap: 0; /* Remove gaps between segments and rows */
+  }
+
+  /* Temp/Dew Pt Column */
+  .wx-table th.wx-temp-col,
+  .wx-table td.wx-temp-col {
+    padding-left: 0;
+    padding-right: 0;
+    white-space: nowrap; /* Forces unit to stay glued to temp */
+  }
+
+  /* Wind Column */
+  .wx-table th.wx-wind-col,
+  .wx-table td.wx-wind-col {
+    padding-left: 0;
+  }
+  .wx-wind-col {
+    flex-wrap: wrap;
+  }
+  /* Remove fixed width on unit so arrow hugs the text */
+  .wx-wind-unit {
+    width: auto;
+    padding-right: 2px;
+  }
+
+  /* ── Targets table ── */
   .tg-table {
     font-size: 11px;
+    width: 100%;
+    table-layout: auto;
   }
   .tg-table th {
     padding: 3px 6px 4px;
     font-size: 9px;
+    white-space: normal;
   }
   .tg-table td {
     padding: 4px 6px;
+    white-space: normal;
   }
   .tg-table td:first-child {
-    white-space: normal;
     max-width: 160px;
   }
-  /* POI elements: reduce font sizes so nearby table fits */
+
+  /* POI elements */
   .poi-maplink,
   .poi-area,
   .poi-badge {
@@ -320,20 +365,13 @@
     width: 11px;
     height: 11px;
   }
-  /* Arch waypoints: allow window time range to wrap */
+
+  /* Arch waypoints */
   .wp-window-td {
     white-space: normal;
   }
-  /* Deep sky targets: fill width and let content wrap naturally */
-  .tg-table {
-    width: 100%;
-    table-layout: auto;
-  }
-  .tg-table td,
-  .tg-table th {
-    white-space: normal;
-  }
-  /* Remove fixed-width spans so alignment columns share space naturally */
+
+  /* Alignment columns */
   .tg-t,
   .tg-alt,
   .tg-az,


### PR DESCRIPTION
## What & why

Reworks the Night Timeline weather columns into compact, field-instrument-style readouts, and relocates the total cloud-cover % so the table fits better on mobile (it was overflowing horizontally on phones).

### Changes

**Clarity / Seeing** — replaces the repetitive `Seeing / Transp.` text with a 4-tier segmented EQ: two stacked rows (`C` = clarity/transparency, `S` = seeing) of rounded box segments. Filled = `--text-dim`, empty = a muted hairline track.

**Sky Cover** — replaces the vertical 3-bar cloud EQ with a monospace per-altitude telemetry stack:
- `>20k` / `>6k` / `<6k` (feet) or `>6km` / `>2km` / `<2km` when the unit toggle is metric (rounded from the 20,000 ft ≈ 6 km and 6,500 ft ≈ 2 km layer boundaries).
- Uses the **exact same** rounded box segments as Clarity/Seeing.

**Total cloud % moved under the Conditions icon** — instead of a big number in the (wide) Sky Cover column, the total renders under the weather icon, and only when it reads as a meaningful, non-precipitating cloud amount (`showCloudTotal`):
- Hidden for clear skies and 0% cloud.
- Hidden for rain / snow / showers / drizzle / sleet / thunderstorm — so a `100%` never looks like a 100% chance of precipitation.
- Shown for partly cloudy, cloudy, fog, and windy skies.

**Mobile width** — moved the weather-table cell styling into `08-weather-table.css` (was in `07-targets-milkyway.css`) and trimmed mobile column widths / paddings to reduce horizontal scrolling.

All colors ride shared design tokens, so red-mode flips to pure red automatically.

### Verification
- `showCloudTotal` classification unit-checked across 16 cases (clear, 0%, partly, cloudy, rain, thunderstorm, snow, showers, fog, windy-clear, etc.) — all pass.
- Layout/CSS verified in-browser against the real component classes (icon + total stacking; Sky Cover without the total; segments byte-identical to Clarity/Seeing).
- `tsc --noEmit` clean; no console errors; red-mode + metric/imperial toggle verified.

> Note: full end-to-end visual verification with live forecast data needs the API backend running; logic + layout were verified via unit tests and a DOM scaffold using the real classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)