### PR TITLE
Drop unused fiona dependency; fix Vite dev-server CI shortcuts crash

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "CI=true vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,7 +7,6 @@
 # Install: pip install -r requirements-build.txt
 geopandas
 pyarrow
-fiona
 h3
 rasterio==1.5.0
 osmium          # pyosmium — parses .osm.pbf for scripts/osm_poi_builder.py

--- a/scripts/build_padus_index.py
+++ b/scripts/build_padus_index.py
@@ -22,7 +22,7 @@ public land cell the park name is returned directly; if it lands on a blackliste
 --- DEPENDENCIES ---
 
     pip install -r requirements-build.txt
-    # or individually: geopandas pyarrow fiona h3
+    # or individually: geopandas pyarrow h3
 
 --- USAGE ---
 


### PR DESCRIPTION
## Summary
- Remove `fiona` from `requirements-build.txt` — geopandas 1.1.3 no longer depends on it (uses pyogrio now), and nothing in the codebase imports it directly; confirmed via full test suite pass.
- Set `CI=true` for the web dev script so Vite skips binding its interactive stdin shortcuts, which were crashing with `EIO` in non-interactive terminal environments.

Neither change affects deployed behavior: `requirements-build.txt` is explicitly excluded from the Lambda runtime path, and the Vite change only affects the local dev server.

## Test plan
- [x] `pytest -q` — 767 passed, 9 skipped
- [x] Verified `fiona` uninstall doesn't break anything (full suite re-run after removal)
- [x] Verified Vite dev server starts cleanly with `CI=true` and stays up under HMR

🤖 Generated with [Claude Code](https://claude.com/claude-code)