### PR TITLE
Add HYG star database to acknowledgments

### DIFF
--- a/docs/ACKNOWLEDGMENTS.md
+++ b/docs/ACKNOWLEDGMENTS.md
@@ -35,6 +35,9 @@ This project was developed with substantial assistance from:
 
 ### Astronomical Data
 - **JPL Ephemeris (DE421)**: NASA Jet Propulsion Laboratory
+- **HYG Star Database (v4.x)**: David Nash / Astronexus compilation of the Hipparcos, Yale Bright Star, and Gliese catalogs, used by `scripts/build_star_catalog.py` to build the web sky-dome star catalog (`apps/web/public/stars.v1.bin`)
+  - https://github.com/astronexus/HYG-Database (now maintained at https://codeberg.org/astronexus/hyg)
+  - License: CC BY-SA 4.0 (requires attribution)
 - **Celestrak**: Two-Line Element sets (TLEs) for ISS, Hubble Space Telescope, Tiangong, and Starlink satellites, used for satellite pass prediction
   - https://celestrak.org/
   - Data is freely available for non-commercial use; see https://celestrak.org/data/update-policy.php


### PR DESCRIPTION
## What

Adds an entry for the HYG star database to the "Astronomical Data" section of `docs/ACKNOWLEDGMENTS.md`, matching the existing entry style (source, usage, license, URLs).

## Why

`apps/web/public/stars.v1.bin` (the sky-dome star catalog) is generated by `scripts/build_star_catalog.py` from the HYG v4.x database, which is CC BY-SA licensed and requires attribution — but it had no acknowledgment entry.

## Notes for review

- License verified at the source: the GitHub repo is now an archived pointer; the active home is https://codeberg.org/astronexus/hyg, which states versions since v4.0 are **CC BY-SA 4.0**. The entry links both URLs.
- Caveat (not addressed here): CC BY-SA is share-alike, and the derived `stars.v1.bin` shipped in this MIT repo is arguably an adaptation of the database. This entry satisfies attribution; if strict SA compliance matters, the .bin may need to carry the CC BY-SA license itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)