### PR TITLE
Redesign weather-table readouts: bar meters, unit-in-header, alignment fixes

### DIFF
--- a/apps/web/src/report/NightTimeline.tsx
+++ b/apps/web/src/report/NightTimeline.tsx
@@ -171,7 +171,7 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
                 <th>Time</th>
                 <th className="wx-cloud-col wx-cloud-hdr">
                   <InfoTip tip={<>The weather icon and total cloud-cover % hang to the left; the telemetry stack breaks cloud out by altitude — high (&gt;20kft / &gt;6km), mid (&gt;6kft / &gt;2km), low (&lt;6kft / &lt;2km) — with more filled blocks meaning more cloud at that layer.</>}>
-                    Sky Cover
+                    Sky Cover at<br />Alt. ({imperial ? 'Feet' : 'Meters'})
                   </InfoTip>
                 </th>
                 {hasAtmos  && (
@@ -181,8 +181,8 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
                     </InfoTip>
                   </th>
                 )}
-                {(hasTemp || hasDew) && <th className="wx-temp-col wx-temp-hdr">TEMP/<br />DEW PT</th>}
-                <th className="wx-wind-col">Wind</th>
+                {(hasTemp || hasDew) && <th className="wx-temp-col wx-temp-hdr">TEMP/<br />DEW PT ({tempUnitLabel(imperial)})</th>}
+                <th className="wx-wind-col">Wind ({windUnitLabel(imperial)})</th>
               </tr>
             </thead>
           )}
@@ -291,9 +291,6 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
                             {fmtTempValue(p.dew_point_c, imperial)}
                           </span>
                         )}
-                        {(p.temperature_c != null || p.dew_point_c != null) && (
-                          <span className="wx-temp-unit">{tempUnitLabel(imperial)}</span>
-                        )}
                       </>)}
                     </td>
                   )}
@@ -310,7 +307,6 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
                         </span>
                       </>
                     )}
-                    <span className="wx-wind-unit">{windUnitLabel(imperial)}</span>
                   </>
                 ) : '—'}
 

--- a/apps/web/src/report/icons.tsx
+++ b/apps/web/src/report/icons.tsx
@@ -145,29 +145,34 @@ export function seeingTier(arcsec: number): 'Optimal' | 'Good' | 'Fair' | 'Poor'
   return 'Poor'
 }
 
-// ── Clarity / Seeing segmented EQ readout ────────────────────────────────────
+// ── Clarity / Seeing bar readout ─────────────────────────────────────────────
 // A quality (not volume) meter: "Full = Optimal". Both seeing and transparency
 // normalize to the same 4-tier vocabulary upstream (Poor/Fair/Good/Optimal, via
-// seeingTier + TRANSP_ABBR), which maps 1:1 onto a contiguous 4-segment scale by
-// the named index below.
+// seeingTier + TRANSP_ABBR), which maps 1:1 onto a proportional fill by the
+// named index below.
 const QUALITY_INDEX: Record<string, number> = {
   Poor: 1, Fair: 2, Good: 3, Optimal: 4, Excellent: 4,
 }
 const EQ_SEGMENTS = 4
 
-// One row of EQ_SEGMENTS rounded boxes — the first `index` are filled (active),
-// the rest are empty tracks — mirroring the cloud-cover EQ meter's solid fill +
-// rounded corners (see .wx-eq2* in 08-weather-table.css).
+// A single proportional fill bar (0–100%), shared by both the Clarity/Seeing
+// and Sky Cover readouts (see .wx-bar-track/.wx-bar-fill in
+// 08-weather-table.css).
+function Bar({ pct, title }: { pct: number; title?: string }) {
+  const clamped = Math.max(0, Math.min(100, pct))
+  return (
+    <span className="wx-bar-track" title={title}>
+      <span className="wx-bar-fill" style={{ width: `${clamped}%` }} />
+    </span>
+  )
+}
+
 function EqRow({ label, tier }: { label: string; tier: string }) {
   const index = Math.max(0, Math.min(EQ_SEGMENTS, QUALITY_INDEX[tier] ?? 0))
   return (
     <div className="wx-eq2-row">
       <span className="wx-eq2-label">{label}</span>
-      <span className="wx-eq2-segs" title={tier}>
-        {Array.from({ length: EQ_SEGMENTS }, (_, i) => (
-          <span key={i} className={`wx-eq2-seg ${i < index ? 'wx-eq2-seg-on' : 'wx-eq2-seg-off'}`} />
-        ))}
-      </span>
+      <Bar pct={(index / EQ_SEGMENTS) * 100} title={tier} />
     </div>
   )
 }
@@ -188,31 +193,15 @@ export function AtmosEq({ clarity, seeing }: {
 
 // ── Sky Cover — aviation-style telemetry readout ─────────────────────────────
 // A "big total" cloud-cover anchor on the left; a monospace telemetry stack of
-// three altitude tiers on the right, each mapping its pct to a bracketed
-// 4-segment EQ, rendered with the exact same rounded box segments as the
-// Clarity/Seeing readout (.wx-eq2-seg — filled --text-dim over a muted track),
-// framed by aviation-style brackets. Fill mapping per tier:
-//   0% → 0 · 1–25 → 1 · 26–50 → 2 · 51–75 → 3 · 76–100 → 4 segments
-function cloudTier(pct: number): number {
-  if (pct <= 0) return 0
-  if (pct <= 25) return 1
-  if (pct <= 50) return 2
-  if (pct <= 75) return 3
-  return 4
-}
-
+// three altitude tiers on the right, each rendered as a proportional fill bar
+// (the raw pct, unquantized) with the exact same bar styling as the
+// Clarity/Seeing readout (.wx-bar-track/.wx-bar-fill — filled --text-dim over
+// a muted track).
 function SkyTierRow({ label, pct }: { label: string; pct: number }) {
-  const n = cloudTier(pct)
   return (
     <div className="wx-sky-row">
       <span className="wx-sky-alt">{label}</span>
-      <span className="wx-sky-eq" title={`${label.trim()}: ${pct}%`}>
-        <span className="wx-eq2-segs">
-          {Array.from({ length: EQ_SEGMENTS }, (_, i) => (
-            <span key={i} className={`wx-eq2-seg ${i < n ? 'wx-eq2-seg-on' : 'wx-eq2-seg-off'}`} />
-          ))}
-        </span>
-      </span>
+      <Bar pct={pct} title={`${label.trim()}: ${pct}%`} />
     </div>
   )
 }

--- a/apps/web/src/styles/07-targets-milkyway.css
+++ b/apps/web/src/styles/07-targets-milkyway.css
@@ -403,7 +403,6 @@ html.red-mode .cond-glow { color: rgb(160, 0, 0) !important; }
   font-variant-numeric: tabular-nums;
 }
 .wx-wind-sep { display: inline-block; margin: 0 1px; color: var(--text-dim); }
-.wx-wind-unit { display: inline-block; width: 26px; text-align: left; padding-left: 2px; color: var(--text-dim); }
 /* Gust sits between two visible neighbors ("/" and the unit), so unlike sustained
    it gets no fixed-width box — that would leave a blank gap against whichever
    side padding falls on. Sized to content instead, so it stays flush against
@@ -423,12 +422,6 @@ html.red-mode .cond-glow { color: rgb(160, 0, 0) !important; }
   font-variant-numeric: tabular-nums;
 }
 .wx-temp-sep { display: inline-block; margin: 0 1px; color: var(--text-dim); }
-/* No fixed width — the unit is the last element in the cell (nothing trails it)
-   and is identical on every row (global imperial/metric toggle, not per-row),
-   so unlike the dew value there's no cross-row variability to guard against. A
-   fixed box here only left trailing blank space after the short "°F"/"°C" text,
-   which is why the right-aligned header didn't line up with the visible data. */
-.wx-temp-unit { display: inline-block; padding-left: 2px; color: var(--text-dim); }
 .wx-dew-val { display: inline-block; width: auto; text-align: left; }
 .wx-dew-warn { color: var(--poor); font-weight: 700; }
 /* Combined Seeing/Transparency readout — always wraps to two lines (Seeing above

--- a/apps/web/src/styles/08-weather-table.css
+++ b/apps/web/src/styles/08-weather-table.css
@@ -31,7 +31,7 @@
   border-bottom: none;
 }
 .wx-now-row td.wx-now-time {
-  padding: 1px 6px 1px 0;
+  padding: 1px 6px;
   background: var(--card);
   color: var(--accent);
   border-left: 2px solid var(--accent);
@@ -66,9 +66,9 @@ html.red-mode .wx-now-row td.wx-now-time {
 }
 /* Time cell: restore padding, solid bg for sticky cover, accent border to mark event rows */
 .wx-ev-row td.wx-ev-time {
-  padding: 3px 6px 3px 0;
+  padding: 3px 6px;
   background: var(--card);
-  border-left: 1.5px solid rgba(var(--tint-rgb), 0.35);
+  border-left-color: rgba(var(--tint-rgb), 0.35);
 }
 /* Label cell: sticky immediately after the time column */
 .wx-ev-content {
@@ -121,7 +121,7 @@ html.red-mode .wx-now-row td.wx-now-time {
 .wx-ev-row.wx-ev-astro .wx-ev-divider::before,
 .wx-ev-row.wx-ev-astro .wx-ev-divider::after {
   content: '';
-  flex: 1;
+  flex: 0 1 32px;
   height: 0;
   border-top: 1px solid rgba(var(--hairline-rgb), 0.6);
 }
@@ -201,10 +201,12 @@ html.red-mode .wx-now-row td.wx-now-time {
   z-index: 1;
   color: var(--text-dim);
   font-variant-numeric: tabular-nums;
-  text-align: right;
-  padding-left: 0;
+  text-align: left;
   width: 1px;
   min-width: 68px; /* fixed so event label cell can use left: 68px */
+  /* Fixed-width transparent border on every row (not just accented ones) so the
+     accent border below never shifts the time text — only its color changes. */
+  border-left: 2px solid transparent;
 }
 .wx-table th:first-child {
   width: 1px;
@@ -235,8 +237,17 @@ html.red-mode .wx-now-row td.wx-now-time {
    exception: its header stays right-aligned (via .wx-num / th:not(:first-child))
    so it sits over the telemetry while the icon+% hang off to the left. */
 .wx-table th.wx-wind-col, .wx-table td.wx-wind-col,
-.wx-table th.wx-atmos-col, .wx-table td.wx-atmos-col {
+.wx-table td.wx-atmos-col {
   text-align: center;
+}
+/* Clarity/Seeing header: left-align instead of centering, so "Clarity /" and
+   "Seeing" share one left edge across their two wrapped lines rather than each
+   line centering independently and reading as staggered/misaligned. Extra
+   left padding keeps that shared edge from hugging the Sky Cover column's
+   right edge — the centered C/S data below sits well clear of it already. */
+.wx-table th.wx-atmos-hdr {
+  text-align: left;
+  padding-left: 16px;
 }
 /* Grouped span headers (e.g. Rise / Peak / Set in sat table) look better centred */
 .wx-table th[colspan] {
@@ -309,12 +320,12 @@ html.red-mode .recalc-overlay {
   }
 }
 
-/* ── Clarity / Seeing segmented EQ readout ──────────────────────────────────
+/* ── Clarity / Seeing bar readout ───────────────────────────────────────────
    Two stacked rows (C = Clarity/transparency, S = Seeing) with a tight 2px gap
-   so they read as one consolidated instrument. Rendered as real rounded boxes
-   (not ▇/░ glyphs): filled = --text-dim, empty = a faint hairline track wash.
-   Both are tokens, so red-mode flips to pure red automatically. The Sky Cover
-   readout below reuses this same colour scheme. The whole block is inline-flex,
+   so they read as one consolidated instrument. Rendered as a proportional fill
+   bar (.wx-bar-track/.wx-bar-fill, shared with the Sky Cover readout below):
+   filled = --text-dim, empty = a faint hairline track wash. Both are tokens,
+   so red-mode flips to pure red automatically. The whole block is inline-flex,
    so it centres in the centred cell while its rows stay left-aligned against a
    rigid label. */
 .wx-eq2 {
@@ -329,8 +340,8 @@ html.red-mode .recalc-overlay {
   align-items: center;
   gap: 6px;
 }
-/* Fixed-width label box → rigid left margin before the segments begin, so C and
-   S line up and the two bars share a common starting axis. Same mono font as the
+/* Fixed-width label box → rigid left margin before the bar begins, so C and S
+   line up and the two bars share a common starting axis. Same mono font as the
    rest of the table; unbold. */
 .wx-eq2-label {
   width: 12px;
@@ -341,19 +352,24 @@ html.red-mode .recalc-overlay {
   font-weight: 400;
   font-size: 11px;
 }
-.wx-eq2-segs {
-  display: inline-flex;
-  gap: 2px;
+/* Bar track height is pinned to the cap-height of the 11px mono label beside
+   it, so the bar and its label read as one baseline-aligned unit rather than
+   a mismatched pair. */
+.wx-bar-track {
+  display: inline-block;
+  width: 34px;
+  height: 8px;
+  border-radius: 3px;
+  background: rgba(var(--hairline-rgb), 0.15);
+  overflow: hidden;
+  flex: none;
 }
-/* Small rounded segment boxes — wider than tall (the ~20% "shorter" look), with
-   the same 1px corner radius as the cloud-cover track tops. */
-.wx-eq2-seg {
-  width: 7px;
-  height: 6px;
-  border-radius: 1px;
+.wx-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--text-dim);
+  border-radius: inherit;
 }
-.wx-eq2-seg-on  { background: var(--text-dim); }
-.wx-eq2-seg-off { background: rgba(var(--hairline-rgb), 0.15); }
 
 /* Sky Cover cell — the condition icon + total % (left) and the altitude
    telemetry stack (right), sharing one column. The header is right-aligned over
@@ -403,17 +419,11 @@ html.red-mode .recalc-overlay {
   white-space: nowrap;
 }
 /* Fixed-width altitude label, right-aligned so the unit sits flush against the
-   segment blocks. Sized to the widest label (4 chars: ">20k" / ">6km"). */
+   bar. Sized to the widest label (4 chars: ">20k" / ">6km"). */
 .wx-sky-alt {
   width: 30px;
   flex: none;
   text-align: right;
   color: var(--text-dim);
   letter-spacing: 0.02em;
-}
-/* EQ — the SAME rounded box segments as the Clarity/Seeing readout
-   (.wx-eq2-seg / .wx-eq2-segs, reused verbatim). */
-.wx-sky-eq {
-  display: inline-flex;
-  align-items: center;
 }

--- a/apps/web/src/styles/11-responsive.css
+++ b/apps/web/src/styles/11-responsive.css
@@ -280,6 +280,14 @@
   .wx-table th:first-child {
     min-width: 52px;
   }
+  /* Event rows (Sunset/Astro Dark/etc.) keep the desktop-width 6px horizontal
+     padding on their time cell otherwise — at 52px that leaves too little room
+     for an 8-char double-digit-hour stamp ("10:14 PM"), wrapping "PM" onto its
+     own line. Match the plain-row 2px gutter so it stays on one line. */
+  .wx-ev-row td.wx-ev-time {
+    padding-left: 2px;
+    padding-right: 2px;
+  }
 
   /* Weather + wind icons shrink; the condition icon lives in the merged Sky
      Cover cell now. */
@@ -298,11 +306,10 @@
     gap: 3px;
   }
 
-  /* Clarity/Seeing — narrower segments, no inter-segment gaps, to stay compact. */
-  .wx-eq2-seg {
-    width: 4px;
+  /* Clarity/Seeing + Sky Cover — narrower bars, to stay compact. */
+  .wx-bar-track {
+    width: 22px;
   }
-  .wx-eq2-segs,
   .wx-eq2 {
     gap: 0;
   }
@@ -312,13 +319,9 @@
     white-space: nowrap;
   }
 
-  /* Wind — let the readout wrap; unit hugs the value. */
+  /* Wind — let the readout wrap. */
   .wx-wind-col {
     flex-wrap: wrap;
-  }
-  .wx-wind-unit {
-    width: auto;
-    padding-right: 2px;
   }
 
   /* ── Targets table ── */

--- a/apps/web/src/styles/11-responsive.css
+++ b/apps/web/src/styles/11-responsive.css
@@ -259,28 +259,30 @@
     white-space: normal;
   }
 
-  /* Global mobile table cell padding and wrapping */
+  /* Even, symmetric cell padding across every column — no per-column zeroing.
+     There's ~no horizontal slack at this width, so the gutter is kept small but
+     consistent so columns read as evenly spaced rather than crammed unevenly. */
   .wx-table th {
-    padding: 2px 1px 3px; /* 1px L/R padding */
+    padding: 2px 2px 3px;
     font-size: 9px;
     letter-spacing: 0.03em;
     white-space: normal;
     vertical-align: bottom; /* Clean bottom alignment */
   }
   .wx-table td {
-    padding: 3px 1px; /* 1px L/R padding */
+    padding: 3px 2px;
     white-space: normal;
   }
 
-  /* Time Column */
+  /* Time Column — sticky first column keeps its min-width; padding comes from
+     the shared rule above (its left edge stays flush via the base .wx-time rule). */
   .wx-table td.wx-time,
   .wx-table th:first-child {
     min-width: 52px;
-    padding-right: 0;
   }
 
-  /* Force the weather and wind icons to shrink and strip hardcoded margins.
-     The condition icon now lives inside the merged Sky Cover cell. */
+  /* Weather + wind icons shrink; the condition icon lives in the merged Sky
+     Cover cell now. */
   .wx-cond-cell svg,
   .wx-table td.wx-wind-col svg {
     width: 20px !important;
@@ -291,48 +293,29 @@
   .wx-cond-total {
     font-size: 9px;
   }
-
-  /* Sky Cover Column (icon + % + telemetry) */
-  .wx-table th.wx-cloud-col,
-  .wx-table td.wx-cloud-col {
-    padding-left: 0;
-    padding-right: 0;
-  }
   /* Tighten the gap between the icon+% and the telemetry stack on mobile. */
   .wx-sky-cell {
     gap: 3px;
   }
 
-  /* Clarity/Seeing Column */
-  .wx-table th.wx-atmos-col,
-  .wx-table td.wx-atmos-col {
-    padding-right: 0;
-  }
+  /* Clarity/Seeing — narrower segments, no inter-segment gaps, to stay compact. */
   .wx-eq2-seg {
-    width: 4px; /* Narrower segments */
+    width: 4px;
   }
   .wx-eq2-segs,
   .wx-eq2 {
-    gap: 0; /* Remove gaps between segments and rows */
+    gap: 0;
   }
 
-  /* Temp/Dew Pt Column */
-  .wx-table th.wx-temp-col,
+  /* Temp/Dew Pt — keep the value and unit glued on one line. */
   .wx-table td.wx-temp-col {
-    padding-left: 0;
-    padding-right: 0;
-    white-space: nowrap; /* Forces unit to stay glued to temp */
+    white-space: nowrap;
   }
 
-  /* Wind Column */
-  .wx-table th.wx-wind-col,
-  .wx-table td.wx-wind-col {
-    padding-left: 0;
-  }
+  /* Wind — let the readout wrap; unit hugs the value. */
   .wx-wind-col {
     flex-wrap: wrap;
   }
-  /* Remove fixed width on unit so arrow hugs the text */
   .wx-wind-unit {
     width: auto;
     padding-right: 2px;


### PR DESCRIPTION
## Summary
- Replace the discrete 4-segment blocks for Sky Cover and Clarity/Seeing with a shared proportional fill bar meter — Sky Cover now shows the raw cloud-cover % directly instead of quantizing into 5 tiers. Bar height (8px) is tuned to match the label glyph's cap-height, and colors reuse existing `--text-dim`/`--hairline-rgb` tokens so red-mode ("Night vision") flips automatically with no extra CSS.
- Move unit labels into the column headers instead of repeating them per row: Sky Cover → "Sky Cover at / Alt. (Feet)" or "(Meters)", Temp/Dew Pt → "(°F)"/"(°C)", Wind → "(MPH)"/"(M/S)" — all driven by the existing imperial/metric toggle.
- Fix Time column misalignment: the cell was right-aligned in a fixed-width column, so timestamps of different lengths ("9:00 PM" vs "12:00 AM") started at different x-positions. Switched to left-align, and normalized the accent `border-left` to a constant 2px (transparent by default, colored per row type) so event rows (Sunset/Sunrise/Moonrise/Astro Dark) no longer shift the text relative to plain rows.
- Shortened the "ASTRO DARK BEGINS/ENDS" divider rules from full-row-width lines to fixed 32px brackets flanking the centered text.
- Fixed a mobile-only bug where 8-character double-digit-hour timestamps ("10:14 PM") wrapped "PM" onto its own line on event rows — traced to the event-row time cell keeping the desktop 6px horizontal padding on mobile while plain rows shrink to 2px.
- Left-aligned the Clarity/Seeing header (previously each wrapped line centered independently, staggering "Clarity /" against "Seeing") and added left padding so it doesn't hug the Sky Cover column boundary.

## Test plan
- [x] Verified in browser preview (desktop + mobile, light/dark, red-mode) via Sedona sample report
- [x] Confirmed bar meters render correctly and track/fill colors flip under red-mode with no extra CSS
- [x] Measured bar height against label glyph cap-height (canvas metrics) — 8px vs ~8.3px actual glyph height
- [x] Confirmed all 15 time cells in a night's timeline land at identical text x-position (was previously skewed for event rows)
- [x] Simulated double-digit-hour event timestamps ("10:14 PM", "11:47 PM", "11:16 PM") on mobile to confirm no more AM/PM wrap
- [x] Confirmed Clarity/Seeing header alignment and spacing from Sky Cover column
- [ ] `python -m pytest -q` not run — this PR only touches `apps/web` (frontend), no backend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)