### PR TITLE
Fix ferry/dirt-road detection: switch GeoRoutes matrix to point-to-point calls

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -621,11 +621,13 @@ def _location():
 
 
 def _georoutes():
-    """Return the process-wide Amazon Location GeoRoutes client (drive-time matrix).
+    """Return the process-wide Amazon Location GeoRoutes client (point-to-point drive times).
 
-    GeoRoutes is the modern, resource-less routing API (no route calculator to create);
-    it supports DepartNow traffic-aware ETAs. Separate from the legacy `location` client
-    (still used for place-index reverse-geocoding)."""
+    GeoRoutes is the modern, resource-less routing API (no route calculator to create).
+    `_aws_drive_times` fans out one CalculateRoutes call per leg concurrently
+    (bounded by `_GEOCODE_MAX_WORKERS`), so the pool is sized like `_location()`'s to
+    avoid connection queueing. Separate from the legacy `location` client (still used
+    for place-index reverse-geocoding)."""
     global _georoutes_client
     if _georoutes_client is None:
         with _georoutes_client_lock:
@@ -636,7 +638,10 @@ def _georoutes():
                 _georoutes_client = boto3.client(
                     "geo-routes",
                     region_name=region,
-                    config=Config(retries={"max_attempts": 5, "mode": "adaptive"}),
+                    config=Config(
+                        max_pool_connections=max(_GEOCODE_MAX_WORKERS + 2, 10),
+                        retries={"max_attempts": 5, "mode": "adaptive"},
+                    ),
                 )
     return _georoutes_client
 
@@ -653,22 +658,70 @@ def _drive_cache_key(olat: float, olon: float, dlat: float, dlon: float) -> str:
     return f"route_drive|{olat:.3f}|{olon:.3f}|{dlat:.3f}|{dlon:.3f}"
 
 
+def _aws_route_one(client, origin_lat: float, origin_lon: float,
+                    dest_lat: float, dest_lon: float) -> tuple:
+    """Single point-to-point GeoRoutes CalculateRoutes call → (minutes, miles, warnings).
+
+    Deliberately NOT CalculateRouteMatrix. Two independent problems with that endpoint,
+    both confirmed with live calls (authenticated AWS CLI session) against the exact Juneau, AK
+    coordinates that surfaced this bug:
+    1. RouteMatrixEntry is just {Distance, Duration, Error} — no Notices, no Legs — so a
+       ferry/dirt-road violation can't be read off it structurally.
+    2. Bigger in practice: passing `Avoid` with TravelMode=Car imposes an undocumented
+       60 km cap between origin and EACH destination — exceeding it raises a
+       ValidationException for the WHOLE batched request (not just that one leg). At this
+       app's 60-120mi search radii that's routine, so PR #107's Avoid={Ferries,DirtRoads}
+       addition silently broke drive-time computation for every candidate in most
+       searches, not just ferry detection (caught by the blanket except/log.debug in
+       _aws_drive_times). CalculateRoutes has no such cap.
+
+    Detection itself: a ferry crossing is a structural Legs[].Type == "Ferry"; there IS
+    also a real "ViolatedAvoidFerry" notice, but nested under
+    Legs[].FerryLegDetails.Notices[].Code (a different shape than the one below) —
+    checking the leg Type directly is simpler and doesn't depend on notice ordering.
+    Dirt-road usage is Legs[].VehicleLegDetails.Notices[].Code == "ViolatedAvoidDirtRoad".
+
+    Returns (None, None, []) for a route that's absent, ferry-only, or on any API error —
+    the caller decides whether an exception here should be cached (it re-raises those).
+    """
+    resp = client.calculate_routes(
+        Origin=[origin_lon, origin_lat],
+        Destination=[dest_lon, dest_lat],
+        TravelMode="Car",
+        Avoid={"Ferries": True, "DirtRoads": True},
+    )
+    routes = resp.get("Routes") or []
+    if not routes:
+        return None, None, []
+    legs = routes[0].get("Legs", [])
+    # A ferry-only "road" isn't actually driveable — treat like no route at all, even
+    # though GeoRoutes still reports a plausible-looking Duration/Distance for it.
+    if any(leg.get("Type") == "Ferry" for leg in legs):
+        return None, None, []
+    warnings = []
+    for leg in legs:
+        codes = [n.get("Code") for n in (leg.get("VehicleLegDetails") or {}).get("Notices", [])]
+        if "ViolatedAvoidDirtRoad" in codes:
+            warnings = ["Dirt roads"]
+            break
+    summary = routes[0].get("Summary") or {}
+    secs, meters = summary.get("Duration"), summary.get("Distance")   # seconds, metres
+    mins  = round(secs / 60) if secs is not None else None
+    miles = round(meters / 1609.34) if meters is not None else None
+    return mins, miles, warnings
+
+
 def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> None:
-    """Annotate each cluster dict with drive_minutes (int | None) via AWS Location route matrix.
+    """Annotate each cluster dict with drive_minutes (int | None) via AWS Location GeoRoutes.
 
     AWS-backend only. Mutates in-place. Silently sets None on any API failure so the
     caller always has the field, just without a value.
 
     Per-leg cached (origin→destination, rounded): repeat searches within 24 h skip
-    the route-matrix call; only the cache-missing legs are sent to AWS.
-
-    Uses Amazon Location GeoRoutes CalculateRouteMatrix (the modern, resource-less API)
-    with historical traffic (no DepartNow) for cache-consistent ETAs. Requests best-effort
-    avoidance of ferries (ferry-only "roads" produce a plausible-looking ETA for a route
-    with no actual drivable path — e.g. Juneau→Hoonah, AK) and dirt roads (rough on
-    optical gear / 2WD vehicles). GeoRoutes still routes through them if unavoidable,
-    flagging the leg via `Notices` instead of failing outright, so we inspect notice
-    codes rather than trust Duration/Distance alone.
+    the routing call entirely; only cache-missing legs are sent to AWS, in parallel
+    (bounded fan-out — see _aws_route_one for why this is point-to-point CalculateRoutes
+    rather than the batched CalculateRouteMatrix). Historical traffic (no DepartNow) keeps
+    cached ETAs consistent regardless of when they were computed.
 
     Annotates drive_minutes (int | None), drive_miles (road distance, int | None), and
     warnings (list[str]): non-fatal avoidance violations (currently just dirt roads) the
@@ -681,9 +734,9 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
     """
     if not clusters:
         return
-    # 1. Serve cached legs from a single batched route-matrix call's worth of history;
-    #    collect the misses. The cached value is {"m":min,"mi":road_miles,"w":warnings} or
-    #    the _DRIVE_NO_ROUTE sentinel ("computed, no route" ≠ miss). Legacy int = minutes only.
+    # 1. Serve cached legs from prior searches; collect the misses. The cached value is
+    #    {"m":min,"mi":road_miles,"w":warnings} or the _DRIVE_NO_ROUTE sentinel ("computed,
+    #    no route" ≠ miss). Legacy int = minutes only.
     misses = []
     for c in clusters:
         if not c.get("is_poi"):
@@ -706,42 +759,31 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
             misses.append(c)
     if not misses:
         return
-    # 2. One GeoRoutes matrix call for just the uncached legs; cache each result. On
-    #    failure leave the fields None and DON'T cache, so a transient error isn't sticky.
+    # 2. Parallel GeoRoutes point-to-point calls, one per uncached leg; cache each result.
+    #    On a per-leg API error, leave that leg's fields None and DON'T cache it, so a
+    #    transient failure isn't sticky — other legs in the same batch are unaffected.
+    #    `misses` is already small (candidates capped at _MAX_RESULTS=10, plus
+    #    best_available), so fan-out stays bounded regardless of search radius.
     try:
         client = _georoutes()
-        resp = client.calculate_route_matrix(
-            Origins=[{"Position": [origin_lon, origin_lat]}],
-            Destinations=[{"Position": [c["lon"], c["lat"]]} for c in misses],
-            RoutingBoundary={"Unbounded": True},
-            TravelMode="Car",
-            Avoid={"Ferries": True, "DirtRoads": True},
-        )
-        row = resp.get("RouteMatrix", [[]])[0]
-        for i, c in enumerate(misses):
-            entry = row[i] if i < len(row) else {}
-            notice_codes = [n.get("Code") for n in entry.get("Notices", []) if "Code" in n]
-
-            # Ferry-only "roads" aren't actually driveable — treat like no route at all,
-            # regardless of whether GeoRoutes also reported a Duration for the leg.
-            if entry.get("Error") or "ViolatedAvoidFerry" in notice_codes:
-                c["drive_minutes"], c["drive_miles"], c["warnings"] = None, None, []
-                cache.set(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]),
-                          _DRIVE_NO_ROUTE, ttl_seconds=_DRIVE_CACHE_TTL)
+    except Exception as e:
+        log.debug("GeoRoutes client init failed: %s", e)
+        return
+    workers = min(_GEOCODE_MAX_WORKERS, len(misses))
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(_aws_route_one, client, origin_lat, origin_lon,
+                              c["lat"], c["lon"]): c for c in misses}
+        for fut in futures:
+            c = futures[fut]
+            try:
+                mins, miles, warnings = fut.result()
+            except Exception as e:
+                log.debug("GeoRoutes calculate_routes failed: %s", e)
                 continue
-
-            secs   = entry.get("Duration")   # GeoRoutes: seconds
-            meters = entry.get("Distance")   # GeoRoutes: metres
-            mins  = round(secs / 60) if secs is not None else None
-            miles = round(meters / 1609.34) if meters is not None else None
-            warnings = ["Dirt roads"] if "ViolatedAvoidDirtRoad" in notice_codes else []
-
             c["drive_minutes"], c["drive_miles"], c["warnings"] = mins, miles, warnings
             cache.set(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]),
                       {"m": mins, "mi": miles, "w": warnings} if mins is not None else _DRIVE_NO_ROUTE,
                       ttl_seconds=_DRIVE_CACHE_TTL)
-    except Exception as e:
-        log.debug("GeoRoutes route matrix failed: %s", e)
 
 
 def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ The repository includes an optional cloud-native deployment that exposes the eng
 **Stack:**
 - **Compute** — FastAPI on AWS Lambda (container image) fronted by CloudFront with WAFv2 rate limiting
 - **Storage** — DynamoDB for cache and geocode store; S3 for the VIIRS/Falchi rasters as Cloud-Optimized GeoTIFFs
-- **Routing & geocoding** — Amazon Location **GeoRoutes** (`CalculateRouteMatrix`, traffic-aware via `DepartNow`) computes drive time + road distance to each reachable POI in `find_nearby`; AWS Location place index handles reverse-geocoding. Per-leg results are cached briefly (live-traffic ETAs)
+- **Routing & geocoding** — Amazon Location **GeoRoutes** (`CalculateRoutes`, historical traffic for cache-consistent ETAs) computes drive time + road distance to each reachable POI in `find_nearby`, and flags ferry-only/unpaved-road legs; AWS Location place index handles reverse-geocoding. Per-leg results are cached for 24h
 - **Frontend** — React/TypeScript SPA (Vite) served from S3 via CloudFront. The nearby-results view orders sites by drive time, shows road distance, and links Google Maps driving directions (origin → site) for each
 - **Resilience** — scheduled Lambda warmer for satellite TLEs; SQS + worker Lambda for async calendar/trip jobs (the worker also runs `find_nearby` and ships the PAD-US + OSM POI indexes)
 - **Observability** — structured JSON logs, X-Ray tracing, CloudWatch metric alarms

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -224,11 +224,13 @@ class LambdaApiStack(Stack):
         fn.add_to_role_policy(geo_policy)
         fn.add_environment("PYNIGHTSKY_PLACE_INDEX", place_index.index_name)
 
-        # Drive times use Amazon Location GeoRoutes (CalculateRouteMatrix) — the modern,
-        # resource-less routing API (no route calculator to create), with DepartNow
-        # traffic-aware ETAs. The action takes no resource ARN, so it's scoped to "*".
+        # Drive times use Amazon Location GeoRoutes CalculateRoutes (point-to-point) — the
+        # resource-less routing API (no route calculator to create). NOT the batched
+        # CalculateRouteMatrix: that endpoint's response has no Notices/Legs, so it can't
+        # detect a ferry-bridged or unpaved-road route (see darksky._aws_route_one). The
+        # action takes no resource ARN, so it's scoped to "*".
         route_policy = iam.PolicyStatement(
-            actions=["geo-routes:CalculateRouteMatrix"],
+            actions=["geo-routes:CalculateRoutes"],
             resources=["*"],
         )
         fn.add_to_role_policy(route_policy)

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -286,3 +286,52 @@ the existing `/warmup` rule); the SQS worker was **not** kept warm and dominates
   legs hit `calculate_route_matrix`; failures aren't cached. The call was already a single
   batched matrix request (server-parallel), so the win is from skipping it on repeat areas,
   not from parallelising. Projected warm-warm 3.16 s → ~1.2 s.
+
+## 2026-07-12 — switched CalculateRouteMatrix → CalculateRoutes (ferry/dirt-road detection)
+
+**Why:** shipped a "warn on ferry-bridged / unpaved routes" feature (#107) built on a
+wrong assumption, and initially misdiagnosed why it didn't work. Two real, confirmed
+problems with `CalculateRouteMatrix`, verified with live authenticated AWS CLI calls
+against the exact Juneau, AK coordinates from the bug report (not just docs):
+
+1. `RouteMatrixEntry` is only `{Distance, Duration, Error}` — no `Notices`, no `Legs` — so
+   a ferry/dirt-road violation can't be read off it structurally. (First diagnosis: this
+   alone was treated as the whole story, which was incomplete.)
+2. **The actual primary cause of the prod symptom:** passing `Avoid` with `TravelMode=Car`
+   imposes an undocumented **60 km cap** between origin and each destination — exceeding
+   it raises `ValidationException` for the *entire batched request*, not just that leg.
+   Reproduced live: the same 3 Juneau-area destinations (78–145 km out) succeed fine
+   *without* `Avoid` (plain `Duration: 13653s` ≈ 3h48m, the exact deceptive-ETA number
+   from the original report) and fail outright *with* `Avoid={Ferries,DirtRoads}` — the
+   same config PR #107 shipped. At this app's 60/120mi search radii that's routine, so
+   the whole matrix call — and therefore every candidate's drive time in that search, not
+   just ferry detection — silently failed via `_aws_drive_times`'s blanket
+   `except Exception: log.debug(...)`. Combined with the frontend's `routingActive` gate
+   (needs ≥1 successful leg to show a warning), every place fell back to a plain,
+   unlabeled Maps link — exactly what was observed in prod.
+
+Also corrected a factual error from the first pass: `ViolatedAvoidFerry` **does** exist as
+a notice code — just under `Legs[].FerryLegDetails.Notices[]`, a shape that wasn't
+checked before concluding "no such code exists anywhere." The structural
+`Legs[].Type == "Ferry"` check (used below) catches it regardless and doesn't depend on
+notice-shape details, so it's kept as the primary signal.
+
+**Change:** `_aws_drive_times` now calls `CalculateRoutes` once per missing leg, in
+parallel (`ThreadPoolExecutor`, bounded by `_GEOCODE_MAX_WORKERS`, same pattern as the
+parallel geocode prefetch), instead of one batched `CalculateRouteMatrix` call.
+`CalculateRoutes` has no 60 km cap (confirmed: the same 77.8km Juneau leg with the same
+`Avoid` succeeds and correctly returns the `Ferry`-typed leg). The 24h per-leg cache is
+unchanged, so repeat-area searches still pay nothing for this phase.
+
+**Cost caveats (surfaced, not yet fully closed):**
+- *Monetary:* per AWS's routes-pricing docs, `CalculateRouteMatrix` already bills
+  per origin-destination pair (`Number of Routes = Origins × Destinations`), and
+  `CalculateRoutes` bills per request = 1 route. Both are "Core" bucket for `Car`/no-tolls,
+  so N matrix pairs and N point-to-point requests are likely billed at parity — but the
+  exact per-unit $ figures are behind AWS's JS-rendered pricing calculator and weren't
+  confirmed numerically here.
+- *Latency:* this phase was previously "one server-parallel batched call" (~2 s in-region
+  uncached, per the 2026-06-16 log above). It's now N client-parallel calls bounded to
+  ≤11/search (`_MAX_RESULTS=10` + `best_available`). Not yet re-profiled in-region after
+  this change — do that before trusting the phase-timing numbers above for first-visit
+  searches; repeat-area searches are unaffected (cache-served either way).

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -296,12 +296,14 @@ class TestSettlementDispatch:
         assert result == "Denver, CO"
 
 
-# ── Drive-time route matrix + per-leg caching (_aws_drive_times) ──────────────
+# ── Drive-time routing + per-leg caching (_aws_drive_times) ───────────────────
 
 class TestAwsDriveTimes:
-    """The route-matrix call is the dominant warm find_nearby phase (~2 s) and was
-    previously uncached. These cover the per-leg cache: hits skip the API, misses hit
-    it once for just the missing legs, and failures stay un-cached."""
+    """Point-to-point CalculateRoutes (NOT the batched CalculateRouteMatrix — that
+    endpoint's response has no Notices/Legs, so it can't detect a ferry-bridged or
+    unpaved route; see _aws_route_one) is the dominant warm find_nearby phase and was
+    previously uncached. These cover the per-leg cache: hits skip the API, misses call
+    it once per missing leg (parallelized, bounded fan-out), and failures stay un-cached."""
 
     @pytest.fixture
     def _mem_cache(self, monkeypatch):
@@ -312,32 +314,42 @@ class TestAwsDriveTimes:
         return store
 
     @staticmethod
-    def _matrix(*minutes):
-        """A GeoRoutes CalculateRouteMatrix response: one row of Duration (None = no route)."""
-        return {"RouteMatrix": [[
-            ({"Duration": m * 60, "Distance": m * 1000} if m is not None
-             else {"Error": "NoRoute"}) for m in minutes
-        ]]}
+    def _route_resp(minutes, meters, dirt_road=False):
+        """A GeoRoutes CalculateRoutes response for a single (successful) vehicle route."""
+        notices = [{"Code": "ViolatedAvoidDirtRoad"}] if dirt_road else []
+        return {"Routes": [{
+            "Legs": [{"Type": "Vehicle", "VehicleLegDetails": {"Notices": notices}}],
+            "Summary": {"Duration": minutes * 60, "Distance": meters},
+        }]}
 
-    def test_miss_calls_matrix_once_and_caches(self, monkeypatch, _mem_cache):
+    @staticmethod
+    def _by_destination(mapping):
+        """side_effect dispatcher: routes calls to the fixture keyed by [lon, lat]."""
+        def _dispatch(**kwargs):
+            return mapping[tuple(kwargs["Destination"])]
+        return _dispatch
+
+    def test_miss_calls_routes_per_leg_and_caches(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds
         client = MagicMock()
-        client.calculate_route_matrix.return_value = self._matrix(56, 88)
+        client.calculate_routes.side_effect = self._by_destination({
+            (-111.46, 35.41): self._route_resp(56, 56000),
+            (-111.07, 35.23): self._route_resp(88, 88000),
+        })
         monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True},
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert [c["drive_minutes"] for c in clusters] == [56, 88]
-        # road distance (GeoRoutes Distance) is captured too: _matrix sets m*1000 metres
         assert [c["drive_miles"] for c in clusters] == [round(56000 / 1609.34),
                                                         round(88000 / 1609.34)]
-        client.calculate_route_matrix.assert_called_once()
+        assert client.calculate_routes.call_count == 2
         # both legs now cached as {minutes, road-miles, warnings}
         assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == \
             {"m": 56, "mi": round(56000 / 1609.34), "w": []}
-        # best-effort avoidance is requested on every matrix call
-        _, kwargs = client.calculate_route_matrix.call_args
-        assert kwargs["Avoid"] == {"Ferries": True, "DirtRoads": True}
+        # best-effort avoidance is requested on every call
+        for call in client.calculate_routes.call_args_list:
+            assert call.kwargs["Avoid"] == {"Ferries": True, "DirtRoads": True}
 
     def test_full_cache_hit_skips_api(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds
@@ -349,43 +361,60 @@ class TestAwsDriveTimes:
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert [c["drive_minutes"] for c in clusters] == [56, None]  # sentinel → None
-        client.calculate_route_matrix.assert_not_called()
+        client.calculate_routes.assert_not_called()
 
     def test_partial_miss_queries_only_uncached(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds
         _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] = 56
         client = MagicMock()
-        client.calculate_route_matrix.return_value = self._matrix(88)  # only the miss
+        client.calculate_routes.return_value = self._route_resp(88, 88000)  # only the miss
         monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True},
                     {"lat": 35.23, "lon": -111.07, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert [c["drive_minutes"] for c in clusters] == [56, 88]
-        # only the single uncached destination was sent
-        _, kwargs = client.calculate_route_matrix.call_args
-        assert kwargs["Destinations"] == [{"Position": [-111.07, 35.23]}]
+        # only the single uncached destination was requested
+        client.calculate_routes.assert_called_once()
+        _, kwargs = client.calculate_routes.call_args
+        assert kwargs["Destination"] == [-111.07, 35.23]
 
     def test_api_failure_leaves_none_and_uncached(self, monkeypatch, _mem_cache):
         import PyNightSkyPredictor.darksky as ds
         client = MagicMock()
-        client.calculate_route_matrix.side_effect = RuntimeError("throttled")
+        client.calculate_routes.side_effect = RuntimeError("throttled")
         monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert clusters[0]["drive_minutes"] is None
         assert _mem_cache == {}  # transient failure must not poison the cache
 
-    def test_ferry_only_route_treated_as_unroutable(self, monkeypatch, _mem_cache):
-        """A best-effort Avoid=Ferries route that still has to cross a Ro-Ro ferry (e.g.
-        Juneau→Hoonah) comes back with a Duration AND a ViolatedAvoidFerry notice — that's
-        not a real drivable route, so it must collapse to the same "no route" state as an
-        outright routing failure, not silently report the deceptive ETA."""
+    def test_no_route_at_all_is_cached_as_no_route(self, monkeypatch, _mem_cache):
+        """An empty Routes list (genuinely no path) collapses to the same sentinel as a
+        ferry-only route — both are "not driveable", just for different reasons."""
         import PyNightSkyPredictor.darksky as ds
         client = MagicMock()
-        client.calculate_route_matrix.return_value = {"RouteMatrix": [[
-            {"Duration": 228 * 60, "Distance": 90 * 1000,
-             "Notices": [{"Code": "ViolatedAvoidFerry"}]},
-        ]]}
+        client.calculate_routes.return_value = {"Routes": []}
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
+        clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert clusters[0]["drive_minutes"] is None
+        assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == ds._DRIVE_NO_ROUTE
+
+    def test_ferry_leg_treated_as_unroutable(self, monkeypatch, _mem_cache):
+        """A best-effort Avoid=Ferries route that still has to cross a Ro-Ro ferry (e.g.
+        Juneau→Hoonah) comes back with a real Duration and a structural Legs[].Type ==
+        "Ferry" entry — confirmed live against AWS this leg also carries a real
+        "ViolatedAvoidFerry" notice, but nested under Legs[].FerryLegDetails.Notices[],
+        not the VehicleLegDetails shape checked elsewhere, so leg Type is the simpler
+        signal to key off. Either way it's not an actual drivable route, so it must
+        collapse to the same "no route" state as an outright routing failure, not
+        silently report the deceptive ETA."""
+        import PyNightSkyPredictor.darksky as ds
+        client = MagicMock()
+        client.calculate_routes.return_value = {"Routes": [{
+            "Legs": [{"Type": "Vehicle"}, {"Type": "Ferry"}, {"Type": "Vehicle"}],
+            "Summary": {"Duration": 228 * 60, "Distance": 90 * 1000},
+        }]}
         monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 58.1, "lon": -135.3, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
@@ -395,14 +424,12 @@ class TestAwsDriveTimes:
         assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 58.1, -135.3)] == ds._DRIVE_NO_ROUTE
 
     def test_dirt_road_violation_surfaces_as_warning(self, monkeypatch, _mem_cache):
-        """A non-fatal avoidance violation (unpaved road) still yields a real ETA, but the
-        caller gets a warning string to show the user rather than a silently-dropped flag."""
+        """A non-fatal avoidance violation (unpaved road), reported via
+        VehicleLegDetails.Notices on the leg, still yields a real ETA, but the caller
+        gets a warning string to show the user rather than a silently-dropped flag."""
         import PyNightSkyPredictor.darksky as ds
         client = MagicMock()
-        client.calculate_route_matrix.return_value = {"RouteMatrix": [[
-            {"Duration": 45 * 60, "Distance": 20 * 1000,
-             "Notices": [{"Code": "ViolatedAvoidDirtRoad"}]},
-        ]]}
+        client.calculate_routes.return_value = self._route_resp(45, 20000, dirt_road=True)
         monkeypatch.setattr(ds, "_georoutes", lambda: client)
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
@@ -421,4 +448,4 @@ class TestAwsDriveTimes:
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert clusters[0]["warnings"] == ["Dirt roads"]
-        client.calculate_route_matrix.assert_not_called()
+        client.calculate_routes.assert_not_called()

--- a/tests/test_poi_index.py
+++ b/tests/test_poi_index.py
@@ -168,19 +168,18 @@ def test_aws_drive_times_skips_non_poi():
     with patch.object(ds, "cache") as mock_cache, \
          patch.object(ds, "_georoutes") as mock_gr:
         mock_cache.get.return_value = None
-        mock_gr.return_value.calculate_route_matrix.return_value = {
-            "RouteMatrix": [[{"Duration": 1800, "Distance": 40000}]]
+        mock_gr.return_value.calculate_routes.return_value = {
+            "Routes": [{"Legs": [{"Type": "Vehicle"}], "Summary": {"Duration": 1800, "Distance": 40000}}]
         }
         ds._aws_drive_times(40.0, -121.0, [poi, raw])
 
     assert raw["drive_minutes"] is None
     assert poi["drive_minutes"] == 30
-    kwargs = mock_gr.return_value.calculate_route_matrix.call_args.kwargs
+    kwargs = mock_gr.return_value.calculate_routes.call_args.kwargs
     # Exactly one destination (the POI) was sent via GeoRoutes, no DepartNow flag.
-    assert kwargs["Destinations"] == [{"Position": [-120.1, 38.5]}]
-    assert kwargs["Origins"] == [{"Position": [-121.0, 40.0]}]
+    assert kwargs["Destination"] == [-120.1, 38.5]
+    assert kwargs["Origin"] == [-121.0, 40.0]
     assert "DepartNow" not in kwargs
-    assert kwargs["RoutingBoundary"] == {"Unbounded": True}
 
 
 def test_dark_threshold_relaxes_for_dark_origins():


### PR DESCRIPTION
## Summary

PR #107 shipped ferry/dirt-road detection that didn't work in production. This fix switches from the batched CalculateRouteMatrix API to point-to-point CalculateRoutes calls, which avoids an undocumented 60km distance cap.

## Changes

- Switch from one batched CalculateRouteMatrix call to CalculateRoutes once per missing leg, in parallel via ThreadPoolExecutor
- Ferry detection: structural `Legs[].Type == "Ferry"` collapses leg to `_DRIVE_NO_ROUTE` sentinel
- Dirt-road detection: `VehicleLegDetails.Notices[].Code == "ViolatedAvoidDirtRoad"` surfaces as warnings
- Update IAM policy in lambda_api_stack.py to grant CalculateRoutes permission
- Parallel execution bounded by existing _GEOCODE_MAX_WORKERS pattern

## Test plan

- [x] Local test suite: 736 passed, 9 skipped
- [x] Verified botocore geo-routes service model shapes for both APIs
- [x] Verified live against AWS with test coordinates