### PR TITLE
Detect and warn on GeoRoutes destinations that aren't actually reachable by road

### DIFF
--- a/PyNightSkyPredictor/darksky.py
+++ b/PyNightSkyPredictor/darksky.py
@@ -543,6 +543,11 @@ _DRIVE_NO_ROUTE  = -1            # sentinel: route matrix returned no duration f
 # Drive times use historical traffic (no DepartNow): cached results must be
 # time-consistent regardless of when they were computed.
 _DRIVE_CACHE_TTL = 86_400        # 24 hours
+# GeoRoutes silently snaps an unreachable destination (e.g. an island lighthouse with no
+# road) to the nearest road and reports a normal-looking route to THAT point instead —
+# no Ferry leg, no notice, no error. A gap this large between the requested destination
+# and the route's actual arrival means the last stretch isn't really drivable.
+_TAIL_GAP_MILES  = 1.0 / 1.60934   # 1 km
 
 # PAD-US H3 spatial index — module-level lazy-load cache
 _PADUS_H3_FILENAME = "darkhours_padus_h3.npz"
@@ -660,7 +665,8 @@ def _drive_cache_key(olat: float, olon: float, dlat: float, dlon: float) -> str:
 
 def _aws_route_one(client, origin_lat: float, origin_lon: float,
                     dest_lat: float, dest_lon: float) -> tuple:
-    """Single point-to-point GeoRoutes CalculateRoutes call → (minutes, miles, warnings).
+    """Single point-to-point GeoRoutes CalculateRoutes call →
+    (minutes, miles, warnings, tail_miles).
 
     Deliberately NOT CalculateRouteMatrix. Two independent problems with that endpoint,
     both confirmed with live calls (authenticated AWS CLI session) against the exact Juneau, AK
@@ -675,14 +681,24 @@ def _aws_route_one(client, origin_lat: float, origin_lon: float,
        searches, not just ferry detection (caught by the blanket except/log.debug in
        _aws_drive_times). CalculateRoutes has no such cap.
 
-    Detection itself: a ferry crossing is a structural Legs[].Type == "Ferry"; there IS
-    also a real "ViolatedAvoidFerry" notice, but nested under
-    Legs[].FerryLegDetails.Notices[].Code (a different shape than the one below) —
-    checking the leg Type directly is simpler and doesn't depend on notice ordering.
-    Dirt-road usage is Legs[].VehicleLegDetails.Notices[].Code == "ViolatedAvoidDirtRoad".
+    Detection: a ferry crossing is a structural Legs[].Type == "Ferry"; there IS also a
+    real "ViolatedAvoidFerry" notice, but nested under Legs[].FerryLegDetails.Notices[].Code
+    (a different shape than the one below) — checking the leg Type directly is simpler and
+    doesn't depend on notice ordering. Dirt-road usage is
+    Legs[].VehicleLegDetails.Notices[].Code == "ViolatedAvoidDirtRoad".
 
-    Returns (None, None, []) for a route that's absent, ferry-only, or on any API error —
-    the caller decides whether an exception here should be cached (it re-raises those).
+    A third failure mode (confirmed live, Sand Island Lighthouse WI — an island reachable
+    only by boat): GeoRoutes can't route to a destination with no nearby road, so instead
+    of erroring it silently snaps the arrival to the nearest reachable road and reports a
+    normal-looking Duration/Distance for THAT point — no Ferry leg, no notice at all.
+    Detected by comparing the final leg's actual arrival position against the requested
+    destination; a gap over _TAIL_GAP_MILES means the last stretch wasn't really driven,
+    surfaced as tail_miles rather than collapsing the whole route to "no route" — the
+    drivable portion up to that point is still real and worth showing.
+
+    Returns (None, None, [], None) for a route that's absent, ferry-only, or on any API
+    error — the caller decides whether an exception here should be cached (it re-raises
+    those).
     """
     resp = client.calculate_routes(
         Origin=[origin_lon, origin_lat],
@@ -692,23 +708,33 @@ def _aws_route_one(client, origin_lat: float, origin_lon: float,
     )
     routes = resp.get("Routes") or []
     if not routes:
-        return None, None, []
+        return None, None, [], None
     legs = routes[0].get("Legs", [])
     # A ferry-only "road" isn't actually driveable — treat like no route at all, even
     # though GeoRoutes still reports a plausible-looking Duration/Distance for it.
     if any(leg.get("Type") == "Ferry" for leg in legs):
-        return None, None, []
+        return None, None, [], None
     warnings = []
     for leg in legs:
         codes = [n.get("Code") for n in (leg.get("VehicleLegDetails") or {}).get("Notices", [])]
         if "ViolatedAvoidDirtRoad" in codes:
             warnings = ["Dirt roads"]
             break
+
+    tail_miles = None
+    if legs:
+        arrival = (legs[-1].get("VehicleLegDetails") or {}).get("Arrival") or {}
+        pos = (arrival.get("Place") or {}).get("Position")   # [lon, lat]
+        if pos:
+            gap_miles = _haversine_miles(dest_lat, dest_lon, pos[1], pos[0])
+            if gap_miles > _TAIL_GAP_MILES:
+                tail_miles = round(gap_miles, 1)
+
     summary = routes[0].get("Summary") or {}
     secs, meters = summary.get("Duration"), summary.get("Distance")   # seconds, metres
     mins  = round(secs / 60) if secs is not None else None
     miles = round(meters / 1609.34) if meters is not None else None
-    return mins, miles, warnings
+    return mins, miles, warnings, tail_miles
 
 
 def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> None:
@@ -723,9 +749,12 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
     rather than the batched CalculateRouteMatrix). Historical traffic (no DepartNow) keeps
     cached ETAs consistent regardless of when they were computed.
 
-    Annotates drive_minutes (int | None), drive_miles (road distance, int | None), and
-    warnings (list[str]): non-fatal avoidance violations (currently just dirt roads) the
-    frontend can surface as a caveat. A ferry-only route is treated the same as "no route"
+    Annotates drive_minutes (int | None), drive_miles (road distance, int | None),
+    warnings (list[str]): non-fatal avoidance violations (currently just dirt roads), and
+    tail_miles (float | None): set when the route's actual arrival point is more than
+    _TAIL_GAP_MILES from the requested destination (e.g. an island with no road) — the
+    drive_minutes/drive_miles up to that point are still real, but the last tail_miles
+    isn't drivable. A ferry-only route is treated the same as "no route"
     (drive_minutes=drive_miles=None) since it isn't actually driveable.
 
     Routes ONLY is_poi candidates: raw backcountry fallbacks have no established road
@@ -735,27 +764,30 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
     if not clusters:
         return
     # 1. Serve cached legs from prior searches; collect the misses. The cached value is
-    #    {"m":min,"mi":road_miles,"w":warnings} or the _DRIVE_NO_ROUTE sentinel ("computed,
-    #    no route" ≠ miss). Legacy int = minutes only.
+    #    {"m":min,"mi":road_miles,"w":warnings,"t":tail_miles} or the _DRIVE_NO_ROUTE
+    #    sentinel ("computed, no route" ≠ miss). Legacy int = minutes only.
     misses = []
     for c in clusters:
         if not c.get("is_poi"):
             c["drive_minutes"] = None      # never route a non-routable fallback pixel
             c["drive_miles"] = None
             c["warnings"] = []
+            c["tail_miles"] = None
             continue
         cached = cache.get(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]))
         if cached is not None:
             if cached == _DRIVE_NO_ROUTE:
-                c["drive_minutes"], c["drive_miles"], c["warnings"] = None, None, []
+                c["drive_minutes"], c["drive_miles"], c["warnings"], c["tail_miles"] = None, None, [], None
             elif isinstance(cached, dict):
                 c["drive_minutes"] = cached.get("m")
                 c["drive_miles"] = cached.get("mi")
                 c["warnings"] = cached.get("w", [])
+                c["tail_miles"] = cached.get("t")
             else:                          # legacy int cache entry: minutes only
-                c["drive_minutes"], c["drive_miles"], c["warnings"] = cached, None, []
+                c["drive_minutes"], c["drive_miles"], c["warnings"], c["tail_miles"] = cached, None, [], None
         else:
-            c["drive_minutes"], c["drive_miles"], c["warnings"] = None, None, []  # until filled below
+            # until filled below
+            c["drive_minutes"], c["drive_miles"], c["warnings"], c["tail_miles"] = None, None, [], None
             misses.append(c)
     if not misses:
         return
@@ -776,13 +808,15 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
         for fut in futures:
             c = futures[fut]
             try:
-                mins, miles, warnings = fut.result()
+                mins, miles, warnings, tail_miles = fut.result()
             except Exception as e:
                 log.debug("GeoRoutes calculate_routes failed: %s", e)
                 continue
-            c["drive_minutes"], c["drive_miles"], c["warnings"] = mins, miles, warnings
+            c["drive_minutes"], c["drive_miles"] = mins, miles
+            c["warnings"], c["tail_miles"] = warnings, tail_miles
             cache.set(_drive_cache_key(origin_lat, origin_lon, c["lat"], c["lon"]),
-                      {"m": mins, "mi": miles, "w": warnings} if mins is not None else _DRIVE_NO_ROUTE,
+                      {"m": mins, "mi": miles, "w": warnings, "t": tail_miles}
+                      if mins is not None else _DRIVE_NO_ROUTE,
                       ttl_seconds=_DRIVE_CACHE_TTL)
 
 
@@ -2479,6 +2513,7 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
                 c["drive_minutes"] = None
                 c["drive_miles"] = None
                 c["warnings"] = []
+                c["tail_miles"] = None
 
     _funnel["results_final"] = len(dark_clusters)
     _funnel["best_available"] = best_available is not None

--- a/apps/web/src/report/Nearby.tsx
+++ b/apps/web/src/report/Nearby.tsx
@@ -71,6 +71,9 @@ export function NearbyResults(
           {p.warnings?.map((warn, idx) => (
             <span key={idx} className="poi-warning">{warn}</span>
           ))}
+          {p.tail_miles != null && (
+            <span className="poi-warning">Last {fmtMi(p.tail_miles)} not drivable</span>
+          )}
           {routingActive && p.is_poi && p.drive_minutes == null ? (
             <span className="poi-unroutable" title="No direct road access — routing avoided a ferry-only crossing">No road access</span>
           ) : (

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -311,6 +311,11 @@ export interface NearbyPlace {
   // Non-fatal routing avoidance violations (e.g. "Dirt roads") the API's best-effort
   // Avoid preferences couldn't route around. Empty/absent when the leg was clean.
   warnings?: string[]
+  // Set when the route's actual arrival point is >1km from this place (e.g. an island
+  // reachable only by boat) — the API silently snapped to the nearest road instead of
+  // erroring. drive_minutes/drive_miles cover the real drivable portion; tail_miles is
+  // the remaining distance that isn't drivable.
+  tail_miles?: number | null
 }
 
 export interface NearbyResult {

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -314,11 +314,16 @@ class TestAwsDriveTimes:
         return store
 
     @staticmethod
-    def _route_resp(minutes, meters, dirt_road=False):
-        """A GeoRoutes CalculateRoutes response for a single (successful) vehicle route."""
+    def _route_resp(minutes, meters, dirt_road=False, arrival_lat=None, arrival_lon=None):
+        """A GeoRoutes CalculateRoutes response for a single (successful) vehicle route.
+        arrival_lat/lon simulate GeoRoutes snapping the destination to the nearest road
+        (VehicleLegDetails.Arrival.Place.Position); omitted means "no gap to check"."""
         notices = [{"Code": "ViolatedAvoidDirtRoad"}] if dirt_road else []
+        vehicle_details = {"Notices": notices}
+        if arrival_lat is not None:
+            vehicle_details["Arrival"] = {"Place": {"Position": [arrival_lon, arrival_lat]}}
         return {"Routes": [{
-            "Legs": [{"Type": "Vehicle", "VehicleLegDetails": {"Notices": notices}}],
+            "Legs": [{"Type": "Vehicle", "VehicleLegDetails": vehicle_details}],
             "Summary": {"Duration": minutes * 60, "Distance": meters},
         }]}
 
@@ -344,9 +349,9 @@ class TestAwsDriveTimes:
         assert [c["drive_miles"] for c in clusters] == [round(56000 / 1609.34),
                                                         round(88000 / 1609.34)]
         assert client.calculate_routes.call_count == 2
-        # both legs now cached as {minutes, road-miles, warnings}
+        # both legs now cached as {minutes, road-miles, warnings, tail_miles}
         assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == \
-            {"m": 56, "mi": round(56000 / 1609.34), "w": []}
+            {"m": 56, "mi": round(56000 / 1609.34), "w": [], "t": None}
         # best-effort avoidance is requested on every call
         for call in client.calculate_routes.call_args_list:
             assert call.kwargs["Avoid"] == {"Ferries": True, "DirtRoads": True}
@@ -421,6 +426,7 @@ class TestAwsDriveTimes:
         assert clusters[0]["drive_minutes"] is None
         assert clusters[0]["drive_miles"] is None
         assert clusters[0]["warnings"] == []
+        assert clusters[0]["tail_miles"] is None
         assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 58.1, -135.3)] == ds._DRIVE_NO_ROUTE
 
     def test_dirt_road_violation_surfaces_as_warning(self, monkeypatch, _mem_cache):
@@ -436,10 +442,45 @@ class TestAwsDriveTimes:
         assert clusters[0]["drive_minutes"] == 45
         assert clusters[0]["warnings"] == ["Dirt roads"]
         assert _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] == \
-            {"m": 45, "mi": round(20000 / 1609.34), "w": ["Dirt roads"]}
+            {"m": 45, "mi": round(20000 / 1609.34), "w": ["Dirt roads"], "t": None}
+
+    def test_unreachable_destination_surfaces_tail_gap(self, monkeypatch, _mem_cache):
+        """GeoRoutes can't route to a destination with no nearby road (e.g. an island
+        lighthouse reachable only by boat — confirmed live against Sand Island Lighthouse,
+        WI), so it silently snaps the arrival to the nearest road and reports a normal
+        Duration/Distance for THAT point instead. The drivable portion is still real
+        (drive_minutes/drive_miles stay populated), but the gap between the requested
+        destination and the actual arrival point (>1km) must surface as tail_miles rather
+        than being silently dropped."""
+        import PyNightSkyPredictor.darksky as ds
+        client = MagicMock()
+        # destination is the island; arrival snaps ~0.02 deg (~1.38 mi) south on the mainland
+        client.calculate_routes.return_value = self._route_resp(
+            180, 259000, arrival_lat=35.98, arrival_lon=-111.6)
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
+        clusters = [{"lat": 36.0, "lon": -111.6, "is_poi": True}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert clusters[0]["drive_minutes"] == 180   # the drivable portion is still real
+        assert clusters[0]["tail_miles"] == pytest.approx(1.38, abs=0.05)
+        cached = _mem_cache[ds._drive_cache_key(35.2, -111.6, 36.0, -111.6)]
+        assert cached["t"] == pytest.approx(1.38, abs=0.05)
+
+    def test_normal_road_snap_does_not_trigger_tail_gap(self, monkeypatch, _mem_cache):
+        """A routine few-meters snap to the nearest driveway/road (every real destination
+        gets one) must NOT be mistaken for an unreachable-destination gap."""
+        import PyNightSkyPredictor.darksky as ds
+        client = MagicMock()
+        # ~0.0005 deg (~55m) south — well under the 1km threshold
+        client.calculate_routes.return_value = self._route_resp(
+            45, 20000, arrival_lat=35.9995, arrival_lon=-111.46)
+        monkeypatch.setattr(ds, "_georoutes", lambda: client)
+        clusters = [{"lat": 36.0, "lon": -111.46, "is_poi": True}]
+        ds._aws_drive_times(35.2, -111.6, clusters)
+        assert clusters[0]["tail_miles"] is None
 
     def test_cached_warnings_round_trip(self, monkeypatch, _mem_cache):
-        """A dict cache entry with a 'w' warnings list is unpacked back onto the cluster."""
+        """A dict cache entry with a 'w' warnings list and no 't' key (older cache
+        schema) is unpacked back onto the cluster without error."""
         import PyNightSkyPredictor.darksky as ds
         _mem_cache[ds._drive_cache_key(35.2, -111.6, 35.41, -111.46)] = \
             {"m": 45, "mi": 12, "w": ["Dirt roads"]}
@@ -448,4 +489,5 @@ class TestAwsDriveTimes:
         clusters = [{"lat": 35.41, "lon": -111.46, "is_poi": True}]
         ds._aws_drive_times(35.2, -111.6, clusters)
         assert clusters[0]["warnings"] == ["Dirt roads"]
+        assert clusters[0]["tail_miles"] is None
         client.calculate_routes.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #109 (ferry/dirt-road detection). Found live while checking the shipped fix on darkhours.app: a third failure mode where GeoRoutes reports a normal-looking "reachable" route to a destination that's actually only accessible by boat, with no ferry leg and no error to flag it.

**Confirmed against Sand Island Lighthouse, WI** (real place from a live report — an island in the Apostle Islands, Lake Superior, reachable only by boat): a live `CalculateRoutes` call with `Avoid={Ferries,DirtRoads}` returned a single `Vehicle` leg, `ViolatedAvoidDirtRoad` notice, and a normal ~3-hour `Duration`/`Distance` — no `Ferry` leg, no error, nothing flagging that the route never actually reaches the island. Comparing the leg's actual arrival position (`VehicleLegDetails.Arrival.Place.Position`) against the requested destination showed a **6.82 km (4.24 mi) gap** — GeoRoutes had silently snapped the destination to the nearest mainland road instead of erroring.

## Changes

- `_aws_route_one` ([darksky.py](PyNightSkyPredictor/darksky.py)) now compares the final leg's actual arrival position against the requested destination. A gap over 1 km surfaces as a new `tail_miles` value rather than being silently dropped — the drivable portion up to that point is still real (`drive_minutes`/`drive_miles` stay populated), it's just the last stretch that isn't drivable.
- Cache schema extended with a `"t"` key (`tail_miles`), read/write paths updated everywhere `warnings`/`drive_miles` are handled.
- Frontend (`types.ts`, `Nearby.tsx`): `NearbyPlace.tail_miles`, rendered as **"Last N mi not drivable"** via the existing `.poi-warning` pill — unit-aware via the same `fmtMi`/imperial-toggle logic already used for every other distance in the component (no hardcoded unit string).
- Threshold is 1 km, per direction from the branch owner — chosen to catch genuine no-road cases (islands, etc.) without flagging routine driveway/road-snap noise (normally tens of meters).

## Test plan
- [x] `python -m pytest -q` — 738 passed, 9 skipped. New cases: `test_unreachable_destination_surfaces_tail_gap` (using the real Sand Island-scale gap), `test_normal_road_snap_does_not_trigger_tail_gap` (~55m snap does NOT false-positive), plus updated cache-schema assertions across the existing `_aws_drive_times` tests.
- [x] `npx tsc -b` — clean.
- [x] Verified in-browser (local backend): injected sample `tail_miles` markup to confirm the "Last N mi not drivable" pill renders correctly (reuses the already red-mode-compliant `.poi-warning` styling, no new CSS needed).
- [x] Verified live against AWS with the real Sand Island Lighthouse coordinates from the bug report before writing the detection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)