### PR TITLE
Moonwash upgrade: Winkler 2022 kernel, live AOD, meteor limiting magnitude, aurora moon factor

### DIFF
--- a/PyNightSkyPredictor/aurora.py
+++ b/PyNightSkyPredictor/aurora.py
@@ -52,6 +52,7 @@ from datetime import date, datetime, timedelta, timezone
 from . import cache as _cache
 from . import _http
 from . import light_dome as _ld
+from . import moonlight as _ml
 from . import provider_health as _ph
 
 log = logging.getLogger(__name__)
@@ -85,6 +86,16 @@ _CLOUD_BLOCK_PCT    = 70     # same threshold as predictor._CLOUD_BLOCK_PCT
 _WEATHER_GAP_SECS   = 5400   # 90-min nearest-neighbour tolerance, as elsewhere
 _DOME_CAUTION_SCORE = _ld.MINOR_DOME_THRESHOLD  # glow_toward ≥ this → caution
 _DOME_AIM_ALT_DEG   = 10.0   # aurora sits low — evaluate the dome at ~10° up
+
+# Moonlight: aurora is an EMISSION source — the moon raises the sky background
+# it must be seen against rather than washing the aurora itself, so moonlight
+# degrades (never blocks alone), and brighter tiers tolerate more of it.
+# Δ mag/arcsec² sky brightening at which each tier is degraded; overhead
+# storms punch through any moon and have no entry.
+_MOON_DELTA_DEGRADE = {
+    "photographic": _ml.KS_MODERATE_THRESH,  # 0.50 — faint-aurora photography is moon-sensitive
+    "naked_eye":    1.50,                    # the K&S 'severe' threshold
+}
 
 _KP_BIN_HOURS = 3
 
@@ -287,12 +298,18 @@ def _condition_vector(
     weather_points: "list | None",
     light_dome: "dict | None",
     bearing: float,
-) -> tuple[list, str, bool]:
-    """Photography blockers for an aurora window → (blockers, viability, dome_caution).
+    tier: str = "photographic",
+    moon_illum_pct: "float | None" = None,
+    moon_alts: "list | None" = None,
+) -> tuple[list, str, bool, bool]:
+    """Photography blockers for an aurora window
+    → (blockers, viability, dome_caution, moon_caution).
 
     Cloud: all in-window points > _CLOUD_BLOCK_PCT ⇒ blocked, some ⇒ degraded,
     no weather data ⇒ fail-open (ok), same as the target condition vectors.
     Light dome toward the look bearing is a caution — degrades, never blocks.
+    Moonlight (tier-scaled, see _MOON_DELTA_DEGRADE) likewise degrades, never
+    blocks; missing moon data (moon_alts=None) fails open like missing weather.
     """
     blockers: list[str] = []
     viability = "ok"
@@ -322,12 +339,29 @@ def _condition_vector(
             dome_caution = True
             if viability == "ok":
                 viability = "degraded"
-    return blockers, viability, dome_caution
+
+    moon_caution = False
+    degrade_at = _MOON_DELTA_DEGRADE.get(tier)
+    if degrade_at is not None and moon_illum_pct and moon_alts:
+        in_window = [alt for t, alt in moon_alts if win_start <= t <= win_end]
+        moon_alt_max = max(in_window) if in_window else None
+        if moon_alt_max is not None and moon_alt_max > 0:
+            # 90° separation = the darkest-accessible-sky proxy geometry
+            # (same convention as ks_moon_credit); aurora sits low, so the
+            # background is evaluated at the dome aim altitude.
+            delta = _ml.ks_delta_mag(moon_illum_pct, 90.0, moon_alt_max,
+                                     target_alt_deg=_DOME_AIM_ALT_DEG)
+            if delta >= degrade_at:
+                moon_caution = True
+                blockers.append("moonlight")
+                if viability == "ok":
+                    viability = "degraded"
+    return blockers, viability, dome_caution, moon_caution
 
 
 def _result_dict(lat, lon, kp_max, kp_source, noaa_scale, tier, margin,
                  peak_start, peak_end, blockers, viability, dome_caution,
-                 stale) -> dict:
+                 moon_caution, stale) -> dict:
     """The NightReport.aurora JSON contract (ISO strings only, so the dict
     survives both the dataclasses.asdict serializer and json.dumps in the
     trip night cache)."""
@@ -346,6 +380,7 @@ def _result_dict(lat, lon, kp_max, kp_source, noaa_scale, tier, margin,
         "look_direction":      _wind16(bearing),
         "blockers":            blockers,
         "light_dome_caution":  dome_caution,
+        "moonlight_caution":   moon_caution,
         "viability":           viability,
         "stale":               stale,
     }
@@ -360,6 +395,8 @@ def nightly_aurora(
     weather_points: "list | None" = None,
     light_dome: "dict | None" = None,
     stale: bool = False,
+    moon_illum_pct: "float | None" = None,
+    moon_alts: "list | None" = None,
 ) -> "dict | None":
     """Aurora outlook for one night from the 3-day Kp product, or None when
     there is nothing to report (no astronomical darkness, no forecast bins
@@ -406,14 +443,15 @@ def nightly_aurora(
     peak_end   = min(bins[hi][1], dark_end)
     peak_row   = bins[peak_i][2]
 
-    blockers, viability, dome_caution = _condition_vector(
-        peak_start, peak_end, weather_points, light_dome, look_bearing(lat, lon))
+    blockers, viability, dome_caution, moon_caution = _condition_vector(
+        peak_start, peak_end, weather_points, light_dome, look_bearing(lat, lon),
+        tier=tier, moon_illum_pct=moon_illum_pct, moon_alts=moon_alts)
 
     return _result_dict(
         lat, lon, kp_max, peak_row["observed"],
         peak_row.get("noaa_scale") or kp_to_g_scale(kp_max),
         tier, margin, peak_start, peak_end,
-        blockers, viability, dome_caution, stale)
+        blockers, viability, dome_caution, moon_caution, stale)
 
 
 def outlook_nightly_aurora(
@@ -426,6 +464,8 @@ def outlook_nightly_aurora(
     weather_points: "list | None" = None,
     light_dome: "dict | None" = None,
     stale: bool = False,
+    moon_illum_pct: "float | None" = None,
+    moon_alts: "list | None" = None,
 ) -> "dict | None":
     """Outlook-grade aurora for one night from the 27-day daily-largest-Kp
     product, in the same JSON shape as nightly_aurora but with kp_source
@@ -445,13 +485,14 @@ def outlook_nightly_aurora(
     if tier == "none":
         return None
 
-    blockers, viability, dome_caution = _condition_vector(
-        dark_start, dark_end, weather_points, light_dome, look_bearing(lat, lon))
+    blockers, viability, dome_caution, moon_caution = _condition_vector(
+        dark_start, dark_end, weather_points, light_dome, look_bearing(lat, lon),
+        tier=tier, moon_illum_pct=moon_illum_pct, moon_alts=moon_alts)
 
     return _result_dict(
         lat, lon, kp, "outlook", kp_to_g_scale(kp),
         tier, margin, None, None,
-        blockers, viability, dome_caution, stale)
+        blockers, viability, dome_caution, moon_caution, stale)
 
 
 def aurora_for_night(
@@ -466,6 +507,8 @@ def aurora_for_night(
     outlook_stale: bool = False,
     weather_points: "list | None" = None,
     light_dome: "dict | None" = None,
+    moon_illum_pct: "float | None" = None,
+    moon_alts: "list | None" = None,
 ) -> "dict | None":
     """Unified nightly aurora: the 3-day Kp product when its bins cover the
     night's dark window, otherwise the 27-day outlook. This is what keeps the
@@ -488,8 +531,10 @@ def aurora_for_night(
         if first <= dark_start and last >= dark_end:
             return nightly_aurora(lat, lon, dark_start, dark_end,
                                   kp_rows=kp_rows, weather_points=weather_points,
-                                  light_dome=light_dome, stale=kp_stale)
+                                  light_dome=light_dome, stale=kp_stale,
+                                  moon_illum_pct=moon_illum_pct, moon_alts=moon_alts)
 
     return outlook_nightly_aurora(lat, lon, d, dark_start, dark_end,
                                   outlook=outlook, weather_points=weather_points,
-                                  light_dome=light_dome, stale=outlook_stale)
+                                  light_dome=light_dome, stale=outlook_stale,
+                                  moon_illum_pct=moon_illum_pct, moon_alts=moon_alts)

--- a/PyNightSkyPredictor/milky_way.py
+++ b/PyNightSkyPredictor/milky_way.py
@@ -521,4 +521,7 @@ def milky_way_arch_summary(
         "farthest_peak_az_deg":  round(farthest_w.peak_az_deg)  if farthest_w else None,
         "core_moon_sep_deg":     getattr(core_w, "moon_sep_at_peak_deg", None),
         "core_moon_alt_deg":     getattr(core_w, "moon_alt_at_peak_deg", None),
+        # Backend-computed severity at the core peak (site SQM + AOD aware);
+        # 'none' = negligible, None = geometry unavailable (frontend falls back).
+        "core_moon_severity":    getattr(core_w, "moon_wash_severity", None),
     }

--- a/PyNightSkyPredictor/moonlight.py
+++ b/PyNightSkyPredictor/moonlight.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 """
-Krisciunas & Schaefer (1991) moonlight model and sky-brightness constants.
+Scattered-moonlight model and sky-brightness constants.
+
+Hybrid of Krisciunas & Schaefer (1991, PASP 103, 1033) and Winkler (2022,
+MNRAS 514, 208): K&S lunar illuminance and optical pathlength, Winkler's
+single-scatter kernel (his eq. 7) with the two-component Rayleigh +
+Henyey-Greenstein phase function (eqs. 10/12).  Aerosol optical depth is a
+live input: smoke/haze both dims the lunar beam and amplifies the forward-
+scattered aureole via the Mie term.
 
 Public API
 ----------
-ks_delta_mag(illumination_pct, sep_deg, moon_alt_deg, sky_sqm) -> float
+ks_delta_mag(illumination_pct, sep_deg, moon_alt_deg, sky_sqm, aod, target_alt_deg) -> float
     Sky surface brightness increase Δ mag/arcsec² from scattered moonlight.
 
 ks_moon_credit(illumination_pct) -> float
@@ -12,6 +19,12 @@ ks_moon_credit(illumination_pct) -> float
 
 moon_wash_severity(illumination_pct, sep_deg, moon_alt_deg) -> str | None
     Classify moon interference as None, 'minor', 'moderate', or 'severe'.
+
+k_ext_from_aod(aod) -> float
+    V-band extinction coefficient (mag/airmass) for a given aerosol optical depth.
+
+nelm_from_sqm(sqm) -> float
+    Naked-eye limiting magnitude for a given sky surface brightness.
 
 Constants exported for use by targets.py and predictor.py:
     KS_CRESCENT_EXEMPTION_PCT — illumination threshold below which the moon
@@ -25,12 +38,30 @@ Constants exported for use by targets.py and predictor.py:
 import math
 
 # ---------------------------------------------------------------------------
-# Krisciunas & Schaefer (1991) model constants
+# Model constants
 # ---------------------------------------------------------------------------
 
-_KS_K_EXT        = 0.172      # typical V-band atmospheric extinction coefficient
+_KS_K_EXT        = 0.172      # legacy K&S V-band extinction coefficient; the reference-AOD anchor
 KS_NATURAL_SKY   = 21.6      # Bortle 2 dark-sky baseline (mag/arcsec²); conservative
 _KS_MEAN_DIST_KM = 384_400.0  # mean Earth-Moon distance used by K&S (1991)
+
+# Optical-depth decomposition (V band).  k (mag/airmass) = _MAG_PER_TAU · τ_total.
+_MAG_PER_TAU = 2.5 * math.log10(math.e)   # 1.0857362… — Bouguer mag-per-optical-depth
+_TAU_RAY     = 0.1066   # Rayleigh scattering, sea level
+_TAU_ABS     = 0.016    # ozone/trace absorption (scatters nothing)
+# Reference aerosol optical depth, derived so k(_AOD_REF) == _KS_K_EXT exactly:
+# aod=None therefore reproduces the legacy fixed-extinction behaviour by construction.
+_AOD_REF = _KS_K_EXT / _MAG_PER_TAU - _TAU_RAY - _TAU_ABS   # ≈ 0.0358
+_AOD_CAP = 3.0          # extreme smoke; single-scatter model validity guard
+_HG_G    = 0.8          # Henyey-Greenstein asymmetry parameter (Winkler 2022, §4.3)
+
+# Normalisation anchoring the Winkler kernel to the legacy K&S intensity at the
+# ks_moon_credit proxy geometry (sep 90°, moon alt 30°, target alt 45°, aod=None):
+# legacy I_scatter/I_moon there = 10^5.36·1.06 · 10^(−0.4·0.172·2.0) = 176891.052…,
+# so ks_moon_credit (and everything derived from it: moon_score, calendar
+# dark-cycle scores) is bit-identical to the pre-Winkler model at reference AOD.
+# Derivation: scripts/verify_moonwash_grid.py; pinned by tests/test_moonlight.py.
+_KS_NORM = 24130491.121213324
 
 # Severity thresholds in Δ mag/arcsec² (sky brightening from dark-sky baseline)
 _KS_MINOR_THRESH    = 0.10   # < 0.10 → None   : imperceptible
@@ -86,19 +117,48 @@ MW_PHOTO_SB_CONTRAST  = 1.5
 MW_VISUAL_SB_CONTRAST = 1.0
 
 
+def _pathlength(alt_deg: float) -> float:
+    """
+    Relative optical pathlength (airmass) toward altitude alt_deg, using the
+    K&S (1991) form X(z) = (1 − 0.96·sin²z)^(−1/2) — finite at the horizon
+    (X = 5.0), unlike the plain secant Winkler (2022) adopts.
+    """
+    z = math.radians(90.0 - max(0.0, alt_deg))
+    return (1.0 - 0.96 * math.sin(z) ** 2) ** -0.5
+
+
+def k_ext_from_aod(aod: "float | None") -> float:
+    """V-band extinction coefficient (mag/airmass) for a given AOD; None → reference sky (0.172)."""
+    tau_m = _AOD_REF if aod is None else min(max(0.0, aod), _AOD_CAP)
+    return _MAG_PER_TAU * (_TAU_RAY + tau_m + _TAU_ABS)
+
+
+def nelm_from_sqm(sqm: float) -> float:
+    """
+    Naked-eye limiting magnitude for a sky of surface brightness sqm
+    (mag/arcsec²), via the standard Schaefer-derived conversion
+    (Unihedron form): NELM = 7.93 − 5·log10(10^(4.316 − SQM/5) + 1).
+    """
+    return 7.93 - 5.0 * math.log10(10 ** (4.316 - sqm / 5.0) + 1.0)
+
+
 def ks_delta_mag(
     illumination_pct: float,
     sep_deg: float,
     moon_alt_deg: float,
     sky_sqm: float = KS_NATURAL_SKY,
     moon_earth_dist_km: float = _KS_MEAN_DIST_KM,
+    aod: "float | None" = None,
+    target_alt_deg: float = 45.0,
 ) -> float:
     """
-    Return sky surface brightness increase Δ mag/arcsec² from scattered moonlight
-    using the Krisciunas & Schaefer (1991) model (PASP 103, 1033).
+    Return sky surface brightness increase Δ mag/arcsec² from scattered moonlight.
 
-    Returns 0.0 when illumination is zero or the moon is below the horizon.
-    sky_sqm is used for the natural-sky baseline I_sky denominator.
+    Hybrid model: K&S (1991) lunar illuminance + Winkler (2022, MNRAS 514, 208)
+    single-scatter kernel (his eq. 7) with the two-component Rayleigh +
+    Henyey-Greenstein phase function (eqs. 10/12).  Returns 0.0 when
+    illumination is zero or the moon is below the horizon.  sky_sqm is used
+    for the natural-sky baseline I_sky denominator.
 
     moon_earth_dist_km — actual Earth-Moon distance at observation time (km).
     K&S (1991) assumes the Moon at its mean distance (384,400 km); passing the
@@ -106,6 +166,15 @@ def ks_delta_mag(
     removing up to ±0.35 mag/arcsec² error on supermoon / micromoon nights.
     Defaults to the mean distance so callers without per-sample ephemeris data
     remain accurate on average.
+
+    aod — aerosol optical depth (V band, dimensionless).  None means the
+    reference clear sky (_AOD_REF), which reproduces the legacy fixed-k
+    behaviour by construction.  Higher AOD both dims the lunar beam and
+    amplifies the forward-scattered aureole (Mie term), so smoke/haze
+    brightens the sky near the moon while dimming it far away.
+
+    target_alt_deg — altitude of the observed sky position; longer slant
+    paths at low altitude scatter more moonlight into the line of sight.
     """
     if illumination_pct <= 0 or moon_alt_deg <= 0:
         return 0.0
@@ -116,18 +185,34 @@ def ks_delta_mag(
     I_moon = 10 ** (-0.4 * (V_moon + 16.57))
     I_moon *= (_KS_MEAN_DIST_KM / moon_earth_dist_km) ** 2  # inverse-square distance correction
 
-    alt    = max(1.0, moon_alt_deg)
-    X_moon = 1.0 / math.cos(math.radians(90.0 - alt))
-    ext    = 10 ** (-0.4 * _KS_K_EXT * X_moon)
+    # Optical depths: Rayleigh + aerosol scatter; ozone only absorbs.
+    tau_m = _AOD_REF if aod is None else min(max(0.0, aod), _AOD_CAP)
+    tau_s = _TAU_RAY + tau_m
+    tau   = tau_s + _TAU_ABS
 
-    rho     = max(0.1, sep_deg)
-    rho_rad = math.radians(rho)
-    if rho > 10.0:
-        f_rho = 10 ** 5.36 * (1.06 + math.cos(rho_rad) ** 2)
+    # Two-component phase function at scattering angle ρ (= moon-target
+    # separation for single scatter).  Winkler (2022) eqs. 10/12: the Mie
+    # weight is the aerosol optical depth itself, so the forward-scattering
+    # aureole grows with aerosol load with no ad-hoc scaling constant.
+    rho     = math.radians(max(0.1, sep_deg))
+    cos_rho = math.cos(rho)
+    p_ray   = 3.0 / (16.0 * math.pi) * (1.0 + cos_rho ** 2)
+    p_mie   = (1.0 - _HG_G ** 2) / (
+        4.0 * math.pi * (1.0 + _HG_G ** 2 - 2.0 * _HG_G * cos_rho) ** 1.5
+    )
+    p = (_TAU_RAY * p_ray + tau_m * p_mie) / tau_s
+
+    # Winkler eq. 7 single-scatter kernel: the line-of-sight airmass X_t
+    # carries the leading factor; the bracket integrates beam extinction
+    # (X_m) against line-of-sight extinction (X_t) along the path.
+    X_t = _pathlength(target_alt_deg)
+    X_m = _pathlength(moon_alt_deg)
+    if abs(X_m - X_t) < 1e-6:
+        kernel = tau * X_t * math.exp(-tau * X_t)
     else:
-        f_rho = 6.2e7 / rho ** 2
+        kernel = X_t * (math.exp(-tau * X_t) - math.exp(-tau * X_m)) / (X_m - X_t)
 
-    I_scatter = f_rho * ext * I_moon
+    I_scatter = _KS_NORM * p * (tau_s / tau) * kernel * I_moon
     I_sky     = 10 ** ((27.78 - sky_sqm) / 2.5)
     return 2.5 * math.log10(1.0 + I_scatter / I_sky)
 
@@ -161,6 +246,11 @@ def ks_moon_credit(illumination_pct: float) -> float:
       100%  full        0.00          0.00   — unchanged
 
     The key win is the 30–75% range where the naive formula is far too generous.
+
+    Deliberately evaluated at aod=None (reference sky): this feeds nightly
+    planning scores (moon_score, calendar dark cycles) which must not wobble
+    with 30-minute weather refetches, and the calendar path has no weather at
+    all.  Do not "fix" this by passing live AOD here.
     """
     delta = ks_delta_mag(illumination_pct, _KS_CREDIT_SEP_DEG, _KS_CREDIT_ALT_DEG)
     return max(0.0, 1.0 - delta / _KS_SEVERE_THRESH)
@@ -170,12 +260,15 @@ def moon_wash_severity(
     illumination_pct: float,
     sep_deg: float | None,
     moon_alt_deg: float | None = None,
+    aod: float | None = None,
+    target_alt_deg: float = 45.0,
 ) -> str | None:
     """
     Classify moon interference as None, 'minor', 'moderate', or 'severe'.
 
     Uses ks_delta_mag internally; sep_deg and moon_alt_deg default to 45°
-    when not provided (conservative mid-sky estimate).
+    when not provided (conservative mid-sky estimate).  aod / target_alt_deg
+    pass through to the scattering model.
 
     Severity thresholds (Δ mag/arcsec² relative to a Bortle-2 dark sky):
       None       < 0.10  — negligible
@@ -187,6 +280,8 @@ def moon_wash_severity(
         illumination_pct,
         sep_deg      if sep_deg      is not None else 45.0,
         moon_alt_deg if moon_alt_deg is not None else 45.0,
+        aod=aod,
+        target_alt_deg=target_alt_deg,
     )
     if delta_mag < _KS_MINOR_THRESH:
         return None

--- a/PyNightSkyPredictor/moonlight.py
+++ b/PyNightSkyPredictor/moonlight.py
@@ -262,15 +262,17 @@ def moon_wash_severity(
     moon_alt_deg: float | None = None,
     aod: float | None = None,
     target_alt_deg: float = 45.0,
+    sky_sqm: float = KS_NATURAL_SKY,
+    moon_earth_dist_km: float = _KS_MEAN_DIST_KM,
 ) -> str | None:
     """
     Classify moon interference as None, 'minor', 'moderate', or 'severe'.
 
     Uses ks_delta_mag internally; sep_deg and moon_alt_deg default to 45°
-    when not provided (conservative mid-sky estimate).  aod / target_alt_deg
-    pass through to the scattering model.
+    when not provided (conservative mid-sky estimate).  aod, target_alt_deg,
+    sky_sqm and moon_earth_dist_km pass through to the scattering model.
 
-    Severity thresholds (Δ mag/arcsec² relative to a Bortle-2 dark sky):
+    Severity thresholds (Δ mag/arcsec² relative to the site's own sky):
       None       < 0.10  — negligible
       'minor'   0.10–0.50 — slight brightening
       'moderate' 0.50–1.50 — noticeable; low-SB targets impacted
@@ -280,6 +282,8 @@ def moon_wash_severity(
         illumination_pct,
         sep_deg      if sep_deg      is not None else 45.0,
         moon_alt_deg if moon_alt_deg is not None else 45.0,
+        sky_sqm,
+        moon_earth_dist_km,
         aod=aod,
         target_alt_deg=target_alt_deg,
     )

--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -899,25 +899,8 @@ def assemble_night(
     # --- Active meteor showers (always computed — fast date check only) ---
     active_showers = _tgt.active_meteor_showers(target)
 
-    # --- Aurora outlook (fetches already resolved off-thread; per-location math
-    # is cheap). On the use_cycle_window path night_start/night_end come from
-    # the fixed-twilight-offset approximation — minutes-scale error against the
-    # 3-hour Kp bins, acceptable. Non-fatal on any failure.
-    aurora_info = None
-    if _aurora_future is not None and night_start and night_end:
-        try:
-            _kp_rows, _kp_stale, _kp_outlook, _outlook_stale = _aurora_future.result()
-            aurora_info = _aur.aurora_for_night(
-                lat, lon, target, night_start, night_end,
-                kp_rows=_kp_rows, kp_stale=_kp_stale,
-                outlook=_kp_outlook, outlook_stale=_outlook_stale,
-                weather_points=night_points,
-                light_dome=light_dome_info,
-            )
-        except Exception as _ae:
-            log.debug("aurora computation failed (non-fatal): %s", _ae)
-
-    # --- Moon altitude track (used for best-time scoring across all target types) ---
+    # --- Moon altitude track (used for best-time scoring across all target types,
+    # and for the aurora moonlight factor below) ---
     # Sampled sunset→sunrise at 15-min resolution.  Requires de421.bsp; falls back
     # gracefully (moon_alts=None) when the ephemeris is absent (e.g. unit tests).
     _moon_alts: list | None = None
@@ -933,6 +916,26 @@ def assemble_night(
             _moon_alts     = list(zip(_sample_times, _moon_alt_vals))
         except Exception as _mae:
             log.debug("moon_altitude_track failed (non-fatal): %s", _mae)
+
+    # --- Aurora outlook (fetches already resolved off-thread; per-location math
+    # is cheap). On the use_cycle_window path night_start/night_end come from
+    # the fixed-twilight-offset approximation — minutes-scale error against the
+    # 3-hour Kp bins, acceptable. Non-fatal on any failure.
+    aurora_info = None
+    if _aurora_future is not None and night_start and night_end:
+        try:
+            _kp_rows, _kp_stale, _kp_outlook, _outlook_stale = _aurora_future.result()
+            aurora_info = _aur.aurora_for_night(
+                lat, lon, target, night_start, night_end,
+                kp_rows=_kp_rows, kp_stale=_kp_stale,
+                outlook=_kp_outlook, outlook_stale=_outlook_stale,
+                weather_points=night_points,
+                light_dome=light_dome_info,
+                moon_illum_pct=illumination,
+                moon_alts=_moon_alts,
+            )
+        except Exception as _ae:
+            log.debug("aurora computation failed (non-fatal): %s", _ae)
 
     # --- Milky Way arch summary (needs weather + moon_alts for best-viewing-time) ---
     if fetch_targets:

--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -29,7 +29,7 @@ from .milky_way import (
     BT_K_MOON as _BT_K_MOON,
     BT_STEP_MIN as _BT_STEP_MIN,
 )
-from .moonlight import ks_moon_credit, KS_CRESCENT_EXEMPTION_PCT
+from .moonlight import ks_moon_credit, ks_delta_mag, nelm_from_sqm, KS_CRESCENT_EXEMPTION_PCT
 from . import weather as wx
 
 log = logging.getLogger(__name__)
@@ -245,6 +245,8 @@ def _apply_condition_vectors(
     light_dome_info: "dict | None",
     illumination_pct: float,
     moon_alts: "list | None" = None,
+    sky_sqm: "float | None" = None,
+    night_aod: "float | None" = None,
 ) -> None:
     """Post-process VisibleTarget list with atmospheric, dome, and lunar viability vectors.
 
@@ -388,10 +390,34 @@ def _apply_condition_vectors(
             if target.type == "meteor_shower":
                 zhr_eff = target.zhr_effective
                 if zhr_eff is not None and window.peak_alt_deg is not None:
-                    window.local_rate_at_peak = (
-                        round(zhr_eff * math.sin(math.radians(window.peak_alt_deg)), 1)
+                    base_rate = (
+                        zhr_eff * math.sin(math.radians(window.peak_alt_deg))
                         if window.peak_alt_deg > 0 else 0.0
                     )
+                    # Limiting-magnitude degradation (IMO convention): the rate a
+                    # visual observer sees scales as r^(lm − 6.5), where lm is the
+                    # naked-eye limiting magnitude under the moon-brightened site
+                    # sky and r the shower's magnitude-distribution index. A full
+                    # moon or a bright site kills faint-meteor-rich showers
+                    # (high r) far harder than fireball-rich ones.
+                    lm_factor = 1.0
+                    r = target.population_index
+                    if r is not None and sky_sqm is not None and window.peak_alt_deg > 0:
+                        delta = 0.0
+                        if (window.moon_sep_at_peak_deg is not None
+                                and window.moon_alt_at_peak_deg is not None):
+                            delta = ks_delta_mag(
+                                illumination_pct,
+                                window.moon_sep_at_peak_deg,
+                                window.moon_alt_at_peak_deg,
+                                sky_sqm,
+                                aod=night_aod,
+                                target_alt_deg=window.peak_alt_deg,
+                            )
+                        lm = nelm_from_sqm(sky_sqm - delta)
+                        lm_factor = min(1.0, r ** (lm - 6.5))
+                        window.lm_factor_at_peak = round(lm_factor, 3)
+                    window.local_rate_at_peak = round(base_rate * lm_factor, 1)
                     if window.peak_alt_deg < _LOW_RADIANT_ALT_DEG:
                         blockers.append("low_radiant")
                 else:
@@ -928,7 +954,8 @@ def assemble_night(
 
     # --- Phase 1: Condition Vectors — apply after weather + moon_alts resolved ---
     if fetch_targets and target_list:
-        _apply_condition_vectors(target_list, night_points, light_dome_info, illumination, _moon_alts)
+        _apply_condition_vectors(target_list, night_points, light_dome_info, illumination, _moon_alts,
+                                 sky_sqm=_site_sqm, night_aod=_night_aod)
 
     # --- Overall rating ---
     _tc = time.monotonic()
@@ -981,6 +1008,7 @@ def assemble_night(
         wx_no_data=wx_no_data,
         wx_archive_error=wx_archive_error,
         wx_error=wx_error,
+        night_aod=_night_aod,
         score=rating["score"],
         score_components=rating["components"],
         visible_targets=target_list,

--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -128,6 +128,10 @@ class NightReport:
     score: float | None
     score_components: dict  # {moon, dark, weather, bortle}
 
+    # Night-median aerosol optical depth (moonlight scattering input); None when
+    # unavailable (past dates, AQ fetch failure, beyond the 7-day AQ horizon).
+    night_aod: float | None = None
+
     # Visible targets (populated when fetch_targets=True)
     visible_targets: list = field(default_factory=list)
     mw_summary:      dict | None = None   # milky_way_arch_summary output (MW targets only)
@@ -689,6 +693,22 @@ def assemble_night(
                 except RuntimeError as _e:
                     _wx_exc = _e
 
+        # Deserialize once, here, so the night's AOD is available to the
+        # visible_targets moonlight model below (the weather block later in
+        # this function reuses these instead of re-deserializing).  The
+        # .result() above already blocked, so this adds pure CPU only.
+        _wx_points_early = None
+        _wx_src_early    = None
+        _wx_fetch_early  = None
+        if _wx_cached is not None:
+            _wx_points_early, _wx_src_early, _wx_fetch_early = _wx_deserialize(_wx_cached)
+        elif _wx_fetched is not None:
+            _wx_points_early, _wx_src_early, _wx_fetch_early = _wx_fetched
+        _night_aod = (
+            wx.night_aod(_wx_points_early, sunset, sunrise)
+            if _wx_points_early else None
+        )
+
         _t["io_wait_ms"] = round((time.monotonic() - _tc) * 1000)
 
         # --- Phase 2: satellite passes + visible_targets in parallel ---
@@ -736,6 +756,7 @@ def assemble_night(
             _vt_future = _pool.submit(
                 _tgt.visible_targets, lat, lon, sunset, sunrise, illumination,
                 night_start=night_start, night_end=night_end, sky_sqm=_site_sqm, tz=tz,
+                aod=_night_aod,
             )
 
         # Collect satellite passes
@@ -816,10 +837,11 @@ def assemble_night(
                 # Future date: use cached or concurrently-fetched result
                 if _wx_exc is not None:
                     raise _wx_exc
-                if _wx_cached is not None:
-                    points, wx_source, wx_fetched_at = _wx_deserialize(_wx_cached)
-                elif _wx_fetched is not None:
-                    points, wx_source, wx_fetched_at = _wx_fetched
+                if _wx_points_early is not None:
+                    # Deserialized once in the io_wait block above.
+                    points, wx_source, wx_fetched_at = (
+                        _wx_points_early, _wx_src_early, _wx_fetch_early
+                    )
                 else:
                     # Pass target string parameters into the provider to bypass the 7-day programmatic limitation
                     points, wx_source, wx_fetched_at = wx.forecast(lat, lon)

--- a/PyNightSkyPredictor/render_report.py
+++ b/PyNightSkyPredictor/render_report.py
@@ -380,12 +380,17 @@ def print_targets(report: NightReport, ctx: FormatCtx) -> None:
                                    report.night_end)
         _peak_moonup = _moon_up_at(window.peak_time)
         if _peak_moonup:
-            sev = moon_wash_severity(
-                report.illumination_pct,
-                window.moon_sep_at_peak_deg,
-                window.moon_alt_at_peak_deg,
-            )
-            if sev is not None:
+            # Prefer the severity serialized by targets.py (site SQM + AOD +
+            # slant path); recompute at defaults only when it's missing
+            # ('none' = computed and negligible → no label).
+            sev = window.moon_wash_severity
+            if sev is None:
+                sev = moon_wash_severity(
+                    report.illumination_pct,
+                    window.moon_sep_at_peak_deg,
+                    window.moon_alt_at_peak_deg,
+                )
+            if sev is not None and sev != "none":
                 condition = f"Moon wash · {sev}"
         flags = []
         if window.moon_interference:

--- a/PyNightSkyPredictor/targets.json
+++ b/PyNightSkyPredictor/targets.json
@@ -313,6 +313,7 @@
     "peak_zhr": 120,
     "b_rise": 0.865,
     "b_decline": 0.827,
+    "population_index": 2.1,
     "peak_hour_utc": 3.5
   },
   {
@@ -326,6 +327,7 @@
     "peak_zhr": 18,
     "b_rise": 1.229,
     "b_decline": 4.620,
+    "population_index": 2.1,
     "peak_hour_utc": 1.68
   },
   {
@@ -339,6 +341,7 @@
     "peak_zhr": 50,
     "b_rise": 0.125,
     "b_decline": 0.079,
+    "population_index": 2.4,
     "peak_hour_utc": 9.47
   },
   {
@@ -352,6 +355,7 @@
     "peak_zhr": 25,
     "b_rise": 0.109,
     "b_decline": 0.071,
+    "population_index": 3.2,
     "peak_hour_utc": 10.0
   },
   {
@@ -365,6 +369,7 @@
     "peak_zhr": 100,
     "b_rise": 0.050,
     "b_decline": 0.092,
+    "population_index": 2.2,
     "peak_hour_utc": 14.88
   },
   {
@@ -378,6 +383,7 @@
     "peak_zhr": 20,
     "b_rise": 0.120,
     "b_decline": 0.119,
+    "population_index": 2.5,
     "peak_hour_utc": 6.9
   },
   {
@@ -391,6 +397,7 @@
     "peak_zhr": 5,
     "b_rise": 0.026,
     "b_decline": 0.026,
+    "population_index": 2.3,
     "peak_hour_utc": 6.98
   },
   {
@@ -404,6 +411,7 @@
     "peak_zhr": 5,
     "b_rise": 0.026,
     "b_decline": 0.026,
+    "population_index": 2.3,
     "peak_hour_utc": 0.37
   },
   {
@@ -417,6 +425,7 @@
     "peak_zhr": 15,
     "b_rise": 0.025,
     "b_decline": 0.15,
+    "population_index": 2.5,
     "peak_hour_utc": 0.0
   },
   {
@@ -430,6 +439,7 @@
     "peak_zhr": 150,
     "b_rise": 0.150,
     "b_decline": 0.462,
+    "population_index": 2.6,
     "peak_hour_utc": 5.73
   },
   {
@@ -443,6 +453,7 @@
     "peak_zhr": 10,
     "b_rise": 2.292,
     "b_decline": 1.258,
+    "population_index": 3.0,
     "peak_hour_utc": 20.98
   },
   {

--- a/PyNightSkyPredictor/targets.py
+++ b/PyNightSkyPredictor/targets.py
@@ -209,12 +209,13 @@ def _find_windows(alt_deg, az_deg, sample_dts: list, min_elev: float) -> list:
     return result
 
 
-def _moon_interferes(sep_deg, moon_alt_deg, moon_dist_km, window_indices: list,
-                     illumination_pct: float) -> bool:
+def _moon_interferes(sep_deg, moon_alt_deg, moon_dist_km, target_alt_deg,
+                     window_indices: list, illumination_pct: float,
+                     aod: "float | None" = None) -> bool:
     """True if the moon produces ≥ moderate sky brightening (Δμ ≥ 0.50) at any window sample.
 
-    Uses the K&S model rather than a binary illumination/separation gate, so a
-    49%-illuminated moon is evaluated on the same physics as a 51% moon.
+    Uses the scattering model rather than a binary illumination/separation gate,
+    so a 49%-illuminated moon is evaluated on the same physics as a 51% moon.
     Returns False immediately for new moon or if the moon is always below the horizon.
     """
     if not window_indices or illumination_pct <= 0:
@@ -222,7 +223,9 @@ def _moon_interferes(sep_deg, moon_alt_deg, moon_dist_km, window_indices: list,
     for i in window_indices:
         if _ml.ks_delta_mag(illumination_pct, float(sep_deg[i]),
                             float(moon_alt_deg[i]),
-                            moon_earth_dist_km=float(moon_dist_km[i])) >= _ml.KS_MODERATE_THRESH:
+                            moon_earth_dist_km=float(moon_dist_km[i]),
+                            aod=aod,
+                            target_alt_deg=float(target_alt_deg[i])) >= _ml.KS_MODERATE_THRESH:
             return True
     return False
 
@@ -374,7 +377,8 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
                     illumination_pct: float, night_date,
                     min_elevation: float,
                     obs_start: datetime, obs_end: datetime,
-                    sky_sqm: float | None = None) -> "VisibleTarget | None":
+                    sky_sqm: float | None = None,
+                    aod: float | None = None) -> "VisibleTarget | None":
     name     = entry["name"]
     ttype    = entry["type"]
     min_elev = entry.get("min_elevation", min_elevation)
@@ -461,7 +465,8 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
     windows = []
     for window, indices in windows_with_idx:
         window.moon_interference = _moon_interferes(obs_sep, obs_moon_alt, obs_moon_dist,
-                                                    indices, illumination_pct)
+                                                    obs_alt, indices, illumination_pct,
+                                                    aod=aod)
 
         # Store moon separation and altitude at peak time for the K&S sky brightness model.
         try:
@@ -503,7 +508,8 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
                 sep      = float(obs_sep[i])
                 malt     = float(obs_moon_alt[i])
                 mdist    = float(obs_moon_dist[i])
-                delta    = _ml.ks_delta_mag(illumination_pct, sep, malt, _sqm, mdist)
+                delta    = _ml.ks_delta_mag(illumination_pct, sep, malt, _sqm, mdist,
+                                            aod=aod, target_alt_deg=float(obs_alt[i]))
                 sky_now  = _sqm - delta   # effective sky brightness this sample
 
                 if sb is not None:
@@ -642,6 +648,7 @@ def visible_targets(
     min_elevation: float = DEFAULT_MIN_ELEVATION,
     sky_sqm: float | None = None,
     tz: "ZoneInfo | None" = None,
+    aod: float | None = None,
 ) -> list:
     """
     Return targets visible during the night.
@@ -650,6 +657,9 @@ def visible_targets(
     (night_start–night_end). Planets use the full sunset–sunrise window
     since they are often worth observing during twilight.
     Falls back to sunset/sunrise for both if night bounds are unavailable.
+
+    aod — night-representative aerosol optical depth for the moonlight
+    scattering model; None means reference clear sky.
     """
     catalog = load_targets()
     if not catalog:
@@ -707,6 +717,7 @@ def visible_targets(
                 min_elevation,
                 obs_start, obs_end,
                 sky_sqm=_sky_sqm,
+                aod=aod,
             )
         except Exception as e:
             log.warning("Error computing target %r: %s", entry.get("name"), e)

--- a/PyNightSkyPredictor/targets.py
+++ b/PyNightSkyPredictor/targets.py
@@ -67,6 +67,8 @@ class TargetWindow:
     arch_angle_deg: float | None = None        # milky_way only: plane angle from horizon
     moon_sep_at_peak_deg: float | None = None  # angular separation from moon at peak time
     moon_alt_at_peak_deg: float | None = None  # moon altitude at peak time (for K&S model)
+    moon_wash_severity: "str | None" = None    # 'none'|'minor'|'moderate'|'severe' at peak (site SQM +
+                                                 # AOD + slant path); None = peak geometry unavailable
     photo_cutoff: "datetime | None" = None     # last sample where astrophotography is viable
     visual_cutoff: "datetime | None" = None    # last sample where visual observation is viable
     photo_start: "datetime | None" = None      # first viable sample (set when moon delays window start)
@@ -477,6 +479,20 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
             peak_obs_idx = obs_dts.index(window.peak_time)
             window.moon_sep_at_peak_deg = float(obs_sep[peak_obs_idx])
             window.moon_alt_at_peak_deg = float(obs_moon_alt[peak_obs_idx])
+            # Serialized severity at peak — the single source of truth for the
+            # UI and CLI (site SQM, AOD, distance and slant path included,
+            # unlike the legacy frontend mirror).  'none' = computed and
+            # negligible; None (field default) = peak geometry unavailable.
+            sev = _ml.moon_wash_severity(
+                illumination_pct,
+                window.moon_sep_at_peak_deg,
+                window.moon_alt_at_peak_deg,
+                aod=aod,
+                target_alt_deg=window.peak_alt_deg,
+                sky_sqm=_sqm,
+                moon_earth_dist_km=float(obs_moon_dist[peak_obs_idx]),
+            )
+            window.moon_wash_severity = sev if sev is not None else "none"
         except Exception as e:
             log.debug("Moon sep/alt at peak failed for %r: %s", name, e)
 

--- a/PyNightSkyPredictor/targets.py
+++ b/PyNightSkyPredictor/targets.py
@@ -78,8 +78,10 @@ class TargetWindow:
     blockers: list = field(default_factory=list)  # ["cloud","transparency","light_dome","moon_washout","low_radiant"]
     weather_score_at_best: "int | None" = None    # rate_conditions() score at best_time
     dome_glow_at_peak: "float | None" = None      # glow_toward() at (peak_az_deg, peak_alt_deg)
-    local_rate_at_peak: "float | None" = None     # meteor showers only: zhr_effective × sin(radiant_alt);
+    local_rate_at_peak: "float | None" = None     # meteor showers only: zhr_effective × sin(radiant_alt) × lm_factor;
                                                     # set by predictor._apply_condition_vectors; None for non-shower targets
+    lm_factor_at_peak: "float | None" = None      # meteor showers only: r^(lm − 6.5) limiting-magnitude degradation
+                                                    # from the moon-brightened site sky; 1.0 = pristine, None = not computed
 
 
 @dataclass
@@ -93,6 +95,8 @@ class VisibleTarget:
     landscape_suitability: str = "prominent"     # "prominent" | "diffuse" | "too_small"
     zhr_effective: "float | None" = None         # meteor showers only: day-decayed peak ZHR (IMO log-linear decay);
                                                    # set by _compute_target; None for non-shower types
+    population_index: "float | None" = None      # meteor showers only: IMO magnitude-distribution index r;
+                                                   # from catalog; drives the limiting-magnitude rate degradation
 
 
 def _landscape_suitability(
@@ -584,6 +588,7 @@ def _compute_target(entry: dict, observer, eph, t_array, sample_dts: list,
         angular_size_arcmin=angular_size,
         landscape_suitability=land_suit,
         zhr_effective=zhr_eff,
+        population_index=entry.get("population_index") if ttype == "meteor_shower" else None,
     )
 
 

--- a/PyNightSkyPredictor/weather.py
+++ b/PyNightSkyPredictor/weather.py
@@ -432,6 +432,7 @@ _AQ_URL = (
     "https://air-quality-api.open-meteo.com/v1/air-quality"
     "?latitude={lat}&longitude={lon}"
     "&hourly=pm2_5,aerosol_optical_depth"
+    "&forecast_days=7"          # pin the horizon (API default is ~5 days)
     "&timezone=GMT"
 )
 
@@ -488,6 +489,29 @@ def _merge_air_quality(points: list, aq: list) -> list:
             p = _dc_replace(p, pm2_5=nearest[1], aerosol_optical_depth=nearest[2])
         result.append(p)
     return result
+
+
+def night_aod(points: list, start: datetime, end: datetime) -> "float | None":
+    """
+    Night-representative aerosol optical depth: the median AOD over the
+    WeatherPoints falling within [start, end] (typically sunset→sunrise).
+
+    Returns None when no point in the window carries AOD — past dates, air-
+    quality fetch failures, or nights beyond the 7-day air-quality horizon —
+    in which case the moonlight model falls back to its reference clear sky.
+    A single scalar is deliberate: CAMS hourly AOD is smooth, and intra-night
+    variation is well below the scattering model's own error.
+    """
+    vals = sorted(
+        p.aerosol_optical_depth for p in points
+        if p.aerosol_optical_depth is not None and start <= p.time <= end
+    )
+    if not vals:
+        return None
+    mid = len(vals) // 2
+    if len(vals) % 2:
+        return float(vals[mid])
+    return float((vals[mid - 1] + vals[mid]) / 2.0)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -541,7 +541,7 @@ export default function ReportCard({
         <MetaRow k="Lunar Conditions" v={moonStrCard}
           icon={<MoonPhaseSvg phaseName={r.phase_name} illuminationPct={r.illumination_pct} size={20} />}
           score={r.score_components.moon}
-          scoreTip={<>25% of the composite — Krisciunas &amp; Schaefer scattered-moonlight model: phase, moon altitude, and hours above the horizon, distance-corrected. A bright moon that sets early can still score well.</>}
+          scoreTip={<>25% of the composite — scattered-moonlight model: phase, moon altitude, and hours above the horizon, distance-corrected. A bright moon that sets early can still score well.</>}
         />
         </div>
         </div>

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -253,6 +253,8 @@ function ksDeltaMag(illuminationPct: number, sepDeg: number, moonAltDeg: number)
 }
 
 // None = negligible, 'minor', 'moderate', 'severe' (mirrors moon_wash_severity)
+// Legacy local approximation — kept only as the fallback for reports cached
+// before the backend started serializing severity (see resolveMoonSeverity).
 export function moonWashSeverity(
   illuminationPct: number,
   sepDeg: number | null,
@@ -263,6 +265,34 @@ export function moonWashSeverity(
   if (delta < 0.50) return 'minor'
   if (delta < 1.50) return 'moderate'
   return 'severe'
+}
+
+// Prefer the backend-serialized severity (site SQM + AOD + slant path aware;
+// 'none' = computed and negligible). Fall back to the local approximation
+// only when the report predates the field.
+export function resolveMoonSeverity(
+  serialized: string | null | undefined,
+  illuminationPct: number,
+  sepDeg: number | null,
+  moonAltDeg: number | null,
+): string | null {
+  if (serialized != null) return serialized === 'none' ? null : serialized
+  return moonWashSeverity(illuminationPct, sepDeg, moonAltDeg)
+}
+
+// Aerosol-amplification education tip: shown when the moonwash is significant
+// AND the night's aerosol load is high enough that smoke/haze is a real
+// contributor. 0.2 sits deliberately below the 0.3 haze-icon gate — Mie
+// forward-scattering amplifies moonlight before the sky reads as hazy.
+export const AOD_AMPLIFY_TIP_THRESH = 0.2
+export const AOD_AMPLIFY_TIP_COPY =
+  'High levels of atmospheric smoke/haze are actively catching and amplifying the moonlight across the sky.'
+export function showAodAmplifyTip(
+  severity: string | null,
+  nightAod: number | null | undefined,
+): boolean {
+  return (severity === 'moderate' || severity === 'severe')
+    && nightAod != null && nightAod > AOD_AMPLIFY_TIP_THRESH
 }
 
 // Is the moon above the horizon at the given ISO time?

--- a/apps/web/src/report/Aurora.tsx
+++ b/apps/web/src/report/Aurora.tsx
@@ -62,6 +62,7 @@ export function auroraAlert(r: NightReport): AuroraAlert | null {
     const factors: string[] = []
     if (a.blockers.includes('cloud')) factors.push('partial cloud cover during the aurora window')
     if (a.light_dome_caution) factors.push(`the light dome toward the ${a.look_direction}`)
+    if (a.moonlight_caution) factors.push('moonlight raising the sky background')
     return {
       aurora: a, state: 'degraded',
       prefix: lead + tierClause.replace(/\.$/, ''),

--- a/apps/web/src/report/MilkyWay.tsx
+++ b/apps/web/src/report/MilkyWay.tsx
@@ -137,7 +137,7 @@ export function MoonBadge({ type, severity, aodTip }: { type: 'penalty' | 'limit
   const base = type === 'penalty' ? 'Moon interference' : 'Moon limited'
   const text = severity ? `${base}: ${severity}` : base
   return (
-    <InfoTip tip={<>Moon wash — scattered moonlight brightening the sky along this line of sight (Krisciunas &amp; Schaefer 1991; Winkler 2022). Severity comes from phase, moon altitude, angular separation, and aerosols, not illumination % alone.{aodTip ? <> {AOD_AMPLIFY_TIP_COPY}</> : null}</>}>
+    <InfoTip tip={<>Moon wash — scattered moonlight brightening the sky along this line of sight. Severity comes from phase, moon altitude, angular separation, and aerosols, not illumination % alone.{aodTip ? <> {AOD_AMPLIFY_TIP_COPY}</> : null}</>}>
       <span className="mw-moon-badge">{text}</span>
     </InfoTip>
   )

--- a/apps/web/src/report/MilkyWay.tsx
+++ b/apps/web/src/report/MilkyWay.tsx
@@ -81,8 +81,14 @@ export function WaypointsAccordion({ waypoints, summary, report }: {
                 report.illumination_pct, report.moonrise, report.moonset,
                 w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg, w.moon_wash_severity,
               )
+              const wpAodTip = showAodAmplifyTip(
+                resolveMoonSeverity(w.moon_wash_severity, report.illumination_pct,
+                                    w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg),
+                report.night_aod,
+              )
+              const moonBadgeSpan = <span className={`tg-sky-inline ${skyClass(sky)}`}>{' '}{sky}</span>
               const moonBadge = sky.startsWith('Moon')
-                ? <span className={`tg-sky-inline ${skyClass(sky)}`}>{' '}{sky}</span>
+                ? (wpAodTip ? <InfoTip tip={<>{AOD_AMPLIFY_TIP_COPY}</>}>{moonBadgeSpan}</InfoTip> : moonBadgeSpan)
                 : null
               return (
                 <tr key={t.name}>

--- a/apps/web/src/report/MilkyWay.tsx
+++ b/apps/web/src/report/MilkyWay.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react'
 import type { NightReport, VisibleTarget, MilkyWaySummary, Direction } from '../types'
-import { formatTime, cardinal, rateConditions, scoreBand, scoreLabel, moonWashSeverity } from '../format'
+import { formatTime, cardinal, rateConditions, scoreBand, scoreLabel, resolveMoonSeverity, showAodAmplifyTip, AOD_AMPLIFY_TIP_COPY } from '../format'
 import { ScoreBar, InfoTip } from '../shared'
 import { WmoIcon } from './icons'
 import { fmtPos } from './common'
@@ -79,7 +79,7 @@ export function WaypointsAccordion({ waypoints, summary, report }: {
               const sky = skyCondition(
                 bestT, report.dark_intervals, report.night_start, report.night_end,
                 report.illumination_pct, report.moonrise, report.moonset,
-                w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg,
+                w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg, w.moon_wash_severity,
               )
               const moonBadge = sky.startsWith('Moon')
                 ? <span className={`tg-sky-inline ${skyClass(sky)}`}>{' '}{sky}</span>
@@ -127,11 +127,11 @@ export function WaypointsAccordion({ waypoints, summary, report }: {
   )
 }
 
-export function MoonBadge({ type, severity }: { type: 'penalty' | 'limited'; severity?: string | null }) {
+export function MoonBadge({ type, severity, aodTip }: { type: 'penalty' | 'limited'; severity?: string | null; aodTip?: boolean }) {
   const base = type === 'penalty' ? 'Moon interference' : 'Moon limited'
   const text = severity ? `${base}: ${severity}` : base
   return (
-    <InfoTip tip={<>Moon wash — scattered moonlight brightening the sky along this line of sight (Krisciunas &amp; Schaefer 1991). Severity comes from phase, moon altitude, and angular separation, not illumination % alone.</>}>
+    <InfoTip tip={<>Moon wash — scattered moonlight brightening the sky along this line of sight (Krisciunas &amp; Schaefer 1991; Winkler 2022). Severity comes from phase, moon altitude, angular separation, and aerosols, not illumination % alone.{aodTip ? <> {AOD_AMPLIFY_TIP_COPY}</> : null}</>}>
       <span className="mw-moon-badge">{text}</span>
     </InfoTip>
   )
@@ -741,11 +741,13 @@ export function MilkyWayCard({ summary, waypoints, report }: {
   const bestLabel = 'Best time'
   const bestTime  = s.best_viewing_time ?? (s.core_peak_in_window ? s.core_peak_time : s.arch_end)
 
-  const moonSeverity = moonWashSeverity(
+  const moonSeverity = resolveMoonSeverity(
+    s.core_moon_severity,
     report.illumination_pct,
     s.core_moon_sep_deg ?? null,
     s.core_moon_alt_deg ?? null,
   )
+  const moonAodTip = showAodAmplifyTip(moonSeverity, report.night_aod)
 
       return (
     <div className="mw-card">
@@ -767,7 +769,7 @@ export function MilkyWayCard({ summary, waypoints, report }: {
           <span className="meta-v">
             {formatTime(s.arch_start, tz)} – {formatTime(s.arch_end, tz)}
             {'  ·  '}{Math.floor(s.arch_hours)}h {Math.round((s.arch_hours % 1) * 60).toString().padStart(2,'0')}m
-            {s.moon_limited && !s.arch_moon_washout && <MoonBadge type="limited" severity={moonSeverity} />}
+            {s.moon_limited && !s.arch_moon_washout && <MoonBadge type="limited" severity={moonSeverity} aodTip={moonAodTip} />}
             {s.weather_limited && !s.weather_blocked && <span className="mw-moon-badge">{`${s.clear_arch_hours.toFixed(1)}h clear`}</span>}
           </span>
         </div>
@@ -797,7 +799,7 @@ export function MilkyWayCard({ summary, waypoints, report }: {
         </div>
 
         <div className="mw-notes-container">
-          {s.moon_penalised && !s.arch_moon_washout && <MoonBadge type="penalty" severity={moonSeverity} />}
+          {s.moon_penalised && !s.arch_moon_washout && <MoonBadge type="penalty" severity={moonSeverity} aodTip={moonAodTip} />}
           {s.arch_moon_washout && <span className="mw-moon-badge">Moon washout</span>}
           {domeSections.length > 0 && (() => {
             const maxGlow  = Math.max(...domeSections.map(ds => ds.glow))

--- a/apps/web/src/report/Targets.tsx
+++ b/apps/web/src/report/Targets.tsx
@@ -149,7 +149,7 @@ export function MeteorShowerCard({ target, zhr, report }: {
         </span>
         {w.local_rate_at_peak != null && (
           <span className="ms-local-rate">
-            <InfoTip tip={<>Peak ZHR adjusted for tonight's decay-from-peak and radiant altitude — the rate you'd actually observe, not the idealized zenith figure.</>}>
+            <InfoTip tip={<>Peak ZHR adjusted for tonight's decay-from-peak, radiant altitude, and the limiting magnitude under your moonlit local sky — the rate you'd actually observe, not the idealized zenith figure.</>}>
               ~{Math.round(w.local_rate_at_peak)}/hr locally
             </InfoTip>
           </span>

--- a/apps/web/src/report/Targets.tsx
+++ b/apps/web/src/report/Targets.tsx
@@ -196,6 +196,7 @@ const _BLOCKER_PRIORITY: [string, string, string][] = [
   ['cloud', 'Clouded out', 'weather'],
   ['transparency', 'Clouded out', 'weather'],
   ['moon_washout', 'Moon washout', 'moonwash'],
+  ['moonlight', 'Moon-brightened sky', 'moonwash'],
   ['light_dome', 'Lost in light dome', 'light pollution'],
   ['low_radiant', 'Radiant too low', 'low radiant'],
 ]

--- a/apps/web/src/report/Targets.tsx
+++ b/apps/web/src/report/Targets.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import type { NightReport, TargetWindow, VisibleTarget, WeatherPoint } from '../types'
-import { formatTime, formatDayTime, cardinal, rateConditions, scoreBand, moonWashSeverity, moonUpAt } from '../format'
+import { formatTime, formatDayTime, cardinal, rateConditions, scoreBand, resolveMoonSeverity, moonUpAt, showAodAmplifyTip, AOD_AMPLIFY_TIP_COPY } from '../format'
 import { InfoTip } from '../shared'
 import { WmoIcon } from './icons'
 import { fmtPos } from './common'
@@ -52,6 +52,7 @@ export function skyCondition(
   moonset:  string | null,
   moonSepAtPeak:  number | null,
   moonAltAtPeak:  number | null,
+  serializedSeverity?: string | null,
 ): string {
   const pt = new Date(peakIso).getTime()
 
@@ -65,7 +66,7 @@ export function skyCondition(
   }
 
   if (moonUpAt(peakIso, moonrise, moonset)) {
-    const sev = moonWashSeverity(illuminationPct, moonSepAtPeak, moonAltAtPeak)
+    const sev = resolveMoonSeverity(serializedSeverity, illuminationPct, moonSepAtPeak, moonAltAtPeak)
     if (sev) return `Moon wash: ${sev}`
   }
   return base
@@ -133,10 +134,15 @@ export function MeteorShowerCard({ target, zhr, report }: {
     ? skyCondition(
         w.peak_time, report.dark_intervals, report.night_start, report.night_end,
         report.illumination_pct, report.moonrise, report.moonset,
-        w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg,
+        w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg, w.moon_wash_severity,
       )
     : null
   const skyCls = sky ? skyClass(sky) : ''
+  const aodTip = showAodAmplifyTip(
+    resolveMoonSeverity(w.moon_wash_severity, report.illumination_pct,
+                        w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg),
+    report.night_aod,
+  )
 
   return (
     <div className="ms-card">
@@ -172,7 +178,13 @@ export function MeteorShowerCard({ target, zhr, report }: {
           {sky && (
             <div className="mw-row">
               <span className="mw-label">Sky</span>
-              <span className={`tg-sky ${skyCls}`}>{sky}</span>
+              {aodTip ? (
+                <InfoTip tip={<>{AOD_AMPLIFY_TIP_COPY}</>}>
+                  <span className={`tg-sky ${skyCls}`}>{sky}</span>
+                </InfoTip>
+              ) : (
+                <span className={`tg-sky ${skyCls}`}>{sky}</span>
+              )}
             </div>
           )}
           {(w.blockers?.length ?? 0) > 0 && (
@@ -454,7 +466,7 @@ export function TargetsTable({ targets, report }: { targets: VisibleTarget[]; re
         ? skyCondition(
             peakForSky, report.dark_intervals, report.night_start, report.night_end,
             report.illumination_pct, report.moonrise, report.moonset,
-            w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg,
+            w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg, w.moon_wash_severity,
           )
         : '—'
       const skyCls = skyClass(sky)
@@ -466,6 +478,11 @@ export function TargetsTable({ targets, report }: { targets: VisibleTarget[]; re
         ? (moonIsUpAtPeak ? ' · moon wash minimal' : ' · pre-moonrise')
         : null
       const showSkyBadge = sky !== 'Dark sky' && sky !== '—'
+      const aodTip = showAodAmplifyTip(
+        resolveMoonSeverity(w.moon_wash_severity, report.illumination_pct,
+                            w.moon_sep_at_peak_deg, w.moon_alt_at_peak_deg),
+        report.night_aod,
+      )
 
       peakJsx = (
         <>
@@ -473,9 +490,17 @@ export function TargetsTable({ targets, report }: { targets: VisibleTarget[]; re
           <span className="tg-p"> · Alt </span><Alt deg={effectiveBestAlt} />
           <span className="tg-p"> Az </span><Az az={w.peak_az_deg} /><span className="tg-p"> </span><Dir az={w.peak_az_deg} />
           {showSkyBadge && (
-            <span className={`tg-sky-inline ${skyCls}`}>
-              {' '}{sky}{moonNoteText ? <span className="tg-moon-note">{moonNoteText}</span> : null}
-            </span>
+            aodTip ? (
+              <InfoTip tip={<>{AOD_AMPLIFY_TIP_COPY}</>}>
+                <span className={`tg-sky-inline ${skyCls}`}>
+                  {' '}{sky}{moonNoteText ? <span className="tg-moon-note">{moonNoteText}</span> : null}
+                </span>
+              </InfoTip>
+            ) : (
+              <span className={`tg-sky-inline ${skyCls}`}>
+                {' '}{sky}{moonNoteText ? <span className="tg-moon-note">{moonNoteText}</span> : null}
+              </span>
+            )
           )}
           {!showSkyBadge && moonNoteText && (
             <span className="tg-moon-note">{' '}{moonNoteText}</span>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -41,6 +41,10 @@ export interface TargetWindow {
   moon_interference: boolean
   moon_sep_at_peak_deg: number | null
   moon_alt_at_peak_deg: number | null
+  // Backend severity at peak (site SQM + AOD + slant path aware); 'none' =
+  // computed and negligible; null/absent = geometry unavailable or pre-field
+  // cached report (fall back to the local mirror via resolveMoonSeverity).
+  moon_wash_severity?: 'none' | 'minor' | 'moderate' | 'severe' | null
   photo_cutoff: string | null   // last moment viable for astrophotography
   visual_cutoff: string | null  // last moment viable for visual observation
   // Phase 1: Condition Vectors
@@ -50,7 +54,9 @@ export interface TargetWindow {
   blockers: string[]                // e.g. ["cloud", "transparency", "light_dome", "moon_washout", "low_radiant"]
   weather_score_at_best: number | null  // rate_conditions() score (1–10) at best_time
   dome_glow_at_peak: number | null  // glow_toward() value at peak az/alt; null outside CONUS
-  local_rate_at_peak: number | null // meteor showers only: zhr_effective × sin(radiant_alt)
+  local_rate_at_peak: number | null // meteor showers only: zhr_effective × sin(radiant_alt) × lm_factor
+  // meteor showers only: r^(lm − 6.5) limiting-magnitude degradation (1 = pristine)
+  lm_factor_at_peak?: number | null
 }
 
 export interface VisibleTarget {
@@ -196,6 +202,8 @@ export interface MilkyWaySummary {
   core_max_alt_deg:     number
   core_moon_sep_deg:    number | null   // moon angular separation from galactic core at peak
   core_moon_alt_deg:    number | null   // moon altitude at core peak (K&S input)
+  // Backend severity at core peak; 'none' = negligible, absent = pre-field report
+  core_moon_severity?:  'none' | 'minor' | 'moderate' | 'severe' | null
 }
 
 // ── Light dome (horizon glow) ─────────────────────────────────────────────────
@@ -257,6 +265,9 @@ export interface NightReport {
   wx_pending: boolean
   wx_no_data: boolean
   wx_error: string | null
+  // Night-median aerosol optical depth (moonlight model input); null when
+  // unavailable, absent on pre-field cached reports
+  night_aod?: number | null
   score: number
   score_components: ScoreComponents
   visible_targets: VisibleTarget[]

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -121,6 +121,9 @@ export interface AuroraForecast {
   look_direction: string               // 16-wind label, e.g. 'NNW'
   blockers: string[]
   light_dome_caution: boolean
+  // Moonlight raises the emission-source background; tier-scaled, degrades only.
+  // Optional: absent on reports cached before this field shipped.
+  moonlight_caution?: boolean
   viability: 'ok' | 'degraded' | 'blocked'
   stale: boolean
 }

--- a/docs/PYNIGHTSKY.md
+++ b/docs/PYNIGHTSKY.md
@@ -61,11 +61,14 @@ The geometric mean means every factor influences the result proportionally, and 
 
 ---
 
-## Moonlight Modeling (Krisciunas & Schaefer 1991)
+## Moonlight Modeling (K&S 1991 × Winkler 2022 hybrid)
 
-PyNightSkyPredictor models scattered moonlight using the empirical photometric model of **Krisciunas, K. & Schaefer, B. E. (1991)**, *"A model of the brightness of moonlight,"* PASP 103(667), 1033–1039. [doi:10.1086/132921](https://doi.org/10.1086/132921)
+PyNightSkyPredictor models scattered moonlight with a hybrid of two photometric models:
 
-The model computes the sky surface brightness increase (Δ mag/arcsec²) at any sky position given the moon's illumination, altitude, and angular separation from the target. It accounts for the moon's phase-dependent luminosity, atmospheric extinction along the moon's air-mass path, and a scattering phase function that produces the characteristic brightening both near the moon *and* at the antisolar point.
+- **Krisciunas, K. & Schaefer, B. E. (1991)**, *"A model of the brightness of moonlight,"* PASP 103(667), 1033–1039. [doi:10.1086/132921](https://doi.org/10.1086/132921) — the phase-dependent lunar luminosity and the optical-pathlength form.
+- **Winkler, H. (2022)**, *"A revised simplified scattering model for the moonlit sky brightness profile based on photometry at SAAO,"* MNRAS 514(1), 208–226. [doi:10.1093/mnras/stac1387](https://doi.org/10.1093/mnras/stac1387) — the single-scatter kernel with correct lunar-beam extinction, and the two-component Rayleigh + Henyey–Greenstein (g = 0.8) phase function.
+
+The model computes the sky surface brightness increase (Δ mag/arcsec²) at any sky position given the moon's illumination, altitude, angular separation from the target, the target's own altitude (slant path), and the atmosphere's aerosol load. Extinction is a live optical-depth decomposition (Rayleigh + aerosol + ozone) rather than a fixed coefficient: the **aerosol optical depth (AOD)** forecast from Open-Meteo's air-quality API (CAMS) feeds in as the night's median, so wildfire smoke and haze both dim the lunar beam and *amplify* the forward-scattered aureole near the moon — smoke brightens the sky near the moon while dimming it far away. When AOD is unavailable (past dates, fetch failure, beyond the ~7-day air-quality horizon) the model falls back to a reference clear sky whose extinction equals the classic k = 0.172 exactly. The normalisation anchors the new kernel to the legacy K&S intensity at the site-wide proxy geometry, so nightly planning scores are unchanged at reference conditions (verified by `scripts/verify_moonwash_grid.py`).
 
 ### Why it matters
 
@@ -97,7 +100,7 @@ K&S is inherently directional — it depends on where you're looking relative to
 - **90° separation** is the darkest accessible sky position: the scattering function reaches its minimum there (the cos²ρ term vanishes), representing the best realistic position when the moon is up
 - **30° altitude** is a representative mid-sky moon position over the course of an evening
 
-For per-target evaluation, the actual moon–target separation and moon altitude are computed from the Skyfield ephemeris at each 20-minute sample window.
+For per-target evaluation, the actual moon–target separation, moon altitude, and target altitude are computed from the Skyfield ephemeris at each 10-minute sample.
 
 ### How it affects the output
 
@@ -105,11 +108,17 @@ For per-target evaluation, the actual moon–target separation and moon altitude
 
 **Clear Dark Sky Hours** — When illumination is ≤ 20% (imperceptible-to-minor impact at any altitude), the full astronomical window is reported as dark sky time. When weather data is available, each dark interval is further clipped to hours where cloud cover ≤ 30%.
 
-**Astro Window per target** — K&S is evaluated at the actual moon–target separation and altitude at every 20-minute sample. The window is clipped when Δmag exceeds the per-type contrast threshold (nebulae/galaxies: surface brightness − sky background − 3.2 mag; clusters: integrated magnitude − site SQM − 13.0; Milky Way: surface brightness − sky background − 1.5 mag).
+**Astro Window per target** — the model is evaluated at the actual moon–target separation, moon altitude, and target altitude at every 10-minute sample. The window is clipped when Δmag exceeds the per-type contrast threshold (nebulae/galaxies: surface brightness − sky background − 3.2 mag; clusters: integrated magnitude − site SQM − 13.0; Milky Way: surface brightness − sky background − 1.5 mag).
 
 **Light pollution interaction** — The site's SQM enters the K&S denominator as the natural-sky baseline. On a darker site the same moon produces less fractional brightening; on a light-polluted site the moon adds less on top of what is already a degraded sky.
 
 **Earth-Moon distance correction** — K&S (1991) assumes the Moon at its mean distance of 384,400 km. The actual distance varies ±8.5%, translating to up to ±0.35 mag/arcsec² error on supermoon/micromoon nights. PyNightSkyPredictor corrects via the inverse-square law: the lunar irradiance is scaled by `(mean_dist / actual_dist)²` at every sample, applied to both site-wide score and per-target evaluations.
+
+**Meteor shower local rates** — `local_rate_at_peak` applies the standard IMO visual-rate correction on top of the decay model and radiant geometry: rate = ZHR_effective × sin(radiant alt) × min(1, r^(lm − 6.5)), where lm is the naked-eye limiting magnitude (NELM = 7.93 − 5·log₁₀(10^(4.316 − SQM/5) + 1)) under the moon-brightened site sky and r is the shower's magnitude-distribution (population) index from the catalog. Faint-meteor-rich showers (Delta Aquariids, r = 3.2) collapse under moonlight or city skies far harder than fireball-rich ones (Perseids, r = 2.2).
+
+**Aurora moon factor** — aurora is an emission source, so moonlight raises the background it must be seen against rather than washing the source. The aurora condition vector degrades (never blocks) tier-scaled: photographic-tier nights at Δ ≥ 0.50 mag/arcsec², naked-eye at ≥ 1.50, and overhead storms punch through any moon.
+
+**Deliberate AOD exclusions** — `ks_moon_credit` (moon_score, calendar dark-cycle scores) always evaluates at the reference sky: planning scores must not wobble with 30-minute weather refetches, and the calendar path fetches no weather at all.
 
 ---
 

--- a/scripts/verify_moonwash_grid.py
+++ b/scripts/verify_moonwash_grid.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Calibration verification grid: legacy simplified-K&S vs Winkler-patched model.
+
+Compares Δ mag/arcsec² and severity buckets across an illumination × separation
+× moon-altitude × target-altitude grid at reference AOD (aod=None), plus the
+ks_moon_credit curve.  Gate (docs in plan / memory note):
+
+  (a) credit endpoints unchanged (bit-identical by _KS_NORM construction);
+  (b) severity bucket flips in the calibrated regime — sep ≥ 45°, moon alt
+      ≥ 30°, target alt = 45° — affect < 10% of those cells and never jump
+      two buckets.  The 0.10/0.50/1.50 thresholds were tuned with NO
+      target-altitude dimension (legacy model had none; every severity
+      consumer uses the 45° default), so the tuned geometry is talt = 45°.
+  (c) target alt 20°/70° rows show the NEW slant-path physics the legacy
+      model could not represent, and near-moon (sep ≤ 20°) / low-moon
+      (alt ≤ 15°) brightening is the Mie aureole + finite-horizon
+      pathlength fix — both reported for documentation, not gated.
+
+Run: .venv/bin/python scripts/verify_moonwash_grid.py
+Exits non-zero if the gate fails.
+"""
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PyNightSkyPredictor import moonlight as m  # noqa: E402
+
+# --- frozen legacy model (verbatim pre-Winkler ks_delta_mag) -----------------
+
+_LEGACY_K_EXT = 0.172
+
+
+def ks_delta_mag_legacy(illumination_pct, sep_deg, moon_alt_deg,
+                        sky_sqm=21.6, moon_earth_dist_km=384_400.0):
+    if illumination_pct <= 0 or moon_alt_deg <= 0:
+        return 0.0
+    illum  = illumination_pct / 100.0
+    alpha  = math.degrees(math.acos(max(-1.0, min(1.0, 2.0 * illum - 1.0))))
+    V_moon = -12.73 + 0.026 * alpha + 4e-9 * alpha**4
+    I_moon = 10 ** (-0.4 * (V_moon + 16.57))
+    I_moon *= (384_400.0 / moon_earth_dist_km) ** 2
+    alt    = max(1.0, moon_alt_deg)
+    X_moon = 1.0 / math.cos(math.radians(90.0 - alt))
+    ext    = 10 ** (-0.4 * _LEGACY_K_EXT * X_moon)
+    rho     = max(0.1, sep_deg)
+    rho_rad = math.radians(rho)
+    if rho > 10.0:
+        f_rho = 10 ** 5.36 * (1.06 + math.cos(rho_rad) ** 2)
+    else:
+        f_rho = 6.2e7 / rho ** 2
+    I_scatter = f_rho * ext * I_moon
+    I_sky     = 10 ** ((27.78 - sky_sqm) / 2.5)
+    return 2.5 * math.log10(1.0 + I_scatter / I_sky)
+
+
+def severity(delta):
+    if delta < 0.10:
+        return "none"
+    if delta < 0.50:
+        return "minor"
+    if delta < 1.50:
+        return "moderate"
+    return "severe"
+
+
+_BUCKETS = ["none", "minor", "moderate", "severe"]
+
+ILLUMS      = [5, 15, 30, 50, 75, 100]
+SEPS        = [5, 10, 20, 45, 90, 120]
+MOON_ALTS   = [5, 15, 30, 60]
+TARGET_ALTS = [20, 45, 70]
+
+
+def main():
+    confusion = {}          # (old_bucket, new_bucket) -> count in calibrated regime
+    calib_cells = 0
+    calib_flips = 0
+    two_bucket_jumps = []
+    exempt_rows = []        # near-moon / low-moon documentation
+
+    print(f"{'illum':>5} {'sep':>4} {'malt':>4} {'talt':>4} "
+          f"{'d_old':>7} {'d_new':>7} {'diff':>7}  old->new")
+    for il in ILLUMS:
+        for sep in SEPS:
+            for malt in MOON_ALTS:
+                for talt in TARGET_ALTS:
+                    d_old = ks_delta_mag_legacy(il, sep, malt)
+                    d_new = m.ks_delta_mag(il, sep, malt, target_alt_deg=talt)
+                    b_old, b_new = severity(d_old), severity(d_new)
+                    calibrated = sep >= 45 and malt >= 30 and talt == 45
+                    exempt = sep <= 20 or malt <= 15 or talt != 45
+                    marker = ""
+                    if calibrated:
+                        calib_cells += 1
+                        confusion[(b_old, b_new)] = confusion.get((b_old, b_new), 0) + 1
+                        if b_old != b_new:
+                            calib_flips += 1
+                            marker = "  <-- FLIP (calibrated regime)"
+                            jump = abs(_BUCKETS.index(b_old) - _BUCKETS.index(b_new))
+                            if jump >= 2:
+                                two_bucket_jumps.append((il, sep, malt, talt, b_old, b_new))
+                    elif exempt and b_old != b_new:
+                        exempt_rows.append((il, sep, malt, talt, d_old, d_new, b_old, b_new))
+                        marker = "  (exempt: new physics — slant path / aureole)"
+                    print(f"{il:>5} {sep:>4} {malt:>4} {talt:>4} "
+                          f"{d_old:>7.3f} {d_new:>7.3f} {d_new-d_old:>+7.3f}  "
+                          f"{b_old}->{b_new}{marker}")
+
+    print("\n--- ks_moon_credit curve (must be identical) ---")
+    max_credit_diff = 0.0
+    for il in range(0, 101, 5):
+        d_anchor_old = ks_delta_mag_legacy(il, 90.0, 30.0)
+        credit_old = max(0.0, 1.0 - d_anchor_old / 1.50)
+        credit_new = m.ks_moon_credit(il)
+        max_credit_diff = max(max_credit_diff, abs(credit_old - credit_new))
+        print(f"  illum {il:>3}%  old {credit_old:.6f}  new {credit_new:.6f}")
+
+    print("\n--- severity confusion matrix (calibrated regime: sep>=45, moon alt>=30, talt=45) ---")
+    for bo in _BUCKETS:
+        row = "  ".join(f"{confusion.get((bo, bn), 0):>4}" for bn in _BUCKETS)
+        print(f"  old {bo:>8} -> {row}")
+
+    flip_pct = 100.0 * calib_flips / calib_cells if calib_cells else 0.0
+    print(f"\ncalibrated cells: {calib_cells}, flips: {calib_flips} ({flip_pct:.1f}%)")
+    print(f"two-bucket jumps in calibrated regime: {len(two_bucket_jumps)}")
+    print(f"max ks_moon_credit diff: {max_credit_diff:.2e}")
+    print(f"exempt-region bucket changes (documented, not gated): {len(exempt_rows)}")
+
+    ok = (max_credit_diff < 1e-12) and (flip_pct < 10.0) and not two_bucket_jumps
+    print("\nGATE:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_aurora_model.py
+++ b/tests/test_aurora_model.py
@@ -352,3 +352,83 @@ class TestTripAurora:
         ))
         d.pop("aurora")
         assert trip._from_dict(d).aurora is None
+
+
+# ---------------------------------------------------------------------------
+# Moonlight factor (tier-scaled, degrades only)
+# ---------------------------------------------------------------------------
+
+class TestMoonlightFactor:
+    _WIN = (datetime(2026, 3, 1, 22, 0, tzinfo=_UTC),
+            datetime(2026, 3, 2, 2, 0, tzinfo=_UTC))
+
+    def _track(self, alt):
+        """Constant-altitude moon track covering the window."""
+        t0, t1 = self._WIN
+        out, t = [], t0
+        while t <= t1:
+            out.append((t, alt))
+            t += timedelta(minutes=30)
+        return out
+
+    def _cv(self, tier, illum, moon_alt=45.0, moon_alts=None):
+        return a._condition_vector(
+            *self._WIN, None, None, 0.0,
+            tier=tier, moon_illum_pct=illum,
+            moon_alts=self._track(moon_alt) if moon_alts is None else moon_alts,
+        )
+
+    def test_full_moon_degrades_photographic(self):
+        blockers, viability, _, moon_caution = self._cv("photographic", 100.0)
+        assert "moonlight" in blockers
+        assert viability == "degraded"
+        assert moon_caution is True
+
+    def test_gibbous_degrades_photographic_but_not_naked_eye(self):
+        """Δ ≈ 1.34 at 40% illumination: over the photographic threshold (0.50),
+        under the naked-eye one (1.50)."""
+        b_photo, v_photo, _, c_photo = self._cv("photographic", 40.0)
+        b_naked, v_naked, _, c_naked = self._cv("naked_eye", 40.0)
+        assert c_photo and "moonlight" in b_photo and v_photo == "degraded"
+        assert not c_naked and "moonlight" not in b_naked and v_naked == "ok"
+
+    def test_full_moon_degrades_naked_eye(self):
+        blockers, viability, _, moon_caution = self._cv("naked_eye", 100.0)
+        assert moon_caution and "moonlight" in blockers and viability == "degraded"
+
+    def test_overhead_tier_punches_through_any_moon(self):
+        blockers, viability, _, moon_caution = self._cv("overhead", 100.0)
+        assert not moon_caution and "moonlight" not in blockers and viability == "ok"
+
+    def test_crescent_degrades_nothing(self):
+        blockers, viability, _, moon_caution = self._cv("photographic", 15.0)
+        assert not moon_caution and blockers == [] and viability == "ok"
+
+    def test_moon_below_horizon_no_caution(self):
+        blockers, viability, _, moon_caution = self._cv("photographic", 100.0, moon_alt=-10.0)
+        assert not moon_caution and blockers == [] and viability == "ok"
+
+    def test_fail_open_without_track(self):
+        """moon_alts=None (no ephemeris) → fail-open like missing weather."""
+        blockers, viability, _, moon_caution = a._condition_vector(
+            *self._WIN, None, None, 0.0,
+            tier="photographic", moon_illum_pct=100.0, moon_alts=None)
+        assert not moon_caution and blockers == [] and viability == "ok"
+
+    def test_moonlight_caution_in_result_dict(self):
+        rows = _rows(("2026-03-01 21:00:00", 7.0), ("2026-03-02 00:00:00", 7.0),
+                     ("2026-03-02 03:00:00", 7.0))
+        out = a.nightly_aurora(_MINNEAPOLIS[0], _MINNEAPOLIS[1],
+                               *self._WIN, kp_rows=rows,
+                               moon_illum_pct=100.0, moon_alts=self._track(45.0))
+        assert out is not None
+        assert "moonlight_caution" in out
+        assert isinstance(out["moonlight_caution"], bool)
+
+    def test_result_dict_defaults_false_without_moon_data(self):
+        rows = _rows(("2026-03-01 21:00:00", 7.0), ("2026-03-02 00:00:00", 7.0),
+                     ("2026-03-02 03:00:00", 7.0))
+        out = a.nightly_aurora(_MINNEAPOLIS[0], _MINNEAPOLIS[1],
+                               *self._WIN, kp_rows=rows)
+        assert out is not None
+        assert out["moonlight_caution"] is False

--- a/tests/test_condition_vectors.py
+++ b/tests/test_condition_vectors.py
@@ -53,10 +53,11 @@ def _make_target(window):
     return VisibleTarget(name="M42", type="nebula", windows=[window], note=None)
 
 
-def _make_shower_target(window, zhr_effective=100.0):
+def _make_shower_target(window, zhr_effective=100.0, population_index=None):
     return VisibleTarget(
         name="Perseids", type="meteor_shower", windows=[window], note="Peak night",
         zhr_effective=zhr_effective,
+        population_index=population_index,
     )
 
 
@@ -75,12 +76,15 @@ def _wx(offset_h, cloud=0, transparency="Excellent", humidity=50):
     )
 
 
-def _run(target, weather=None, light_dome=None, illumination=0.0):
+def _run(target, weather=None, light_dome=None, illumination=0.0,
+         sky_sqm=None, night_aod=None):
     _apply_condition_vectors(
         [target],
         weather or [],
         light_dome,
         illumination,
+        sky_sqm=sky_sqm,
+        night_aod=night_aod,
     )
 
 
@@ -429,3 +433,75 @@ def test_low_radiant_combines_with_other_blockers():
     assert "low_radiant" in w.blockers
     assert "cloud" in w.blockers
     assert t.viability == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Meteor limiting-magnitude factor (r^(lm − 6.5))
+# ---------------------------------------------------------------------------
+
+import math as _math
+
+
+def test_lm_factor_skipped_without_sqm():
+    """No site SQM → factor not computed; geometric rate preserved."""
+    w = _make_window(peak_alt=60.0, moon_alt=-10.0)
+    t = _make_shower_target(w, zhr_effective=100.0, population_index=2.2)
+    _run(t)
+    assert w.lm_factor_at_peak is None
+    assert w.local_rate_at_peak == pytest.approx(
+        round(100.0 * _math.sin(_math.radians(60.0)), 1))
+
+
+def test_lm_factor_skipped_without_population_index():
+    """No catalog r → factor not computed even with SQM (pre-field entries)."""
+    w = _make_window(peak_alt=60.0, moon_alt=-10.0)
+    t = _make_shower_target(w, zhr_effective=100.0)
+    _run(t, sky_sqm=21.6)
+    assert w.lm_factor_at_peak is None
+
+
+def test_lm_factor_caps_at_one_pristine_moonless():
+    """SQM 22.0 moonless → lm > 6.5 → factor capped at exactly 1.0."""
+    w = _make_window(peak_alt=60.0, moon_alt=-10.0)
+    t = _make_shower_target(w, zhr_effective=100.0, population_index=2.2)
+    _run(t, sky_sqm=22.0)
+    assert w.lm_factor_at_peak == 1.0
+    assert w.local_rate_at_peak == pytest.approx(
+        round(100.0 * _math.sin(_math.radians(60.0)), 1))
+
+
+def test_lm_factor_reduces_rate_under_full_moon():
+    """Full moon at 45° alt / 60° sep collapses the visual rate."""
+    w = _make_window(peak_alt=60.0, moon_alt=45.0, moon_sep=60.0)
+    t = _make_shower_target(w, zhr_effective=100.0, population_index=2.2)
+    _run(t, illumination=100.0, sky_sqm=21.6)
+    geometric = 100.0 * _math.sin(_math.radians(60.0))
+    assert w.lm_factor_at_peak is not None and w.lm_factor_at_peak < 0.5
+    assert w.local_rate_at_peak < geometric * 0.5
+
+
+def test_higher_population_index_degrades_harder():
+    """Faint-meteor-rich showers (high r) lose more under the same moon."""
+    def rate_for(r):
+        w = _make_window(peak_alt=60.0, moon_alt=45.0, moon_sep=60.0)
+        t = _make_shower_target(w, zhr_effective=100.0, population_index=r)
+        _run(t, illumination=100.0, sky_sqm=21.6)
+        return w.lm_factor_at_peak
+    assert rate_for(3.2) < rate_for(2.2)
+
+
+def test_lm_factor_bright_site_degrades_moonless():
+    """Light pollution alone (Bortle 8, no moon) already suppresses the rate."""
+    w = _make_window(peak_alt=60.0, moon_alt=-10.0)
+    t = _make_shower_target(w, zhr_effective=100.0, population_index=2.2)
+    _run(t, sky_sqm=18.0)
+    assert w.lm_factor_at_peak is not None and w.lm_factor_at_peak < 0.2
+
+
+def test_non_shower_targets_untouched_by_lm():
+    """DSO windows never get a lm factor."""
+    w = _make_window()
+    t = _make_target(w)
+    _run(t, sky_sqm=21.6)
+    assert w.lm_factor_at_peak is None
+    assert w.local_rate_at_peak is None

--- a/tests/test_moonlight.py
+++ b/tests/test_moonlight.py
@@ -163,3 +163,73 @@ class TestMoonWashSeverity:
         """Moon altitude ≤ 0 → ks_delta_mag returns 0 → severity None."""
         assert moon_wash_severity(100, 45.0, 0.0) is None
         assert moon_wash_severity(100, 45.0, -20.0) is None
+
+
+# ---------------------------------------------------------------------------
+# Winkler (2022) hybrid model: AOD, slant path, normalisation anchor
+# ---------------------------------------------------------------------------
+
+class TestWinklerModel:
+    def test_aod_none_equals_reference_aod(self):
+        """aod=None must be exactly the reference clear sky (_AOD_REF)."""
+        from PyNightSkyPredictor.moonlight import _AOD_REF
+        for illum, sep, alt in [(30, 45, 20), (80, 10, 60), (100, 120, 45)]:
+            assert ks_delta_mag(illum, sep, alt) == ks_delta_mag(illum, sep, alt, aod=_AOD_REF)
+
+    def test_norm_anchors_to_legacy_at_credit_geometry(self):
+        """_KS_NORM pins the new kernel to the legacy K&S intensity at the
+        ks_moon_credit proxy geometry, keeping the credit curve bit-identical."""
+        import math
+        legacy_ratio = 10 ** 5.36 * 1.06 * 10 ** (-0.4 * 0.172 * 2.0)  # sep 90°, moon alt 30°
+        for illum in (5, 25, 50, 75, 100):
+            alpha  = math.degrees(math.acos(max(-1.0, min(1.0, 2.0 * illum / 100.0 - 1.0))))
+            v_moon = -12.73 + 0.026 * alpha + 4e-9 * alpha ** 4
+            i_moon = 10 ** (-0.4 * (v_moon + 16.57))
+            i_sky  = 10 ** ((27.78 - 21.6) / 2.5)
+            legacy_delta = 2.5 * math.log10(1.0 + legacy_ratio * i_moon / i_sky)
+            assert ks_delta_mag(illum, 90.0, 30.0) == pytest.approx(legacy_delta, abs=1e-12)
+
+    def test_high_aod_amplifies_aureole_near_moon(self):
+        """Smoke brightens the sky near the moon (Mie forward scattering)."""
+        assert ks_delta_mag(80, 10.0, 45.0, aod=0.8) > ks_delta_mag(80, 10.0, 45.0)
+
+    def test_high_aod_dims_far_sky(self):
+        """Smoke dims the sky far from the moon (beam extinction dominates)."""
+        assert ks_delta_mag(80, 120.0, 45.0, aod=0.8) < ks_delta_mag(80, 120.0, 45.0)
+
+    def test_aod_capped(self):
+        """AOD beyond the single-scatter validity cap is clamped."""
+        assert ks_delta_mag(80, 45.0, 45.0, aod=50.0) == ks_delta_mag(80, 45.0, 45.0, aod=3.0)
+
+    def test_negative_aod_clamped_to_zero(self):
+        assert ks_delta_mag(80, 45.0, 45.0, aod=-1.0) == ks_delta_mag(80, 45.0, 45.0, aod=0.0)
+
+    def test_degenerate_airmass_continuous(self):
+        """moon alt == target alt hits the analytic kernel limit; it must be
+        finite and continuous with the neighbouring geometry."""
+        same  = ks_delta_mag(80, 45.0, 45.0, target_alt_deg=45.0)
+        near  = ks_delta_mag(80, 45.0, 45.001, target_alt_deg=45.0)
+        assert same > 0
+        assert same == pytest.approx(near, rel=1e-3)
+
+    def test_low_target_altitude_brighter(self):
+        """Longer slant path at low target altitude scatters more moonlight."""
+        low  = ks_delta_mag(80, 90.0, 30.0, target_alt_deg=20.0)
+        high = ks_delta_mag(80, 90.0, 30.0, target_alt_deg=70.0)
+        assert low > high
+
+
+class TestHelpers:
+    def test_k_ext_from_aod_reference(self):
+        from PyNightSkyPredictor.moonlight import k_ext_from_aod
+        assert k_ext_from_aod(None) == pytest.approx(0.172, abs=1e-12)
+
+    def test_k_ext_from_aod_monotonic(self):
+        from PyNightSkyPredictor.moonlight import k_ext_from_aod
+        assert k_ext_from_aod(0.5) > k_ext_from_aod(0.1) > k_ext_from_aod(0.0)
+
+    def test_nelm_known_points(self):
+        from PyNightSkyPredictor.moonlight import nelm_from_sqm
+        assert nelm_from_sqm(22.0) == pytest.approx(6.62, abs=0.02)   # pristine sky
+        assert nelm_from_sqm(18.0) == pytest.approx(3.97, abs=0.02)   # Bortle 8
+        assert nelm_from_sqm(22.0) > nelm_from_sqm(20.0) > nelm_from_sqm(18.0)


### PR DESCRIPTION
## What

Upgrades the scattered-moonlight model from the simplified K&S 1991 fit to a **K&S × Winkler 2022 hybrid** and threads live atmospheric data through everything that depends on it:

- **Model** (`moonlight.py`): Winkler (2022, MNRAS 514, 208) single-scatter kernel with the two-component Rayleigh + Henyey-Greenstein (g=0.8) phase function. The old fit had **no Mie/aerosol term at all**; restoring it is what makes aerosols physical. Extinction is now an optical-depth decomposition with **aerosol optical depth as a live input** — smoke/haze dims the lunar beam *and* amplifies the aureole near the moon. The line-of-sight slant path (`target_alt_deg`) now matters too.
- **AOD plumbing**: night-median AOD from the already-fetched Open-Meteo air-quality data, joined where the weather future already blocks — **zero added latency** (visible_targets ~48 ms vs ~46 ms on main; report time stays network-dominated). Missing AOD (past dates, fetch failure, beyond the air-quality horizon) degrades to a reference sky whose extinction equals the legacy k=0.172 **exactly**.
- **Meteors**: `local_rate_at_peak` gains the standard IMO r^(lm−6.5) limiting-magnitude correction; per-shower population indices added to the catalog. Full-moon Perseids ≈ ×0.14 of the geometric rate; city cores collapse ~15× even moonless.
- **Aurora**: tier-scaled moonlight factor in the condition vector (deferred from #105). Emission physics respected: degrades, never blocks; photographic tier at Δ≥0.50, naked-eye at ≥1.50, overhead punches through.
- **Frontend**: severity is now **backend-serialized** (site SQM + AOD + slant path aware) — the drifted TS `ksDeltaMag` mirror survives only as a fallback for stale cached reports. New aerosol-amplification education tip on severity badges when moonwash is moderate/severe AND night AOD > 0.2. Academic citations moved out of tooltips into `docs/PYNIGHTSKY.md`.

## Calibration safety

`_KS_NORM` anchors the new kernel to the legacy intensity at the credit proxy geometry, so `ks_moon_credit` — and with it moon_score and calendar dark-cycle scores — is **bit-identical** at reference AOD. `scripts/verify_moonwash_grid.py` gates the rest: 3/36 single-bucket severity flips (8.3%) at the tuned geometry, zero two-bucket jumps, credit curve diff 0.00e+00.

## Expected product changes (intentional physics, not drift)

- Low-moon / low-target-altitude skies read brighter (restored Mie aureole + finite-horizon pathlength) → photo cutoffs clip slightly earlier near moonrise/set; a couple of marginal targets shift photo-viability under a bright moon.
- Under high AOD, near-moon targets get suppressed while far-from-moon targets can become *viable* (beam extinction) — verified both directions.
- Serialized severities use site SQM where the old TS mirror hardcoded 21.6 — bright-site users see different (correct) labels.
- Faint-meteor showers now honestly report near-zero city rates; the meteor banner correctly disappears on moon-washed nights.
- `ks_moon_credit` deliberately ignores AOD (planning-score stability across 30-min weather refetches; calendar path has no weather) — commented in code.

## Testing

- 763 passed, 9 skipped (27 new hermetic tests: kernel anchors, AOD monotonicity both directions, meteor lm behaviour, aurora tiers incl. fail-open).
- `tsc --noEmit` clean.
- End-to-end verified against live providers (real night_aod 0.22 near Boise) and in the browser preview: serialized severities, aurora card, meteor local rates, aerosol tip gate ON/OFF, red-mode rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)