### PR TITLE
Add meteor shower ZHR decay model and integrated scorecard alert

### DIFF
--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -159,6 +159,11 @@ _WEATHER_GAP_SECS         = 5400  # 90 min nearest-neighbour tolerance (matches 
 _MIN_VIABLE_MIN           = 30    # effective window must be at least this long to be viable
 _MOON_WASHOUT_RADIUS_DEG  = 45.0  # washout zone radius at 100% illumination;
                                    # scales linearly → effective = 45° × (illum/100)
+_LOW_RADIANT_ALT_DEG      = 25.0  # meteor showers only: radiant altitude below this →
+                                   # "low_radiant" blocker. sin(25°) ≈ 0.42 — local rate
+                                   # collapses to <45% of the decayed-ZHR figure from
+                                   # foreshortening/extinction alone, even under an
+                                   # otherwise clear, dark, moonless sky.
 
 
 def _bt_window_best(
@@ -360,6 +365,28 @@ def _apply_condition_vectors(
                 effective_radius = _MOON_WASHOUT_RADIUS_DEG * (illumination_pct / 100.0)
                 if window.moon_sep_at_peak_deg < effective_radius:
                     blockers.append("moon_washout")
+
+            # --- Radiant Altitude / Local Rate Vector (meteor showers only) ----
+            # window.peak_alt_deg/peak_az_deg ARE the radiant's alt/az for shower
+            # targets (_sky_object builds the Star from radiant_ra/radiant_dec),
+            # so no extra geometry is needed here. local_rate_at_peak is the
+            # zenith/radiant-altitude-corrected rate a visual observer would
+            # actually see (ZHR convention divides observed rate by sin(radiant
+            # alt) to normalize to zenith; inverted, that's the multiplication
+            # below) — feeds both the scorecard banner's "local rate" figure and
+            # the low_radiant blocker. Scoped to meteor_shower so DSO/planet
+            # blocker logic is untouched.
+            if target.type == "meteor_shower":
+                zhr_eff = target.zhr_effective
+                if zhr_eff is not None and window.peak_alt_deg is not None:
+                    window.local_rate_at_peak = (
+                        round(zhr_eff * math.sin(math.radians(window.peak_alt_deg)), 1)
+                        if window.peak_alt_deg > 0 else 0.0
+                    )
+                    if window.peak_alt_deg < _LOW_RADIANT_ALT_DEG:
+                        blockers.append("low_radiant")
+                else:
+                    window.local_rate_at_peak = None
 
             window.blockers = blockers
 
@@ -677,7 +704,7 @@ def assemble_night(
             _site_sqm = ds_info.get("sqm") if ds_info else None
             _vt_future = _pool.submit(
                 _tgt.visible_targets, lat, lon, sunset, sunrise, illumination,
-                night_start=night_start, night_end=night_end, sky_sqm=_site_sqm,
+                night_start=night_start, night_end=night_end, sky_sqm=_site_sqm, tz=tz,
             )
 
         # Collect satellite passes

--- a/PyNightSkyPredictor/targets.json
+++ b/PyNightSkyPredictor/targets.json
@@ -310,7 +310,10 @@
     "peak_month": 1,
     "peak_day": 3,
     "active_window_days": 6,
-    "peak_zhr": 120
+    "peak_zhr": 120,
+    "b_rise": 0.865,
+    "b_decline": 0.827,
+    "peak_hour_utc": 3.5
   },
   {
     "name": "Lyrids",
@@ -320,7 +323,10 @@
     "peak_month": 4,
     "peak_day": 22,
     "active_window_days": 10,
-    "peak_zhr": 18
+    "peak_zhr": 18,
+    "b_rise": 1.229,
+    "b_decline": 4.620,
+    "peak_hour_utc": 1.68
   },
   {
     "name": "Eta Aquariids",
@@ -330,7 +336,10 @@
     "peak_month": 5,
     "peak_day": 5,
     "active_window_days": 18,
-    "peak_zhr": 50
+    "peak_zhr": 50,
+    "b_rise": 0.125,
+    "b_decline": 0.079,
+    "peak_hour_utc": 9.47
   },
   {
     "name": "Delta Aquariids",
@@ -340,7 +349,10 @@
     "peak_month": 7,
     "peak_day": 28,
     "active_window_days": 20,
-    "peak_zhr": 25
+    "peak_zhr": 25,
+    "b_rise": 0.109,
+    "b_decline": 0.071,
+    "peak_hour_utc": 10.0
   },
   {
     "name": "Perseids",
@@ -350,7 +362,10 @@
     "peak_month": 8,
     "peak_day": 12,
     "active_window_days": 14,
-    "peak_zhr": 100
+    "peak_zhr": 100,
+    "b_rise": 0.050,
+    "b_decline": 0.092,
+    "peak_hour_utc": 14.88
   },
   {
     "name": "Orionids",
@@ -360,7 +375,10 @@
     "peak_month": 10,
     "peak_day": 21,
     "active_window_days": 14,
-    "peak_zhr": 20
+    "peak_zhr": 20,
+    "b_rise": 0.120,
+    "b_decline": 0.119,
+    "peak_hour_utc": 6.9
   },
   {
     "name": "Northern Taurids",
@@ -370,7 +388,10 @@
     "peak_month": 11,
     "peak_day": 12,
     "active_window_days": 50,
-    "peak_zhr": 5
+    "peak_zhr": 5,
+    "b_rise": 0.026,
+    "b_decline": 0.026,
+    "peak_hour_utc": 6.98
   },
   {
     "name": "Southern Taurids",
@@ -380,7 +401,10 @@
     "peak_month": 11,
     "peak_day": 5,
     "active_window_days": 60,
-    "peak_zhr": 5
+    "peak_zhr": 5,
+    "b_rise": 0.026,
+    "b_decline": 0.026,
+    "peak_hour_utc": 0.37
   },
   {
     "name": "Leonids",
@@ -390,7 +414,10 @@
     "peak_month": 11,
     "peak_day": 17,
     "active_window_days": 10,
-    "peak_zhr": 15
+    "peak_zhr": 15,
+    "b_rise": 0.025,
+    "b_decline": 0.15,
+    "peak_hour_utc": 0.0
   },
   {
     "name": "Geminids",
@@ -400,7 +427,10 @@
     "peak_month": 12,
     "peak_day": 14,
     "active_window_days": 10,
-    "peak_zhr": 150
+    "peak_zhr": 150,
+    "b_rise": 0.150,
+    "b_decline": 0.462,
+    "peak_hour_utc": 5.73
   },
   {
     "name": "Ursids",
@@ -410,7 +440,10 @@
     "peak_month": 12,
     "peak_day": 22,
     "active_window_days": 6,
-    "peak_zhr": 10
+    "peak_zhr": 10,
+    "b_rise": 2.292,
+    "b_decline": 1.258,
+    "peak_hour_utc": 20.98
   },
   {
     "name": "Galactic Core",

--- a/PyNightSkyPredictor/targets.py
+++ b/PyNightSkyPredictor/targets.py
@@ -3,10 +3,12 @@
 
 import json
 import logging
+import math
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import numpy as np
 from skyfield.api import Loader, Star, load, wgs84
@@ -73,9 +75,11 @@ class TargetWindow:
     effective_start: "datetime | None" = None  # MCVI lower bound; UI binds displayed window here
     effective_end: "datetime | None" = None    # MCVI upper bound; condition-gated window end
     best_time: "datetime | None" = None        # recommended observation moment within effective window
-    blockers: list = field(default_factory=list)  # ["cloud","transparency","light_dome","moon_washout"]
+    blockers: list = field(default_factory=list)  # ["cloud","transparency","light_dome","moon_washout","low_radiant"]
     weather_score_at_best: "int | None" = None    # rate_conditions() score at best_time
     dome_glow_at_peak: "float | None" = None      # glow_toward() at (peak_az_deg, peak_alt_deg)
+    local_rate_at_peak: "float | None" = None     # meteor showers only: zhr_effective × sin(radiant_alt);
+                                                    # set by predictor._apply_condition_vectors; None for non-shower targets
 
 
 @dataclass
@@ -87,6 +91,8 @@ class VisibleTarget:
     viability: str = "ok"  # "ok" | "degraded" | "blocked" — set by _apply_condition_vectors
     angular_size_arcmin: "float | None" = None   # from catalog; None for planets/meteors/MW
     landscape_suitability: str = "prominent"     # "prominent" | "diffuse" | "too_small"
+    zhr_effective: "float | None" = None         # meteor showers only: day-decayed peak ZHR (IMO log-linear decay);
+                                                   # set by _compute_target; None for non-shower types
 
 
 def _landscape_suitability(
@@ -221,6 +227,123 @@ def _moon_interferes(sep_deg, moon_alt_deg, moon_dist_km, window_indices: list,
     return False
 
 
+_ZHR_DECAY_FLOOR = 2.0  # meteors/hr — below this, indistinguishable from sporadic background
+
+
+def _resolve_peak_year_offset(entry: dict, night_date) -> "tuple[int, int] | None":
+    """Find the year_offset in (0, -1, 1) whose calendar peak date is nearest
+    night_date (handles year-boundary showers: Quadrantids, Ursids). Returns
+    (year_offset, delta_days), or None if peak_month/peak_day never form a
+    valid date across all three offsets.
+
+    The single source of truth for "which year's peak is this night closest
+    to" — _days_from_peak() and _peak_datetime() both call this so they can
+    never disagree about which peak instance a given night belongs to.
+    """
+    from datetime import date as _date
+
+    peak_month = entry["peak_month"]
+    peak_day   = entry["peak_day"]
+    best = None  # (year_offset, delta)
+    for year_offset in (0, -1, 1):
+        try:
+            peak  = _date(night_date.year + year_offset, peak_month, peak_day)
+            delta = (night_date - peak).days
+            if best is None or abs(delta) < abs(best[1]):
+                best = (year_offset, delta)
+        except ValueError:
+            continue
+    return best
+
+
+def _days_from_peak(entry: dict, night_date) -> "float | None":
+    """Signed day-delta from night_date to the nearest instance of this
+    shower's peak. Extracted so decay math and note-text share one
+    peak-finding implementation.
+    """
+    resolved = _resolve_peak_year_offset(entry, night_date)
+    return resolved[1] if resolved else None
+
+
+def _peak_datetime(entry: dict, night_date) -> "datetime | None":
+    """UTC datetime of this shower's peak, for whichever year
+    _resolve_peak_year_offset() picked for night_date — guaranteed
+    consistent with _days_from_peak()'s choice of year for the same
+    night_date. Returns None if the catalog entry has no peak_hour_utc yet
+    (not all showers have been sourced with a peak time-of-day); callers
+    should render a date-only peak in that case, not a fabricated time.
+    """
+    from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+
+    if entry.get("peak_hour_utc") is None:
+        return None
+    resolved = _resolve_peak_year_offset(entry, night_date)
+    if resolved is None:
+        return None
+    year_offset, _delta = resolved
+    peak_month = entry["peak_month"]
+    peak_day   = entry["peak_day"]
+    return (
+        _dt(night_date.year + year_offset, peak_month, peak_day, tzinfo=_tz.utc)
+        + _td(hours=entry["peak_hour_utc"])
+    )
+
+
+def effective_zhr(peak_zhr: float, days_from_peak: float, b_rise: float, b_decline: float) -> float:
+    """IMO/NASA-MEO-style asymmetric log-linear decay: ZHR(t) = peak_zhr * 10^(-B*|t|).
+
+    b_rise applies before peak (t < 0), b_decline at/after peak (t >= 0) — real
+    showers commonly rise faster approaching peak than they decline afterward.
+
+    CAVEAT: the canonical IMO/meteor-science formulation uses solar longitude
+    (λ☉) as the time axis, not calendar days. This module already keys every
+    shower's peak off peak_month/peak_day (see _resolve_peak_year_offset), so
+    using calendar-day offset here is a deliberate simplification consistent
+    with the rest of the module. Solar longitude advances ~0.9856°/day on
+    average, so B values (per degree of solar longitude) carry over to
+    per-day within ~1.5% error most of the year — except near perihelion
+    (early January), where Earth moves ~3.4% faster than the mean rate,
+    relevant to Quadrantids (peak Jan 3) and marginally Ursids (peak Dec 22).
+    """
+    if peak_zhr <= 0:
+        return 0.0
+    b = b_rise if days_from_peak < 0 else b_decline
+    return peak_zhr * (10 ** (-b * abs(days_from_peak)))
+
+
+def meaningful_activity_half_window(peak_zhr: float, b_rise: float, b_decline: float,
+                                     floor: float = _ZHR_DECAY_FLOOR) -> float:
+    """Day-offset beyond which decayed ZHR drops below `floor` on either side —
+    solves peak_zhr * 10^(-B*t) = floor for t, using min(b_rise, b_decline)
+    (the shallower/slower-decaying side) so the window is generous in both
+    directions. This is a pre-filter half-window, not a display value.
+    """
+    b_min = min(b_rise, b_decline)
+    if peak_zhr <= floor or b_min <= 0:
+        return 0.0
+    return math.log10(peak_zhr / floor) / b_min
+
+
+def _gate_half_window_days(entry: dict) -> float:
+    """Cheap gate deciding whether a shower is worth computing tonight at all —
+    used by both the fast path (active_meteor_showers) and the slow/geometry
+    path (_compute_target's early exit via _meteor_shower_note).
+
+    Takes MAX(curated active_window_days/2, decay-derived half-window) — not
+    min() — because this is a performance pre-filter where a false negative
+    (wrongly dropping a still-active shower) is worse than a false positive
+    (computing geometry for a negligible one; cheap either way). Concretely:
+    Taurids are hand-curated to 50-60 day windows because their activity is
+    genuinely broad and low-ZHR; an imperfect b_rise/b_decline value should
+    never be able to silently shrink that below the curated floor.
+    """
+    b_rise    = entry.get("b_rise", 0.0)
+    b_decline = entry.get("b_decline", 0.0)
+    half_curated = entry["active_window_days"] / 2
+    half_decay   = meaningful_activity_half_window(entry.get("peak_zhr", 0), b_rise, b_decline)
+    return max(half_curated, half_decay)
+
+
 def _meteor_shower_note(entry: dict, night_date) -> str | None:
     """
     Return a proximity string (e.g. '3 days before peak') or None if the
@@ -229,21 +352,8 @@ def _meteor_shower_note(entry: dict, night_date) -> str | None:
     Handles year-boundary showers (e.g. Quadrantids: peak Jan 3, active Dec–Jan)
     by trying adjacent years and picking the closest peak.
     """
-    from datetime import date as _date
-
-    peak_month = entry["peak_month"]
-    peak_day   = entry["peak_day"]
-    half       = entry["active_window_days"] // 2
-
-    best_delta = None
-    for year_offset in (0, -1, 1):
-        try:
-            peak  = _date(night_date.year + year_offset, peak_month, peak_day)
-            delta = (night_date - peak).days
-            if best_delta is None or abs(delta) < abs(best_delta):
-                best_delta = delta
-        except ValueError:
-            continue
+    half = _gate_half_window_days(entry)
+    best_delta = _days_from_peak(entry, night_date)
 
     if best_delta is None or abs(best_delta) > half:
         return None
@@ -270,10 +380,18 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
     min_elev = entry.get("min_elevation", min_elevation)
 
     note = None
+    zhr_eff = None
     if ttype == "meteor_shower":
         note = _meteor_shower_note(entry, night_date)
         if note is None:
             return None  # outside active window
+        delta = _days_from_peak(entry, night_date)
+        if delta is not None:
+            zhr_eff = round(
+                effective_zhr(entry.get("peak_zhr", 0), delta,
+                              entry.get("b_rise", 0.0), entry.get("b_decline", 0.0)),
+                1,
+            )
 
     try:
         if ttype == "planet":
@@ -459,6 +577,7 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
         name=name, type=ttype, windows=windows, note=note,
         angular_size_arcmin=angular_size,
         landscape_suitability=land_suit,
+        zhr_effective=zhr_eff,
     )
 
 
@@ -484,7 +603,9 @@ def active_meteor_showers(target_date) -> list:
 
     Does not compute sky positions — fast date-arithmetic only.
 
-    Returns a list of dicts: [{"name": str, "note": str, "zhr": int}, ...]
+    Returns a list of dicts:
+        [{"name": str, "note": str, "zhr": int,
+          "zhr_effective": float | None, "peak_time_utc": str | None}, ...]
     Showers outside their active window are excluded.
     """
     results = []
@@ -493,10 +614,19 @@ def active_meteor_showers(target_date) -> list:
             continue
         note = _meteor_shower_note(entry, target_date)
         if note is not None:
+            delta = _days_from_peak(entry, target_date)
+            zhr_eff = (
+                round(effective_zhr(entry.get("peak_zhr", 0), delta,
+                                     entry.get("b_rise", 0.0), entry.get("b_decline", 0.0)), 1)
+                if delta is not None else None
+            )
+            peak_dt = _peak_datetime(entry, target_date)
             results.append({
                 "name": entry["name"],
                 "note": note,
                 "zhr":  entry.get("peak_zhr", 0),
+                "zhr_effective": zhr_eff,
+                "peak_time_utc": peak_dt.isoformat() if peak_dt is not None else None,
             })
     return results
 
@@ -511,6 +641,7 @@ def visible_targets(
     night_end: datetime | None   = None,
     min_elevation: float = DEFAULT_MIN_ELEVATION,
     sky_sqm: float | None = None,
+    tz: "ZoneInfo | None" = None,
 ) -> list:
     """
     Return targets visible during the night.
@@ -551,7 +682,11 @@ def visible_targets(
     moon_alt_v, _, _ = moon_astr.apparent().altaz()
     moon_alt_deg_all = moon_alt_v.degrees          # ndarray, one value per sample
     moon_dist_km_all = moon_astr.distance().km     # ndarray, Earth-Moon distance per sample
-    night_date = sunset.date()
+    # sunset is UTC-aware; its raw .date() is the UTC calendar date, which for
+    # evening sunsets west of UTC (most of the Americas/Europe) is frequently
+    # one day ahead of the observer's local calendar date — meteor shower
+    # peak-proximity text/decay math needs the LOCAL date the night belongs to.
+    night_date = sunset.astimezone(tz).date() if tz is not None else sunset.date()
 
     # Use provided SQM or fall back to the K&S natural-sky baseline (Bortle 2).
     _sky_sqm = sky_sqm if sky_sqm is not None else _ml.KS_NATURAL_SKY

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every run produces a single-night report:
 - **Night Timeline** — sunset, astronomical night begin/end, moonrise/set, sunrise
 - **Light Pollution** — SQM, Bortle class, djlorenz zone for the coordinates
 - **Moon** — phase, illumination, distance; supermoon/micromoon flags; eclipse type and magnitude when applicable
-- **Meteor Showers** — active showers with peak note and ZHR (always shown, no flag needed)
+- **Meteor Showers** — active showers with peak note and ZHR (always shown, no flag needed); the engine also models day-decayed, radiant-altitude-corrected local rates — see [docs/TARGETS.md](docs/TARGETS.md#meteor-shower-zhr-decay-model)
 - **Clear Dark Sky Hours** — effective dark time, cloud-adjusted and moon-corrected; lunar-cycle average alongside for context
 
 `--weather` adds an hourly conditions table: cloud cover, seeing, transparency, wind (speed + direction), dew point, feels-like, humidity, precipitation — each hour rated 1–10 for astrophotography.

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -9,7 +9,7 @@ import { fmtNightDate, MetaRow } from './report/common'
 import { WeatherTable } from './report/NightTimeline'
 import { SatellitePasses } from './report/Satellites'
 import { MilkyWayAbsent, MilkyWayCard } from './report/MilkyWay'
-import { isPrime, MeteorShowerCard, TargetsTable } from './report/Targets'
+import { isPrime, MeteorShowerCard, TargetsTable, MeteorAlertBanner, meteorShowerAlert } from './report/Targets'
 import { NearbyResults } from './report/Nearby'
 import { LightDomePanel } from './report/LightDomePanel'
 
@@ -330,6 +330,7 @@ export default function ReportCard({
   }).format(new Date(r.date + 'T00:00:00'))
 
   const verdict = nightVerdict(r)
+  const meteorAlert = meteorShowerAlert(r)
 
   // Collapsed-summary one-liners (hidden while a section is open — see .sum-brief)
   const planningBrief = calendarState.phase === 'done' && calendarState.data.ranked[0]?.score != null
@@ -451,7 +452,9 @@ export default function ReportCard({
         </nav>
       )}
 
-      <div className={`overall band-${scoreBand(r.score)}`}>
+      <div className={`overall-group${meteorAlert ? ` state-${meteorAlert.state}` : ''}`}>
+      {meteorAlert && <MeteorAlertBanner alert={meteorAlert} />}
+      <div className={`overall band-${scoreBand(r.score)} ${meteorAlert ? 'overall--has-alert' : ''}`}>
         <div className="overall-left">
         <div className="overall-score-block">
           <div className="overall-score-header">
@@ -493,13 +496,6 @@ export default function ReportCard({
           />
         )}
 
-        {(r.active_showers?.length ?? 0) > 0 && (
-          <MetaRow
-            k="Meteor Showers"
-            v={r.active_showers.map(s => `${s.name}  ·  ${s.note}  ·  ZHR ${s.zhr}`).join(',  ')}
-            tip={<>ZHR — zenithal hourly rate: meteors per hour for a single observer under a perfectly dark sky with the radiant overhead. Field counts run well below it; it's a comparison index, not a promise.</>}
-          />
-        )}
         <MetaRow
           k="Clear Dark Sky"
           v={darkStrCard}
@@ -526,6 +522,7 @@ export default function ReportCard({
         </div>
         </div>
         {r.light_dome && <LightDomePanel summary={r.light_dome} imperial={imperial} />}
+      </div>
       </div>
 
 

--- a/apps/web/src/report/Targets.tsx
+++ b/apps/web/src/report/Targets.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import type { NightReport, TargetWindow, VisibleTarget, WeatherPoint } from '../types'
-import { formatTime, cardinal, rateConditions, scoreBand, moonWashSeverity, moonUpAt } from '../format'
+import { formatTime, formatDayTime, cardinal, rateConditions, scoreBand, moonWashSeverity, moonUpAt } from '../format'
 import { InfoTip } from '../shared'
 import { WmoIcon } from './icons'
 import { fmtPos } from './common'
@@ -147,6 +147,13 @@ export function MeteorShowerCard({ target, zhr, report }: {
             Peak ZHR {zhr}
           </InfoTip>
         </span>
+        {w.local_rate_at_peak != null && (
+          <span className="ms-local-rate">
+            <InfoTip tip={<>Peak ZHR adjusted for tonight's decay-from-peak and radiant altitude — the rate you'd actually observe, not the idealized zenith figure.</>}>
+              ~{Math.round(w.local_rate_at_peak)}/hr locally
+            </InfoTip>
+          </span>
+        )}
       </div>
       {target.note && <div className="ms-note">{target.note}</div>}
       {w.peak_time && w.peak_alt_deg != null && (
@@ -168,6 +175,11 @@ export function MeteorShowerCard({ target, zhr, report }: {
               <span className={`tg-sky ${skyCls}`}>{sky}</span>
             </div>
           )}
+          {(w.blockers?.length ?? 0) > 0 && (
+            <div className="mw-row">
+              <BlockerBadge blockers={w.blockers} />
+            </div>
+          )}
         </>
       )}
     </div>
@@ -176,11 +188,26 @@ export function MeteorShowerCard({ target, zhr, report }: {
 
 // ── Blocker badge (Phase 2) ───────────────────────────────────────────────────
 
+// Shared priority-ordered blocker → (badge label, CTA reason) table.
+// blockerLabel() and blockerReason() both read from this one list so the
+// blocked-row badge and the meteor alert banner can't drift out of sync.
+const _BLOCKER_PRIORITY: [string, string, string][] = [
+  // [blocker key, badge label, CTA reason]
+  ['cloud', 'Clouded out', 'weather'],
+  ['transparency', 'Clouded out', 'weather'],
+  ['moon_washout', 'Moon washout', 'moonwash'],
+  ['light_dome', 'Lost in light dome', 'light pollution'],
+  ['low_radiant', 'Radiant too low', 'low radiant'],
+]
+
 export function blockerLabel(blockers: string[]): string {
-  if (blockers.includes('cloud') || blockers.includes('transparency')) return 'Clouded out'
-  if (blockers.includes('moon_washout')) return 'Moon washout'
-  if (blockers.includes('light_dome')) return 'Lost in light dome'
+  for (const [key, label] of _BLOCKER_PRIORITY) if (blockers.includes(key)) return label
   return 'Unavailable Tonight'
+}
+
+export function blockerReason(blockers: string[]): string | null {
+  for (const [key, , reason] of _BLOCKER_PRIORITY) if (blockers.includes(key)) return reason
+  return null
 }
 
 export function BlockerBadge({ blockers }: { blockers: string[] }) {
@@ -195,6 +222,102 @@ export function clipTooltip(w: TargetWindow, tz: string): string {
   if (b.includes('moon_washout')) return 'Moon washout'
   if (b.includes('light_dome'))   return 'Viewing constrained by horizon glow'
   return 'Window clipped by conditions'
+}
+
+// ── Meteor shower alert (scorecard banner) ────────────────────────────────────
+
+export interface MeteorAlert {
+  shower: VisibleTarget
+  state: 'ok' | 'degraded' | 'blocked'
+  prefix: string           // plain-color lead-in — name, "active tonight", local rate
+  warning: string | null   // red clause — leading comma through trailing period; null for 'ok'
+  suffix: string | null    // plain-color trailing sentence — the "consider another..." CTA; null for 'ok'
+  peakTimeLocal: string | null  // formatted local date+time of the shower's peak, or null if unsourced
+}
+
+const _BANNER_MIN_LOCAL_RATE = 5  // meteors/hr — below this, not worth the "unmissable" banner interruption
+
+export function meteorShowerAlert(r: NightReport): MeteorAlert | null {
+  const showers = (r.visible_targets ?? []).filter(t => t.type === 'meteor_shower')
+  if (showers.length === 0) return null
+
+  // Only showers whose estimated local rate clears the floor earn the banner —
+  // a technically-active shower decayed to 1-2/hr is indistinguishable from
+  // sporadic background and would just be noise here. It still appears in the
+  // Prominent Sky Features card regardless (no rate floor there).
+  const qualifying = showers.filter(t => {
+    const w = bestWindow(t)
+    const rate = w.local_rate_at_peak ?? t.zhr_effective ?? 0
+    return rate >= _BANNER_MIN_LOCAL_RATE
+  })
+  if (qualifying.length === 0) return null
+
+  // Multiple simultaneously-active, qualifying showers (e.g. N/S Taurids
+  // overlap in Nov): show only the highest zhr_effective to keep a
+  // single-glance framing — the rest still render individually as
+  // MeteorShowerCards in Prominent Sky Features.
+  const primary = [...qualifying].sort((a, b) => (b.zhr_effective ?? 0) - (a.zhr_effective ?? 0))[0]
+  const w = bestWindow(primary)
+  const reason = blockerReason(w.blockers ?? [])
+  const rate = w.local_rate_at_peak ?? primary.zhr_effective ?? 0
+
+  // peak_time_utc lives on active_showers (date-only fast path, no geometry
+  // needed) — looked up by name, same pattern the existing zhr lookup at
+  // ReportCard.tsx uses.
+  const peakIso = r.active_showers?.find(s => s.name === primary.name)?.peak_time_utc ?? null
+  const peakTimeLocal = peakIso ? formatDayTime(peakIso, r.tz_name) : null
+  const rateSentence = `The estimated local rate is ~${Math.round(rate)} meteors per hour`
+
+  if (primary.viability === 'ok' || !reason) {
+    return {
+      shower: primary, state: 'ok',
+      prefix: `PREDICTED SKY EVENT: The ${primary.name} meteor shower is active tonight. ${rateSentence}.`,
+      warning: null,
+      suffix: null,
+      peakTimeLocal,
+    }
+  }
+
+  if (reason === 'moonwash') {
+    return {
+      shower: primary, state: primary.viability,
+      prefix: `PREDICTED SKY EVENT: The ${primary.name} meteor shower is active tonight. ${rateSentence}`,
+      warning: `, but tonight's moonwash will severely degrade visibility globally.`,
+      suffix: ` Consider another night for better viewing.`,
+      peakTimeLocal,
+    }
+  }
+
+  // 'weather' | 'light pollution' | 'low radiant' — local issues, a different site can fix them.
+  const factor = reason === 'low radiant' ? 'low radiant altitude' : reason
+  return {
+    shower: primary, state: primary.viability,
+    prefix: `PREDICTED SKY EVENT: The ${primary.name} meteor shower is active tonight. ${rateSentence}`,
+    warning: `, but this location's ${factor} will prevent visibility.`,
+    suffix: ` Consider another location for better viewing.`,
+    peakTimeLocal,
+  }
+}
+
+export function MeteorAlertBanner({ alert }: { alert: MeteorAlert }) {
+  return (
+    <div className={`meteor-alert-banner state-${alert.state}`}>
+      <div className="mab-headline">
+        {alert.prefix}
+        {alert.warning && <span className="mab-warning">{alert.warning}</span>}
+        {alert.suffix}
+      </div>
+      <div className="mab-sub-row">
+        {alert.peakTimeLocal && (
+          <span className="mab-peak-time">
+            <InfoTip tip={<>The statistically fitted peak moment — for broad showers, rates stay elevated for hours either side, not a knife-edge instant.</>}>
+              Peaks {alert.peakTimeLocal} local
+            </InfoTip>
+          </span>
+        )}
+      </div>
+    </div>
+  )
 }
 
 /*function clipReasonShort(w: TargetWindow): string {

--- a/apps/web/src/styles/02-red-mode.css
+++ b/apps/web/src/styles/02-red-mode.css
@@ -153,6 +153,11 @@ html.red-mode .band-fair,
 html.red-mode .band-poor {
   background: rgba(255, 0, 0, 0.05);
 }
+/* Meteor alert banner tint (was green/purple/red rgba) → faint red;
+   border-color already resolves correctly via --good/--fair/--poor. */
+html.red-mode .meteor-alert-banner {
+  background: rgba(255, 0, 0, 0.05);
+}
 /* Links (incl. visited): otherwise they fall back to the browser's blue/purple. */
 html.red-mode a:link,
 html.red-mode a:visited {

--- a/apps/web/src/styles/04-report-core.css
+++ b/apps/web/src/styles/04-report-core.css
@@ -368,6 +368,70 @@ html.red-mode .ld-legend-bar { background: #6a0000; }
   color: var(--poor);
 }
 
+/* ── Meteor shower scorecard alert banner ──────────────────────── */
+/* .overall-group is the single bordered container when an alert is present —
+   it owns the ONE continuous border in the alert's state color; the banner
+   and .overall inside are borderless (overall--has-alert strips .overall's
+   own border/radius) so there's no seam, no color mismatch, and no gap from
+   .report's flex `gap` (banner+card are one flex child, not two). */
+.overall-group.state-ok,
+.overall-group.state-degraded,
+.overall-group.state-blocked {
+  border-radius: 3px;
+  overflow: hidden;
+}
+.overall-group.state-ok       { border: 1px solid var(--good); }
+.overall-group.state-degraded { border: 1px solid var(--fair); }
+.overall-group.state-blocked  { border: 1px solid var(--poor); }
+
+.meteor-alert-banner {
+  padding: 12px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.meteor-alert-banner.state-ok {
+  border-bottom: 1px solid var(--good);
+  background: rgba(90, 209, 154, 0.05);
+}
+.meteor-alert-banner.state-degraded {
+  border-bottom: 1px solid var(--fair);
+  background: rgba(167, 139, 250, 0.05);
+}
+.meteor-alert-banner.state-blocked {
+  border-bottom: 1px solid var(--poor);
+  background: rgba(248, 113, 113, 0.05);
+}
+.mab-headline {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--text-h);
+  line-height: 1.4;
+}
+/* The "why it's not visible" clause — leading comma through trailing period —
+   always reads as a hard stop, regardless of the banner's own state color
+   (amber for degraded, red for blocked). */
+.mab-warning {
+  color: var(--poor);
+}
+.mab-sub-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+.mab-peak-time {
+  color: var(--text-dim);
+}
+/* Score module loses its own border/radius entirely when wrapped — the
+   parent .overall-group owns the single continuous border instead. */
+.overall--has-alert {
+  border: none;
+  border-radius: 0;
+}
+
 .bar-row {
   display: grid;
   grid-template-columns: 120px 1fr 36px;

--- a/apps/web/src/styles/07-targets-milkyway.css
+++ b/apps/web/src/styles/07-targets-milkyway.css
@@ -75,6 +75,10 @@
   font-size: 12px;
   color: var(--text-dim);
 }
+.ms-local-rate {
+  font-size: 12px;
+  color: var(--text-dim);
+}
 .ms-note {
   font-size: 12px;
   color: var(--fair);

--- a/apps/web/src/styles/11-responsive.css
+++ b/apps/web/src/styles/11-responsive.css
@@ -49,6 +49,12 @@
   .lightdome-panel {
     grid-column: 1;
   }
+  .meteor-alert-banner {
+    padding: 10px 8px;
+  }
+  .mab-sub-row {
+    gap: 8px;
+  }
 
   .report-head .place {
     font-size: 14px;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -47,9 +47,10 @@ export interface TargetWindow {
   effective_start: string | null    // MCVI lower bound (condition-gated window start)
   effective_end: string | null      // MCVI upper bound (condition-gated window end)
   best_time: string | null          // recommended observation moment within [effective_start, effective_end]
-  blockers: string[]                // e.g. ["cloud", "transparency", "light_dome", "moon_washout"]
+  blockers: string[]                // e.g. ["cloud", "transparency", "light_dome", "moon_washout", "low_radiant"]
   weather_score_at_best: number | null  // rate_conditions() score (1–10) at best_time
   dome_glow_at_peak: number | null  // glow_toward() value at peak az/alt; null outside CONUS
+  local_rate_at_peak: number | null // meteor showers only: zhr_effective × sin(radiant_alt)
 }
 
 export interface VisibleTarget {
@@ -60,6 +61,7 @@ export interface VisibleTarget {
   viability: 'ok' | 'degraded' | 'blocked'  // Phase 1: aggregate condition state
   angular_size_arcmin: number | null         // Phase 3: catalog angular extent
   landscape_suitability: 'prominent' | 'diffuse' | 'too_small'  // Phase 3: wide-field filter
+  zhr_effective: number | null              // meteor showers only: day-decayed peak ZHR
 }
 
 export interface WeatherPoint {
@@ -97,6 +99,8 @@ export interface ActiveShower {
   name: string
   note: string
   zhr: number
+  zhr_effective: number | null
+  peak_time_utc: string | null
 }
 
 export interface SatPass {

--- a/docs/ACKNOWLEDGMENTS.md
+++ b/docs/ACKNOWLEDGMENTS.md
@@ -38,6 +38,10 @@ This project was developed with substantial assistance from:
 - **Celestrak**: Two-Line Element sets (TLEs) for ISS, Hubble Space Telescope, Tiangong, and Starlink satellites, used for satellite pass prediction
   - https://celestrak.org/
   - Data is freely available for non-commercial use; see https://celestrak.org/data/update-policy.php
+- **Meteor shower ZHR decay model**: double-exponential (asymmetric log-linear) activity-profile decay rate constants (`b_rise`/`b_decline` in `targets.json`), used to model how a shower's ZHR falls off before/after its peak date. See [docs/TARGETS.md § Meteor Shower ZHR Decay Model](TARGETS.md#meteor-shower-zhr-decay-model) for the formula and per-shower caveats.
+  - Moorhead, A., Blaauw, R., Moser, D., Campbell-Brown, M., Brown, P., Cooke, W. (2019). *Meteor Shower Forecasting in Near-Earth Space.* Journal of Spacecraft and Rockets / [arXiv:1904.06370](https://arxiv.org/abs/1904.06370), Table 5 (NASA Meteoroid Environment Office)
+  - Egal, A. et al. (2020). *Activity of the η-Aquariid and Orionid meteor showers.* Astronomy & Astrophysics, 640, A58
+  - Peak-time-of-day (`peak_hour_utc`) sourced from [EarthSky's meteor shower guide](https://earthsky.org/astronomy-essentials/earthskys-meteor-shower-guide/) (2026/2027 apparition), drawn from AMS/IMO predictions
 
 ## Python Dependencies
 

--- a/docs/PYNIGHTSKY.md
+++ b/docs/PYNIGHTSKY.md
@@ -210,6 +210,8 @@ Meteor Showers:     Perseids · Peak night · ZHR 100
 
 With `--targets`, showers also appear in the targets table with the full astro window.
 
+The `ZHR` shown here is always the catalog's raw peak value, regardless of how far the queried night falls from the actual peak date. The engine also computes a day-decayed, radiant-altitude-corrected "local rate" estimate (surfaced today in the web app's scorecard alert, not yet in this CLI output) — see [docs/TARGETS.md § Meteor Shower ZHR Decay Model](TARGETS.md#meteor-shower-zhr-decay-model) for the formula and sourcing.
+
 ---
 
 ## Milky Way

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -77,8 +77,11 @@ Uses a fixed radiant point (the position in the sky the meteors appear to origin
 | `radiant_dec` | Yes | Declination of the radiant in the format `"±DD° MM' SS\""` |
 | `peak_month` | Yes | Month of peak activity (1–12) |
 | `peak_day` | Yes | Day of peak activity (1–31) |
-| `active_window_days` | Yes | Total number of days the shower is active (centred on peak) |
+| `active_window_days` | Yes | Total number of days the shower is active (centred on peak) — also acts as a floor for the decay-derived activity gate, see [ZHR Decay Model](#meteor-shower-zhr-decay-model) below |
 | `peak_zhr` | Yes | Zenithal hourly rate at peak (meteors/hour under ideal conditions) |
+| `b_rise` | No | Decay-rate constant for days *before* peak. Omitted → treated as 0, meaning ZHR is flat at `peak_zhr` for the whole active window (pre-decay-model behavior) |
+| `b_decline` | No | Decay-rate constant for days *at/after* peak |
+| `peak_hour_utc` | No | Approximate UTC hour-of-day (0–24, fractional) of peak activity for a specific reference apparition. Omitted → only the peak date is shown, no clock time |
 
 **Example:**
 ```json
@@ -90,9 +93,57 @@ Uses a fixed radiant point (the position in the sky the meteors appear to origin
   "peak_month": 12,
   "peak_day": 14,
   "active_window_days": 10,
-  "peak_zhr": 150
+  "peak_zhr": 150,
+  "b_rise": 0.150,
+  "b_decline": 0.462,
+  "peak_hour_utc": 5.73
 }
 ```
+
+---
+
+## Meteor Shower ZHR Decay Model
+
+A shower's ZHR isn't constant across its active window — it peaks on `peak_day` and falls off on either side. `PyNightSkyPredictor/targets.py` (`effective_zhr()`) models this with the same double-exponential (asymmetric log-linear) profile used throughout meteor science literature:
+
+```
+ZHR(t) = ZHR_peak · 10^(−B·|t|)
+```
+
+`t` is the signed day-offset from peak; `b_rise` applies for `t < 0` (approaching peak), `b_decline` for `t ≥ 0` (receding from peak) — real showers commonly rise faster than they decline.
+
+**Days vs. solar longitude:** the canonical form of this equation is parameterized by solar longitude (λ☉), not calendar days, because Earth's orbital speed varies through the year (fastest near perihelion in early January). This catalog already keys every shower off a fixed `peak_month`/`peak_day` rather than a computed λ☉ crossing, so day-offset is used as a deliberate stand-in for λ☉. Solar longitude advances ≈0.9856°/day on average, so `B` values (published per degree of λ☉) carry over to per-day within ~1.5% error for most of the year — up to ~3.4% near perihelion, relevant to Quadrantids (peak Jan 3) and marginally Ursids (peak Dec 22).
+
+### Zenith / radiant-altitude correction
+
+The visual ZHR convention assumes the radiant sits at the zenith; the rate an observer actually sees at any other altitude is reduced roughly by `sin(radiant_altitude)`. `predictor.py`'s condition-vector pipeline inverts this to estimate real observed rate:
+
+```
+local_rate = ZHR(t) · sin(radiant_altitude)
+```
+
+Below 25° radiant altitude (`_LOW_RADIANT_ALT_DEG` in `predictor.py`; `sin(25°) ≈ 0.42`), local rate collapses to under 45% of the decayed-ZHR figure from foreshortening/atmospheric extinction alone — even under an otherwise clear, dark, moonless sky. This triggers a `low_radiant` blocker, distinct from the existing weather / light-pollution / moon-washout blockers.
+
+### Activity-window gate
+
+Before running the full geometry pass for a shower on a given night, `_gate_half_window_days()` cheaply pre-filters using `MAX(active_window_days / 2, decay-derived half-window)`, where the decay-derived half-window is the day-offset at which `ZHR(t)` drops below a 2/hr floor (`_ZHR_DECAY_FLOOR`), using whichever of `b_rise`/`b_decline` is shallower. Taking the *larger* of the two — not the smaller — means the decay math can only widen a shower's computed active window relative to the curated `active_window_days`, never silently narrow it below what's already been hand-tuned.
+
+### Sourced decay constants
+
+`b_rise` / `b_decline` for the 11 catalog showers are sourced from:
+
+- Moorhead, A., Blaauw, R., Moser, D., Campbell-Brown, M., Brown, P., Cooke, W. (2019). *Meteor Shower Forecasting in Near-Earth Space.* Journal of Spacecraft and Rockets / [arXiv:1904.06370](https://arxiv.org/abs/1904.06370), Table 5 — the NASA Meteoroid Environment Office's operational double-exponential fit to CMOR radar flux measurements.
+- Egal, A. et al. (2020). *Activity of the η-Aquariid and Orionid meteor showers.* Astronomy & Astrophysics, 640, A58 — used to corroborate the Eta Aquariid and Orionid values against a visual/video-based fit; Moorhead's radar-fit point estimates for both showers fall inside Egal's reported range.
+
+`peak_hour_utc` values are sourced from [EarthSky](https://earthsky.org/astronomy-essentials/earthskys-meteor-shower-guide/)'s 2026/2027 meteor shower guide (itself drawn from AMS/IMO predictions) and the American Meteor Society calendar.
+
+**Caveats:**
+- Moorhead et al.'s table is fit to *radar* flux, not visual ZHR — radar profiles are typically sharper than visual ones (radar detects far more faint meteors, amplifying the apparent gradient). This pairs a radar-fit *shape* (`b_rise`/`b_decline`) with each catalog entry's existing *visual* `peak_zhr` *amplitude* — a reasonable approximation (shape is more transferable than amplitude across detection methods) but a known provenance mismatch.
+- Perseids and Leonids use only the "base component" of Moorhead's two-component fit — the paper also gives a sharper "peak spike" component with a degenerate `Bm = 0` that isn't usable in this single-formula model. This means the model slightly *under*-predicts ZHR right at peak night for these two showers specifically (a safe direction to be wrong in).
+- Northern/Southern Taurids fit `Bm ≈ 0` (a genuinely flat, broad plateau, consistent with their well-known low-level long tail) — substituted with the `b_rise` value since a literal 0 is degenerate for the decay formula (implies the shower never decays). A modeling choice, not a literature value.
+- `peak_hour_utc` is pinned to the 2026/2027 apparition specifically and will drift a few hours in other years (leap-year solar-longitude cycle) — the same order of imprecision this catalog already accepts for the fixed `peak_month`/`peak_day` fields, just one level deeper.
+- These values were extracted from the primary sources via automated tooling, not manually cross-checked cell-by-cell — a spot-check against arXiv:1904.06370 Table 5 is a reasonable follow-up before leaning on exact figures for anything beyond "roughly how fast does this decay."
+- The CLI (`pynightsky.py`) does not yet surface `zhr_effective` / `local_rate_at_peak` — only the web app's report does. This is a known parity gap.
 
 ---
 
@@ -106,9 +157,10 @@ Uses a fixed radiant point (the position in the sky the meteors appear to origin
    - [NASA/IPAC Extragalactic Database](https://ned.ipac.caltech.edu/) — galaxies
    - Stellarium or SkySafari (desktop/mobile)
 5. Only add `min_elevation` if this target specifically needs a different threshold than the global default
+6. For a new `meteor_shower` entry, source `b_rise`/`b_decline` from a published double-exponential activity-profile fit (e.g. the IMO Working List of Visual Meteor Showers, or a paper like Moorhead et al. 2019 — see [ZHR Decay Model](#meteor-shower-zhr-decay-model)) rather than guessing a value; if no such fit is available, omit them and the shower falls back to the pre-decay-model flat-ZHR behavior
 
 ## Notes
 
 - Deep sky objects are visible year-round in principle — the engine determines whether they're above the horizon *during the current night* at your location
 - Southern hemisphere objects (negative declination) may never rise for high northern latitudes, and vice versa — the engine handles this automatically
-- Meteor shower entries outside their `active_window_days` are silently skipped
+- Meteor shower entries outside their (decay-widened) `active_window_days` are silently skipped — see [ZHR Decay Model](#meteor-shower-zhr-decay-model)

--- a/tests/test_condition_vectors.py
+++ b/tests/test_condition_vectors.py
@@ -53,6 +53,13 @@ def _make_target(window):
     return VisibleTarget(name="M42", type="nebula", windows=[window], note=None)
 
 
+def _make_shower_target(window, zhr_effective=100.0):
+    return VisibleTarget(
+        name="Perseids", type="meteor_shower", windows=[window], note="Peak night",
+        zhr_effective=zhr_effective,
+    )
+
+
 def _wx(offset_h, cloud=0, transparency="Excellent", humidity=50):
     return WeatherPoint(
         time=_BASE + timedelta(hours=offset_h),
@@ -370,3 +377,55 @@ def test_photo_cutoff_clamps_effective_end():
     t = _make_target(w)
     _run(t, weather=wx_pts)
     assert w.effective_end <= photo_cutoff
+
+
+# ---------------------------------------------------------------------------
+# Radiant Altitude / Local Rate Vector (meteor showers only)
+# ---------------------------------------------------------------------------
+
+def test_low_radiant_blocker_fires_below_threshold():
+    """Radiant at 10° (< 25° threshold) → low_radiant blocker; local rate ≈ zhr_effective * sin(10°)."""
+    import math
+    w = _make_window(peak_alt=10.0)
+    t = _make_shower_target(w, zhr_effective=100.0)
+    _run(t)
+    assert "low_radiant" in w.blockers
+    assert w.local_rate_at_peak == pytest.approx(100.0 * math.sin(math.radians(10.0)), abs=0.05)
+
+
+def test_low_radiant_blocker_absent_above_threshold():
+    """Radiant at 45° (>= 25° threshold) → no low_radiant blocker."""
+    w = _make_window(peak_alt=45.0)
+    t = _make_shower_target(w, zhr_effective=100.0)
+    _run(t)
+    assert "low_radiant" not in w.blockers
+    assert w.local_rate_at_peak is not None
+
+
+def test_local_rate_none_for_non_shower_targets():
+    """DSO target: local_rate_at_peak stays None — vector is type-scoped."""
+    w = _make_window(peak_alt=10.0)
+    t = _make_target(w)  # type="nebula"
+    _run(t)
+    assert w.local_rate_at_peak is None
+    assert "low_radiant" not in w.blockers
+
+
+def test_local_rate_zero_at_or_below_horizon():
+    """Radiant at/below horizon → local_rate_at_peak is 0.0, not None or negative."""
+    w = _make_window(peak_alt=0.0)
+    t = _make_shower_target(w, zhr_effective=100.0)
+    _run(t)
+    assert w.local_rate_at_peak == 0.0
+    assert "low_radiant" in w.blockers
+
+
+def test_low_radiant_combines_with_other_blockers():
+    """Low radiant + full cloud cover → both blockers present, viability blocked."""
+    w = _make_window(peak_alt=10.0)
+    wx_pts = [_wx(i, cloud=95) for i in range(5)]
+    t = _make_shower_target(w, zhr_effective=100.0)
+    _run(t, weather=wx_pts)
+    assert "low_radiant" in w.blockers
+    assert "cloud" in w.blockers
+    assert t.viability == "blocked"

--- a/tests/test_meteor_shower_decay.py
+++ b/tests/test_meteor_shower_decay.py
@@ -1,0 +1,169 @@
+"""Tests for the meteor shower ZHR decay model and peak-time helpers in targets.py."""
+
+from datetime import date
+
+import pytest
+
+from PyNightSkyPredictor.targets import (
+    _days_from_peak,
+    _gate_half_window_days,
+    _meteor_shower_note,
+    _peak_datetime,
+    _resolve_peak_year_offset,
+    active_meteor_showers,
+    effective_zhr,
+    load_targets,
+    meaningful_activity_half_window,
+)
+
+
+def _shower(name, **overrides):
+    base = {
+        "name": name,
+        "type": "meteor_shower",
+        "radiant_ra": "00h 00m 00s",
+        "radiant_dec": "+00° 00' 00\"",
+        "peak_month": 8,
+        "peak_day": 12,
+        "active_window_days": 14,
+        "peak_zhr": 100,
+        "b_rise": 0.1,
+        "b_decline": 0.1,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# effective_zhr
+# ---------------------------------------------------------------------------
+
+def test_effective_zhr_exact_at_peak():
+    assert effective_zhr(100, 0, 0.1, 0.2) == 100
+
+
+def test_effective_zhr_monotonic_decay_both_sides():
+    vals_before = [effective_zhr(100, -t, 0.1, 0.2) for t in (0, 1, 2, 5)]
+    vals_after  = [effective_zhr(100, t, 0.1, 0.2) for t in (0, 1, 2, 5)]
+    assert vals_before == sorted(vals_before, reverse=True)
+    assert vals_after == sorted(vals_after, reverse=True)
+
+
+def test_effective_zhr_asymmetric_sides_differ():
+    # Same |t|, different b_rise/b_decline → different decayed values.
+    before = effective_zhr(100, -3, 0.1, 0.5)
+    after  = effective_zhr(100, 3, 0.1, 0.5)
+    assert before != after
+    assert before > after  # shallower b_rise decays slower
+
+
+def test_effective_zhr_zero_peak_zhr():
+    assert effective_zhr(0, 3, 0.1, 0.1) == 0.0
+    assert effective_zhr(-5, 3, 0.1, 0.1) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_peak_year_offset / _days_from_peak / _meteor_shower_note
+# year-wraparound regression (Quadrantids: peak Jan 3; Ursids: peak Dec 22)
+# ---------------------------------------------------------------------------
+
+def test_year_wraparound_quadrantids():
+    entries = {e["name"]: e for e in load_targets() if e.get("type") == "meteor_shower"}
+    qua = entries["Quadrantids"]
+
+    # Late Dec (next year's peak is closer than this year's already-passed one)
+    assert _days_from_peak(qua, date(2025, 12, 30)) == -4
+    assert _meteor_shower_note(qua, date(2026, 1, 1)) == "2 days before peak"
+    assert _meteor_shower_note(qua, date(2026, 1, 3)) == "Peak night"
+    assert _meteor_shower_note(qua, date(2026, 1, 6)) == "3 days after peak"
+
+
+def test_year_wraparound_ursids():
+    entries = {e["name"]: e for e in load_targets() if e.get("type") == "meteor_shower"}
+    urs = entries["Ursids"]
+    assert _meteor_shower_note(urs, date(2026, 12, 22)) == "Peak night"
+    assert _days_from_peak(urs, date(2026, 12, 20)) == -2
+
+
+def test_peak_datetime_year_matches_days_from_peak():
+    """_peak_datetime must resolve the SAME year as _days_from_peak for any
+    given night_date — a Dec 30 night must not get 'days before peak' text
+    for next January while peak_time_utc points at last January's instance.
+    """
+    entries = {e["name"]: e for e in load_targets() if e.get("type") == "meteor_shower"}
+    qua = entries["Quadrantids"]
+    for d in (date(2025, 12, 30), date(2026, 1, 1), date(2026, 1, 3), date(2026, 1, 6)):
+        resolved = _resolve_peak_year_offset(qua, d)
+        delta = _days_from_peak(qua, d)
+        pt = _peak_datetime(qua, d)
+        assert resolved[1] == delta
+        assert pt.year == d.year + resolved[0]
+        assert pt.month == 1 and pt.day == 3
+
+
+def test_peak_datetime_none_without_peak_hour_utc():
+    entry = _shower("Synthetic")
+    entry.pop("peak_hour_utc", None)
+    assert _peak_datetime(entry, date(2026, 8, 12)) is None
+
+
+# ---------------------------------------------------------------------------
+# meaningful_activity_half_window / _gate_half_window_days
+# ---------------------------------------------------------------------------
+
+def test_meaningful_activity_half_window_hand_computed():
+    # peak_zhr=120, b=0.3, floor=2 -> log10(60)/0.3 ~= 5.93
+    import math
+    expected = math.log10(60) / 0.3
+    assert meaningful_activity_half_window(120, 0.3, 0.3, floor=2.0) == pytest.approx(expected)
+
+
+def test_meaningful_activity_half_window_uses_shallower_side():
+    # Shallower (smaller) b dominates -> wider window.
+    wide = meaningful_activity_half_window(100, 0.05, 0.5, floor=2.0)
+    narrow = meaningful_activity_half_window(100, 0.5, 0.5, floor=2.0)
+    assert wide > narrow
+
+
+def test_gate_half_window_uses_max_not_min():
+    # Curated window wider than decay-derived -> gate uses curated.
+    entry_wide_curated = _shower("A", active_window_days=100, peak_zhr=100, b_rise=0.5, b_decline=0.5)
+    assert _gate_half_window_days(entry_wide_curated) == pytest.approx(50.0)
+
+    # Decay-derived wider than curated -> gate uses decay-derived.
+    entry_wide_decay = _shower("B", active_window_days=2, peak_zhr=100, b_rise=0.01, b_decline=0.01)
+    gate = _gate_half_window_days(entry_wide_decay)
+    assert gate > 1.0  # wider than curated half (1.0)
+
+
+def test_gate_never_narrows_curated_catalog_entries():
+    for entry in load_targets():
+        if entry.get("type") != "meteor_shower":
+            continue
+        assert _gate_half_window_days(entry) >= entry["active_window_days"] / 2
+
+
+# ---------------------------------------------------------------------------
+# active_meteor_showers (fast path)
+# ---------------------------------------------------------------------------
+
+def test_active_meteor_showers_zhr_effective_never_exceeds_peak():
+    showers = active_meteor_showers(date(2026, 8, 12))
+    assert any(s["name"] == "Perseids" for s in showers)
+    for s in showers:
+        if s["zhr_effective"] is not None:
+            assert s["zhr_effective"] <= s["zhr"]
+
+
+def test_active_meteor_showers_peak_time_utc_is_iso():
+    showers = active_meteor_showers(date(2026, 8, 12))
+    per = next(s for s in showers if s["name"] == "Perseids")
+    assert per["peak_time_utc"] is not None
+    assert per["peak_time_utc"].startswith("2026-08-12T")
+
+
+def test_active_meteor_showers_at_exact_peak_matches_peak_zhr():
+    showers = active_meteor_showers(date(2026, 8, 12))
+    per = next(s for s in showers if s["name"] == "Perseids")
+    assert per["note"] == "Peak night"
+    assert per["zhr_effective"] == per["zhr"]


### PR DESCRIPTION
## Summary
- Replaces the static peak-ZHR badge with an IMO/NASA-MEO-style double-exponential decay model (`effective_zhr()`) sourced from Moorhead et al. 2019 (arXiv:1904.06370) and cross-checked against Egal et al. 2020, plus a radiant-altitude/zenith correction that estimates the rate a real observer would actually see.
- Adds a new `low_radiant` condition-vector blocker and a scorecard alert banner that names the active shower, states its estimated local rate and peak time, diagnoses the blocker (weather/light pollution/low radiant → "Choose another location"; moonwash → "Choose another day"), and duplicates the data into the Prominent Sky Features card.
- Fixes a pre-existing bug (found during verification, not introduced by this change) where meteor-shower peak-proximity logic used `sunset.date()` — the UTC calendar date — instead of the observer's local date, silently off by a day for most US/EU evening sunsets.
- Full formula documentation and citations added to `docs/TARGETS.md` and `docs/ACKNOWLEDGMENTS.md`.

## Test plan
- [x] `python -m pytest -q` — 676 passed, 7 skipped (20 new tests: decay formula edge cases, year-wraparound regression, `low_radiant` blocker vector)
- [x] `tsc -b` — clean
- [x] `eslint .` — clean
- [x] Live-verified all banner states (ok / weather-blocked / light-pollution-blocked / moonwash / low-radiant) in the browser, in both light and red-mode, desktop and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)