### PR TITLE
Live WAQI haze cross-check on the Night Timeline; monitor WAQI + SWPC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,4 +73,5 @@ jobs:
           PYNIGHTSKY_RASTER_BUCKET: ${{ secrets.PYNIGHTSKY_RASTER_BUCKET }}
           PYNIGHTSKY_CACHE_TABLE: ${{ secrets.PYNIGHTSKY_CACHE_TABLE }}
           PYNIGHTSKY_BLOG_BUCKET: ${{ secrets.PYNIGHTSKY_BLOG_BUCKET }}
+          AQICN_TOKEN: ${{ secrets.AQICN_TOKEN }}
         run: cdk deploy PyNightSkyLambda --require-approval never

--- a/PyNightSkyPredictor/aqicn.py
+++ b/PyNightSkyPredictor/aqicn.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Live haze cross-check — WAQI (World Air Quality Index, aqicn.org) real-time
+station readings.
+
+This is NOT a general air-quality/health feature. The only thing it answers
+is: "does a nearby ground station's live particulate reading say it's hazy
+right now?" — as a cross-check against the forecast-driven Haze icon
+(icons.tsx), whose PM2.5/AOD come from Open-Meteo's CAMS forecast and can
+diverge from a fast-moving real-world event (e.g. wildfire smoke) that
+ground stations already see.
+
+Only the pollutant-specific PM2.5 (fallback PM10) sub-index is used, never
+WAQI's blended top-level `aqi` — that number is max() over ALL pollutants
+(including gas-phase ones like ozone that don't scatter starlight), so using
+it directly would produce false positives/negatives for exactly what this
+module cares about.
+
+WAQI's `geo:lat;lon` query returns whatever station it considers "nearest",
+even when that station is hundreds or thousands of km away in a
+sparse-coverage region — silently attributing a reading to conditions that
+have nothing to do with the queried location. `current_haze()` rejects any
+station beyond MAX_STATION_DISTANCE_KM, treating it the same as "no PM data
+nearby" rather than showing a misleading cross-check.
+
+Public API:
+    current_haze(lat, lon) -> dict | None
+        {"pm_value": int, "pollutant": "pm25"|"pm10", "hazy": bool,
+         "station": str | None, "observed_at": str | None, "stale": bool}
+        None when unavailable: no token configured, fetch failed with no
+        stale cache to fall back on, the nearest station reports neither
+        PM2.5 nor PM10, or the nearest station is too far away to be
+        regionally representative.
+"""
+import json
+import logging
+import math
+import os
+import threading
+import urllib.error
+
+from . import _http
+from . import cache as _cache
+from . import provider_health as _ph
+
+log = logging.getLogger(__name__)
+
+WAQI_URL = "https://api.waqi.info/feed/geo:{lat};{lon}/?token={token}"
+
+AQICN_TTL = 1800  # 30 min — WAQI stations update roughly hourly; matches the
+                  # KP_TTL precedent in aurora.py for a short-lived upstream value.
+
+_TOKEN = os.environ.get("AQICN_TOKEN", "")
+
+# Sub-index cutoff for "hazy". EPA's own PM2.5 breakpoint table puts AQI 100
+# at ~35.4 ug/m3, which lines up with this app's existing forecast-side haze
+# threshold (icons.tsx pmHazy: pm25 > 35 ug/m3). PM10's breakpoint table is
+# coarser-particle-scaled, so this isn't an identical physical severity for a
+# PM10 fallback reading — it's a reasonable proxy, not an exact equivalence.
+HAZY_SUBINDEX = 100
+
+# WAQI's "nearest station" can be arbitrarily far away in sparse-coverage
+# regions (observed: a Kampala/Nairobi query returning a station in Mayotte,
+# ~2500 km away). 100 km mirrors this app's own existing notion of "nearby"
+# (the Find Sky Nearby search's 60 mi default radius, ~97 km) — a station
+# further than that isn't a meaningful stand-in for local haze conditions.
+MAX_STATION_DISTANCE_KM = 100.0
+
+_EARTH_RADIUS_KM = 6371.0
+
+# Per-location locks (not a single global lock): unlike aurora.py's two
+# genuinely-global SWPC products, this cache key is per-(lat, lon) — a
+# /calendar multi-night fan-out for one location would otherwise thunder-herd
+# a single shared lock for no reason. Mirrors weather.py's lock_for.
+_fetch_locks: dict[str, threading.Lock] = {}
+_fetch_locks_guard = threading.Lock()
+
+
+def lock_for(lat: float, lon: float) -> threading.Lock:
+    key = f"{lat:.2f},{lon:.2f}"
+    with _fetch_locks_guard:
+        lock = _fetch_locks.get(key)
+        if lock is None:
+            lock = _fetch_locks[key] = threading.Lock()
+        return lock
+
+
+def _cache_key(lat: float, lon: float) -> str:
+    return f"aqicn|{lat:.2f}|{lon:.2f}"
+
+
+def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance between two points, in km."""
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = (math.sin(dphi / 2) ** 2
+         + math.cos(p1) * math.cos(p2) * math.sin(dlambda / 2) ** 2)
+    return 2 * _EARTH_RADIUS_KM * math.asin(min(1.0, math.sqrt(a)))
+
+
+def _fetch_url(lat: float, lon: float, timeout: int = 10) -> str:
+    """GET the WAQI feed for (lat, lon); provider-health accounting."""
+    url = WAQI_URL.format(lat=lat, lon=lon, token=_TOKEN)
+    try:
+        with _http.urlopen(url, timeout=timeout) as resp:
+            text = resp.read().decode("utf-8")
+        return text
+    except urllib.error.HTTPError as e:
+        _ph.record("waqi", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+        raise RuntimeError(f"WAQI HTTP {e.code}") from e
+    except urllib.error.URLError as e:
+        _ph.record("waqi", "error", str(e.reason)[:120])
+        raise RuntimeError(f"WAQI unreachable: {e.reason}") from e
+
+
+def _parse(text: str, lat: float, lon: float) -> dict | None:
+    """WAQI feed JSON -> the current_haze contract (minus `stale`, filled in
+    by the caller). None when the response is malformed, the station reports
+    an error status, there's no PM2.5/PM10 reading to cross-check with, or
+    the nearest station is further than MAX_STATION_DISTANCE_KM away.
+    Records provider_health for a well-formed response; parse-level failures
+    (bad JSON, non-"ok" status) are also recorded so /healthz reflects them."""
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError) as e:
+        _ph.record("waqi", "error", f"bad JSON: {str(e)[:100]}")
+        raise RuntimeError("WAQI response was not valid JSON") from e
+
+    if payload.get("status") != "ok":
+        _ph.record("waqi", "error", f"status={payload.get('status')}")
+        raise RuntimeError(f"WAQI status={payload.get('status')}")
+
+    data = payload.get("data") or {}
+    city = data.get("city") or {}
+
+    geo = city.get("geo")
+    if (not isinstance(geo, (list, tuple)) or len(geo) != 2
+            or not all(isinstance(v, (int, float)) for v in geo)):
+        # Can't verify the station is nearby — treat like "no usable data"
+        # rather than trust an unverifiable reading. WAQI always includes
+        # geo in practice, so this is a defensive edge case, not the norm.
+        _ph.record("waqi", "ok")
+        return None
+    distance_km = _haversine_km(lat, lon, geo[0], geo[1])
+    if distance_km > MAX_STATION_DISTANCE_KM:
+        log.info("AQICN nearest station %.0f km away (> %.0f km cutoff) for (%.2f, %.2f) — skipping",
+                  distance_km, MAX_STATION_DISTANCE_KM, lat, lon)
+        _ph.record("waqi", "ok")
+        return None
+
+    iaqi = data.get("iaqi") or {}
+    pm25 = (iaqi.get("pm25") or {}).get("v")
+    pm10 = (iaqi.get("pm10") or {}).get("v")
+    if pm25 is not None:
+        pm_value, pollutant = pm25, "pm25"
+    elif pm10 is not None:
+        pm_value, pollutant = pm10, "pm10"
+    else:
+        _ph.record("waqi", "ok")  # station reached fine, just no PM sensor
+        return None
+
+    _ph.record("waqi", "ok")
+    return {
+        "pm_value": round(float(pm_value)),
+        "pollutant": pollutant,
+        "hazy": float(pm_value) > HAZY_SUBINDEX,
+        "station": city.get("name"),
+        "observed_at": (data.get("time") or {}).get("iso"),
+    }
+
+
+def current_haze(lat: float, lon: float) -> dict | None:
+    """Fresh cache -> single-flight fetch -> stale-cache fallback -> None.
+
+    Never raises; this is a live cross-check, not a pipeline dependency — any
+    failure (missing token, network error, malformed response, no PM data at
+    the nearest station, nearest station too far away) degrades to None or a
+    stale reading, same "enrichment, never fatal" philosophy as
+    weather._fetch_air_quality.
+    """
+    if not _TOKEN:
+        return None
+
+    key = _cache_key(lat, lon)
+    cached = _cache.get(key)
+    if cached is not None:
+        return {**cached, "stale": False}
+
+    with lock_for(lat, lon):
+        cached = _cache.get(key)
+        if cached is not None:
+            return {**cached, "stale": False}
+        try:
+            fresh = _parse(_fetch_url(lat, lon), lat, lon)
+            if fresh is not None:
+                _cache.set(key, fresh, ttl_seconds=AQICN_TTL)
+                return {**fresh, "stale": False}
+        except Exception as e:
+            log.warning("AQICN fetch failed for %s: %s", key, e)
+
+    stale = _cache.get_stale(key)
+    return {**stale, "stale": True} if stale is not None else None

--- a/PyNightSkyPredictor/predictor.py
+++ b/PyNightSkyPredictor/predictor.py
@@ -12,6 +12,7 @@ from datetime import date, datetime, timedelta, timezone
 
 from zoneinfo import ZoneInfo
 
+from . import aqicn as _aqicn
 from . import aurora as _aur
 from . import darksky as _ds
 from . import light_dome as _ld
@@ -131,6 +132,13 @@ class NightReport:
     # Night-median aerosol optical depth (moonlight scattering input); None when
     # unavailable (past dates, AQ fetch failure, beyond the 7-day AQ horizon).
     night_aod: float | None = None
+
+    # Live station PM2.5/PM10 reading (WAQI) — a haze cross-check against the
+    # forecast-driven Haze icon, surfaced only on the Night Timeline's live
+    # "Now" row. NOT part of weather_score/rate_conditions. None when
+    # unavailable, outside the +/-1 day window, token unset, no station PM
+    # data nearby, or the nearest station is too far away to be meaningful.
+    current_haze: dict | None = None
 
     # Visible targets (populated when fetch_targets=True)
     visible_targets: list = field(default_factory=list)
@@ -545,6 +553,14 @@ def assemble_night(
                 return rows, r_stale, outlook, o_stale
             _aurora_future = _pool.submit(_aurora_io)
 
+        # Live PM2.5/PM10 haze cross-check (WAQI) — a "right now" ground-station
+        # reading, not a forecast, so it's meaningless for a report several days
+        # out. Same -1 day UTC-slop convention as the aurora gate above.
+        _haze_future: _futures.Future | None = None
+        _haze_days_ahead = (target - _now.date()).days
+        if fetch_weather and -1 <= _haze_days_ahead <= 1:
+            _haze_future = _pool.submit(_aqicn.current_haze, lat, lon)
+
         # Heuristic: start weather for tonight-or-future dates without waiting for
         # sunrise. "Tonight" may be yesterday in UTC when the night spans midnight
         # (e.g. 03:00 UTC — still before sunrise for a US location). Subtracting
@@ -704,6 +720,11 @@ def assemble_night(
         # Light dome — precomputed H3 index lookup (O(log n), no raster read), so it's
         # safe on the initial page-load path. None when outside the index coverage.
         light_dome_info = _ld.lightdome_lookup(lat, lon)
+
+        # Collect the live haze cross-check — independent of the weather-forecast
+        # cache/fetch below, so a slow or failed WAQI call never affects wx_exc
+        # handling or the forecast blend.
+        _current_haze = _haze_future.result() if _haze_future is not None else None
 
         # Collect weather future (cache check + HTTP fetch both ran off-thread).
         _wx_fetched = None
@@ -1012,6 +1033,7 @@ def assemble_night(
         wx_archive_error=wx_archive_error,
         wx_error=wx_error,
         night_aod=_night_aod,
+        current_haze=_current_haze,
         score=rating["score"],
         score_components=rating["components"],
         visible_targets=target_list,

--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ Beyond the score:
 * Monthly night scoring calendar
 * Multi-location trip comparison across a date range
 * Historical weather analysis back to 1940 via ERA5 reanalysis
+* Live haze cross-check — a real-time ground-station PM2.5/PM10 reading (WAQI), shown on
+  tonight's live "Now" marker when it crosses this app's own haze threshold, catching
+  fast-moving smoke/haze events the forecast hasn't caught up to yet
+* Aurora visibility forecast — NOAA SWPC Kp-index forecast run through a dipole
+  geomagnetic-latitude viewline model, tiered overhead/naked-eye/photographic by margin
 
-Built on open data: NOAA, Open-Meteo, NASA/VIIRS, Falchi, 7Timer, OpenStreetMap, Celestrak, and USGS PAD-US.
+Built on open data: NOAA (SWPC space weather, NWS), Open-Meteo, NASA/VIIRS, Falchi, 7Timer, OpenStreetMap, Celestrak, WAQI, and USGS PAD-US.
 
 The two CLI scripts are:
 
@@ -342,6 +347,8 @@ External I/O — caching, the saved-location store, and the light-pollution rast
 | `PyNightSkyPredictor/config.py` | Configuration loader — merges `PyNightSkyPredictor/config.json` over built-in defaults (see [Configuration](#configuration) below) |
 | `PyNightSkyPredictor/darksky.py` | Light pollution lookup (VIIRS + Falchi); POI-first `find_nearby()` dark-sky search (routable OSM POI index + drive times); `LocalRasterSource` adapter |
 | `PyNightSkyPredictor/weather.py` | Weather forecast — NOAA/NWS, Open-Meteo, 7Timer ASTRO |
+| `PyNightSkyPredictor/aqicn.py` | Live haze cross-check — WAQI real-time station PM2.5/PM10, ±1 day window, distance-filtered against far-away "nearest" stations |
+| `PyNightSkyPredictor/aurora.py` | Aurora visibility forecast — NOAA SWPC 3-day Kp forecast + 27-day outlook, dipole geomagnetic-latitude viewline model |
 | `PyNightSkyPredictor/location.py` | Geocoding and timezone resolution; `LocalGeocodeStore` adapter |
 | `PyNightSkyPredictor/satellites.py` | Satellite pass prediction — Skyfield SGP4 propagation, Moon proximity |
 | `PyNightSkyPredictor/tle_provider.py` | TLE acquisition — Celestrak fetch, 6-hour cache, stale-data fallback |
@@ -385,6 +392,8 @@ External datasets are downloaded on first use and stored in `~/.pynightsky-predi
 | Nominatim geocoding | OpenStreetMap | 90 days |
 | Overpass API (area names for `--show-nearby`) | OpenStreetMap | 90 days |
 | Weather forecasts | NOAA / Open-Meteo / 7Timer | Hours–days |
+| Live haze cross-check (PM2.5/PM10) | WAQI (World Air Quality Index Project) | 30 minutes |
+| Aurora Kp forecast (3-day) / outlook (27-day) | NOAA SWPC | 30 minutes / 6 hours |
 | Satellite TLEs (ISS, Hubble, Tiangong, Starlink) | Celestrak | 6 hours |
 
 The file `PyNightSkyPredictor/de421.bsp` (JPL DE421 planetary ephemeris, 1900–2050) is bundled in the repository — no download needed for astronomical computations.

--- a/apps/provider_health/handler.py
+++ b/apps/provider_health/handler.py
@@ -1,13 +1,19 @@
 """Weather provider health monitor.
 
-Runs on a schedule (EventBridge → Lambda) to poll the two weather providers the
-engine depends on (Open-Meteo, 7Timer) and record UP/DOWN status + latency to
-DynamoDB, so an SRE can alarm on sustained provider outages independently of
-user traffic. Zero third-party imports beyond boto3 (ships with the runtime) —
-this Lambda never touches the PyNightSkyPredictor engine, so it stays a tiny
-zip with no rasterio/GDAL tax.
+Runs on a schedule (EventBridge → Lambda) to poll the providers the engine
+depends on (Open-Meteo, 7Timer, WAQI, NOAA SWPC) and record UP/DOWN status +
+latency to DynamoDB, so an SRE can alarm on sustained provider outages
+independently of user traffic. Zero third-party imports beyond boto3 (ships
+with the runtime) — this Lambda never touches the PyNightSkyPredictor engine,
+so it stays a tiny zip with no rasterio/GDAL tax.
 
-Env it expects: ``PROVIDER_HEALTH_TABLE``.
+Deliberately NOT monitored here: Celestrak. It has specific access-timing
+expectations and will shut off a client that polls it too regularly — a
+5-minute synthetic health check is exactly the kind of traffic that would put
+this app's TLE access at risk, so it's excluded on purpose, not an oversight.
+
+Env it expects: ``PROVIDER_HEALTH_TABLE``, ``AQICN_TOKEN`` (optional — the
+WAQI check is skipped entirely, not marked DOWN, when unset).
 """
 import json
 import logging
@@ -16,24 +22,63 @@ import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any
+from typing import Any, Callable
 
 import boto3
 from botocore.exceptions import ClientError
 
-PROVIDERS: list[dict[str, str]] = [
+
+def _status_200(status_code: int, body: bytes) -> bool:
+    return status_code == 200
+
+
+def _waqi_ok(status_code: int, body: bytes) -> bool:
+    # WAQI returns HTTP 200 even on an invalid/expired token
+    # (body: {"status":"error","data":"Invalid key"}) — a plain status-code
+    # check would report this provider as permanently "UP" regardless of
+    # whether the token still works, so the body must be inspected too.
+    if status_code != 200:
+        return False
+    try:
+        return json.loads(body).get("status") == "ok"
+    except (ValueError, AttributeError):
+        return False
+
+
+PROVIDERS: list[dict[str, Any]] = [
     {
         "id": "open-meteo",
         "url": (
             "https://api.open-meteo.com/v1/forecast"
             "?latitude=33.3943&longitude=-104.5230&current=temperature_2m"
         ),
+        "validate": _status_200,
     },
     {
         "id": "7timer",
         "url": "http://www.7timer.info/bin/api.pl?lon=-104.5230&lat=33.3943&product=astro&output=json",
+        "validate": _status_200,
+    },
+    {
+        "id": "swpc",
+        # NOAA Space Weather Prediction Center — 3-day Kp forecast (aurora.py).
+        # Keyless, plain 200-on-success/404-on-failure — no body-inspection
+        # quirk like WAQI's, confirmed by hand against the live endpoint.
+        "url": "https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json",
+        "validate": _status_200,
     },
 ]
+
+_AQICN_TOKEN = os.environ.get("AQICN_TOKEN", "")
+if _AQICN_TOKEN:
+    PROVIDERS.append({
+        "id": "waqi",
+        # Same fixed reference point as the other two checks — this is purely
+        # an "is the API up and authenticating" probe, independent of the
+        # app's own distance-filtered nearest-station logic.
+        "url": f"https://api.waqi.info/feed/geo:33.3943;-104.5230/?token={_AQICN_TOKEN}",
+        "validate": _waqi_ok,
+    })
 
 TIMEOUT_S = 4.0
 RETRY_DELAY_S = 2.0
@@ -90,8 +135,8 @@ def _emit_dynamo_write_failure(provider: str) -> None:
     print(json.dumps(emf))
 
 
-def _probe(url: str) -> tuple[int, float]:
-    """Returns (http_status_code, latency_ms). Raises on network failure."""
+def _probe(url: str) -> tuple[int, float, bytes]:
+    """Returns (http_status_code, latency_ms, body). Raises on network failure."""
     req = urllib.request.Request(url, method="GET")
 
     # FIX: Build an opener that explicitly ONLY supports HTTP and HTTPS.
@@ -106,10 +151,10 @@ def _probe(url: str) -> tuple[int, float]:
 
     # Use our locked-down opener instead of the default urllib.request.urlopen
     with opener.open(req, timeout=TIMEOUT_S) as resp:
-        resp.read()  # drain body to free the connection
+        body = resp.read()  # some providers' "up" check needs to inspect this
         status = resp.status
 
-    return status, (time.monotonic() - t0) * 1000
+    return status, (time.monotonic() - t0) * 1000, body
 
 
 def _write_status(provider_id: str, status: str, epoch: int) -> None:
@@ -121,15 +166,16 @@ def _write_status(provider_id: str, status: str, epoch: int) -> None:
              error_type=type(exc).__name__, error_message=str(exc))
 
 
-def _check_provider(provider: dict[str, str]) -> None:
+def _check_provider(provider: dict[str, Any]) -> None:
     """One attempt, then (on failure) one retry after RETRY_DELAY_S, then persist."""
     pid, url = provider["id"], provider["url"]
+    validate: Callable[[int, bytes], bool] = provider.get("validate", _status_200)
     last_latency_ms = TIMEOUT_S * 1000
 
     for attempt in (1, 2):
         try:
-            status_code, latency_ms = _probe(url)
-            is_up = status_code == 200
+            status_code, latency_ms, body = _probe(url)
+            is_up = validate(status_code, body)
             _log("info", pid, attempt, event="probe_complete", http_status=status_code,
                  latency_ms=round(latency_ms, 2), status="UP" if is_up else "DOWN")
             _emit_provider_metrics(pid, latency_ms, is_up)

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -654,6 +654,10 @@ export default function App() {
         <a href="https://open-meteo.com" target="_blank" rel="noreferrer">Open-Meteo</a>
         {' / '}
         <a href="https://github.com/Yeqzids/7timer-issues/wiki" target="_blank" rel="noreferrer">7Timer</a>
+        {' · '}Live haze:{' '}
+        <a href="https://waqi.info" target="_blank" rel="noreferrer">World Air Quality Index Project</a>
+        {' · '}Aurora:{' '}
+        <a href="https://www.swpc.noaa.gov/" target="_blank" rel="noreferrer">NOAA SWPC</a>
         <br />
         Satellites:{' '}
         <a href="https://celestrak.org" target="_blank" rel="noreferrer">CelesTrak</a>

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -620,6 +620,7 @@ export default function ReportCard({
           cathodeSnap={cathodeSnap}
           wxSource={showWeather ? r.wx_source : null}
           wxFetchedAt={showWeather ? r.wx_fetched_at : null}
+          currentHaze={showWeather ? r.current_haze : null}
         />
       )}
 

--- a/apps/web/src/report/NightTimeline.tsx
+++ b/apps/web/src/report/NightTimeline.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import type { SkyEvent, WeatherPoint } from '../types'
+import type { SkyEvent, WeatherPoint, CurrentHaze } from '../types'
 import { formatTime, formatDayTime, fmtTempValue, tempUnitLabel, fmtWindSpeed, windUnitLabel, moonUpAt, formatAge, formatIssuedUtc } from '../format'
 import { InfoTip } from '../shared'
 import { Star } from 'lucide-react'
@@ -8,7 +8,7 @@ import { cell } from './common'
 
 // ── Weather table ────────────────────────────────────────────────────────────
 
-export function WeatherTable({ points, events = [], tz, imperial, moonrise, moonset, moonPhaseName = null, moonIlluminationPct = null, isFetching = false, cathodeSnap = false, wxSource = null, wxFetchedAt = null }: {
+export function WeatherTable({ points, events = [], tz, imperial, moonrise, moonset, moonPhaseName = null, moonIlluminationPct = null, isFetching = false, cathodeSnap = false, wxSource = null, wxFetchedAt = null, currentHaze = null }: {
   points: WeatherPoint[]
   events?: SkyEvent[]
   tz: string
@@ -21,6 +21,7 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
   cathodeSnap?: boolean
   wxSource?: string | null
   wxFetchedAt?: string | null
+  currentHaze?: CurrentHaze | null
 }) {
   // Clip the table to the sunset→sunrise window. Events/points outside this
   // range are daytime and not useful once the astro-night band conveys darkness.
@@ -195,7 +196,18 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
                   <tr key="now-marker" className="wx-now-row">
                     <td className="wx-time wx-now-time">{formatTime(new Date(row.ts).toISOString(), tz)}</td>
                     <td colSpan={hasWx ? totalCols - 1 : 1} className="wx-now-content">
-                      <span className="wx-now-inner">▶ Now</span>
+                      <span className="wx-now-inner">
+                        ▶ Now
+                        {currentHaze?.hazy && (
+                          <InfoTip tip={<>Live station reading (WAQI): {currentHaze.pollutant.toUpperCase()} AQI sub-index {currentHaze.pm_value}
+                            {currentHaze.station ? ` at ${currentHaze.station}` : ''}
+                            {currentHaze.observed_at ? `, ${new Date(currentHaze.observed_at).toLocaleString()}` : ''} —
+                            above this app's haze threshold. The forecast rows above may not reflect this yet.
+                            {currentHaze.stale ? ' (cached — station temporarily unreachable)' : ''} Data: World Air Quality Index Project (waqi.info).</>}>
+                            <span className="wx-cond-word"> · Haze (live)</span>
+                          </InfoTip>
+                        )}
+                      </span>
                     </td>
                   </tr>
                 )
@@ -329,15 +341,20 @@ export function WeatherTable({ points, events = [], tz, imperial, moonrise, moon
             })}
           </tbody>
         </table>
-        {hasWx && <WxProvenanceBadge source={wxSource} fetchedAt={wxFetchedAt} />}
+        {hasWx && <WxProvenanceBadge source={wxSource} fetchedAt={wxFetchedAt} currentHaze={isLive ? currentHaze : null} />}
       </div>
     </details>
   )
 }
 
 // Dense, monospace "instrument readout" footer for the Night Timeline table — shows
-// which weather source served this forecast and how fresh the data is.
-export function WxProvenanceBadge({ source, fetchedAt }: { source: string | null; fetchedAt: string | null }) {
+// which weather source served this forecast and how fresh the data is. The WAQI
+// item only appears when the live Haze badge is actually showing (see the "Now"
+// row above) — that's the one case this report actually displays WAQI's data to
+// the user, and their terms require attribution wherever it's shown.
+export function WxProvenanceBadge({ source, fetchedAt, currentHaze = null }: {
+  source: string | null; fetchedAt: string | null; currentHaze?: CurrentHaze | null
+}) {
   if (!source) return null
   return (
     <div className="wx-provenance">
@@ -346,6 +363,12 @@ export function WxProvenanceBadge({ source, fetchedAt }: { source: string | null
       <span className="wx-prov-item">ISSUED: {formatIssuedUtc(fetchedAt)}</span>
       <span className="wx-prov-sep">·</span>
       <span className="wx-prov-item">UPDATED: {formatAge(fetchedAt)}</span>
+      {currentHaze?.hazy && (
+        <>
+          <span className="wx-prov-sep">·</span>
+          <span className="wx-prov-item">LIVE HAZE: WORLD AIR QUALITY INDEX PROJECT (WAQI.INFO)</span>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -239,6 +239,19 @@ export interface LightDomeSummary {
   domes: LightDome[]                       // worst-first; [] when none stand out
 }
 
+// Live station PM2.5/PM10 reading (WAQI) — a haze cross-check, not a health
+// rating. `pollutant` is 'pm25' unless the nearest station only reports
+// 'pm10' (coarser dust, still light-scattering, clearly labeled as a
+// fallback). `hazy` mirrors the app's own forecast-side haze threshold.
+export interface CurrentHaze {
+  pm_value: number
+  pollutant: 'pm25' | 'pm10'
+  hazy: boolean
+  station: string | null
+  observed_at: string | null
+  stale: boolean
+}
+
 export interface NightReport {
   date: string
   lat: number
@@ -274,6 +287,11 @@ export interface NightReport {
   // Night-median aerosol optical depth (moonlight model input); null when
   // unavailable, absent on pre-field cached reports
   night_aod?: number | null
+  // Live station PM2.5/PM10 reading (WAQI) — a haze cross-check surfaced on
+  // the Night Timeline's "Now" row, not part of weather_score. null when
+  // unavailable/not near-term/token unset/no station PM data, absent on
+  // pre-field cached reports.
+  current_haze?: CurrentHaze | null
   score: number
   score_components: ScoreComponents
   visible_targets: VisibleTarget[]

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -101,6 +101,9 @@ class LambdaApiStack(Stack):
         raster_bucket = os.environ["PYNIGHTSKY_RASTER_BUCKET"]
         cache_table = os.environ["PYNIGHTSKY_CACHE_TABLE"]
         blog_bucket_name = os.environ["PYNIGHTSKY_BLOG_BUCKET"]
+        # Optional (not a hard deploy dependency): aqicn.py degrades to "no live haze
+        # data" when unset, so a missing secret shouldn't break the stack.
+        aqicn_token = os.environ.get("AQICN_TOKEN", "")
 
         Tags.of(self).add("Project", "pynightsky")
         Tags.of(self).add("Env", "prod")
@@ -150,6 +153,7 @@ class LambdaApiStack(Stack):
                 "PYNIGHTSKY_CACHE_TABLE": cache_table,
                 "PYNIGHTSKY_RASTER_BUCKET": raster_bucket,
                 "LOG_LEVEL": "INFO",
+                "AQICN_TOKEN": aqicn_token,
             },
         )
 
@@ -281,6 +285,7 @@ class LambdaApiStack(Stack):
                 "PYNIGHTSKY_CACHE_TABLE": cache_table,
                 "PYNIGHTSKY_RASTER_BUCKET": raster_bucket,
                 "LOG_LEVEL": "INFO",
+                "AQICN_TOKEN": aqicn_token,
             },
         )
         bucket.grant_read(worker)

--- a/cdk/provider_health_stack.py
+++ b/cdk/provider_health_stack.py
@@ -1,12 +1,17 @@
 """Weather provider health monitor.
 
 A tiny zip Lambda (just apps/provider_health — boto3 comes from the runtime, no
-rasterio/GDAL) on a 5-minute EventBridge schedule. It polls Open-Meteo and 7Timer
-independently, writes UP/DOWN + latency to its own DynamoDB table, and emits
-CloudWatch EMF metrics (ProviderUp, HTTPVerificationLatency, DynamoDBWriteFailure)
-so SRE alarms can fire on sustained outage or a missed execution, decoupled from
-user traffic.
+rasterio/GDAL) on a 5-minute EventBridge schedule. It polls Open-Meteo, 7Timer,
+NOAA SWPC, and WAQI (when AQICN_TOKEN is configured) independently, writes
+UP/DOWN + latency to its own DynamoDB table, and emits CloudWatch EMF metrics
+(ProviderUp, HTTPVerificationLatency, DynamoDBWriteFailure) so SRE alarms can
+fire on sustained outage or a missed execution, decoupled from user traffic.
+
+Celestrak is deliberately NOT in this list — it has specific access-timing
+expectations and will shut off a client that polls it too regularly; a 5-min
+synthetic check would put this app's real TLE access at risk.
 """
+import os
 import pathlib
 import shutil
 
@@ -27,7 +32,10 @@ from constructs import Construct
 
 _REPO = pathlib.Path(__file__).resolve().parents[1]
 _NAMESPACE = "PyNightSky/WeatherProviders"
-_PROVIDERS = ["open-meteo", "7timer"]
+_AQICN_TOKEN = os.environ.get("AQICN_TOKEN", "")
+_PROVIDERS = ["open-meteo", "7timer", "swpc"]
+if _AQICN_TOKEN:
+    _PROVIDERS.append("waqi")
 
 
 def _stage_provider_health_code() -> str:
@@ -63,9 +71,12 @@ class ProviderHealthStack(Stack):
             architecture=lambda_.Architecture.ARM_64,
             handler="apps.provider_health.handler.handler",
             code=lambda_.Code.from_asset(_stage_provider_health_code()),
-            timeout=Duration.seconds(30),   # 2 providers x (4s timeout + 2s retry delay), in parallel
+            timeout=Duration.seconds(30),   # N providers x (4s timeout + 2s retry delay), in parallel
             memory_size=128,
-            environment={"PROVIDER_HEALTH_TABLE": table.table_name},
+            environment={
+                "PROVIDER_HEALTH_TABLE": table.table_name,
+                "AQICN_TOKEN": _AQICN_TOKEN,
+            },
             description="Polls weather providers every 5 min, writes UP/DOWN to DynamoDB.",
         )
         table.grant_write_data(fn)

--- a/docs/ACKNOWLEDGMENTS.md
+++ b/docs/ACKNOWLEDGMENTS.md
@@ -14,6 +14,22 @@ This project was developed with substantial assistance from:
   - Attribution: Link to https://open-meteo.com/ must be displayed where data is shown
   - https://open-meteo.com/
 
+### Air Quality Data
+- **WAQI (World Air Quality Index Project)**: real-time ground-station PM2.5/PM10 readings,
+  used for a live haze cross-check against the forecast-driven Haze indicator (shown on the
+  Night Timeline's "Now" row when a live reading crosses this app's own haze threshold)
+  - License: free API use; attribution to the World Air Quality Index Project and the
+    originating station/EPA required wherever the data is shown (station name is included
+    inline where the reading appears)
+  - https://waqi.info/
+
+### Space Weather Data
+- **NOAA Space Weather Prediction Center (SWPC)**: 3-day planetary Kp-index forecast and
+  27-day outlook, used for the aurora visibility forecast (dipole geomagnetic-latitude
+  viewline model in `aurora.py`)
+  - License: public domain (U.S. Government work — no restrictions on use)
+  - https://www.swpc.noaa.gov/
+
 ### Light Pollution Data
 - **VIIRS Black Marble 2025**: Raw satellite radiance data from lightpollutionmap.info
 - **Falchi World Atlas 2016**: World Atlas of Artificial Night Sky Brightness by Cinzano, Falchi, and Elvidge (GFZ Potsdam)

--- a/tests/test_aqicn.py
+++ b/tests/test_aqicn.py
@@ -1,0 +1,250 @@
+"""
+Tests for aqicn.py — WAQI feed parsing (PM2.5/PM10 pollutant preference, hazy
+threshold, distant-station rejection), cache state machine, stale fallback,
+and provider-health accounting. All hermetic: no network, no real WAQI calls
+(cache and HTTP are mocked).
+"""
+import io
+import json
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from PyNightSkyPredictor import aqicn as q
+
+# Query point used throughout: Minneapolis, MN.
+_QLAT, _QLON = 44.98, -93.27
+# A station essentially at the query point (~0 km away).
+_LOCAL_GEO = [44.98, -93.27]
+# A station in Mayotte — genuinely ~14,700 km from Minneapolis, the real
+# "nearest station" WAQI returned for an East-African query during manual
+# testing. Good stand-in for "absurdly far nearest station."
+_FAR_GEO = [-12.76, 45.23]
+
+
+def _feed(pm25=None, pm10=None, status="ok", city="Test Station", iso="2026-07-17T02:00:00+00:00",
+          geo=_LOCAL_GEO):
+    iaqi = {}
+    if pm25 is not None:
+        iaqi["pm25"] = {"v": pm25}
+    if pm10 is not None:
+        iaqi["pm10"] = {"v": pm10}
+    data = {
+        "aqi": pm25 if pm25 is not None else (pm10 or 0),
+        "iaqi": iaqi,
+        "city": {"name": city},
+        "time": {"iso": iso},
+    }
+    if geo is not None:
+        data["city"]["geo"] = geo
+    return json.dumps({"status": status, "data": data})
+
+
+def _mock_cache(get_val=None, stale_val=None):
+    c = mock.MagicMock()
+    c.get.return_value = get_val
+    c.get_stale.return_value = stale_val
+    return c
+
+
+def _http_response(text: str):
+    """Context-manager response like urllib's, yielding *text* bytes."""
+    resp = mock.MagicMock()
+    resp.read.return_value = text.encode("utf-8")
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda self, *exc: False
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _haversine_km — pure geometry
+# ---------------------------------------------------------------------------
+
+class TestHaversine:
+    def test_same_point_is_zero(self):
+        assert q._haversine_km(44.98, -93.27, 44.98, -93.27) == pytest.approx(0.0, abs=1e-6)
+
+    def test_known_distance_minneapolis_to_mayotte(self):
+        # Roughly 14,000-15,000 km — sanity check the formula isn't wildly off.
+        d = q._haversine_km(_QLAT, _QLON, _FAR_GEO[0], _FAR_GEO[1])
+        assert 13000 < d < 16000
+
+    def test_short_local_distance(self):
+        # ~0.5 degrees latitude apart at this latitude is roughly 55 km.
+        d = q._haversine_km(44.98, -93.27, 45.48, -93.27)
+        assert 50 < d < 60
+
+
+# ---------------------------------------------------------------------------
+# _parse — pollutant preference, hazy threshold, distance rejection
+# ---------------------------------------------------------------------------
+
+class TestParse:
+    def test_pm25_preferred_when_present(self):
+        result = q._parse(_feed(pm25=76, pm10=30), _QLAT, _QLON)
+        assert result["pollutant"] == "pm25"
+        assert result["pm_value"] == 76
+
+    def test_falls_back_to_pm10_when_pm25_absent(self):
+        result = q._parse(_feed(pm10=120), _QLAT, _QLON)
+        assert result["pollutant"] == "pm10"
+        assert result["pm_value"] == 120
+
+    def test_none_when_neither_pollutant_present(self):
+        assert q._parse(_feed(), _QLAT, _QLON) is None
+
+    def test_hazy_boundary_at_100(self):
+        assert q._parse(_feed(pm25=100), _QLAT, _QLON)["hazy"] is False
+        assert q._parse(_feed(pm25=101), _QLAT, _QLON)["hazy"] is True
+
+    def test_station_and_observed_at_carried_through(self):
+        result = q._parse(_feed(pm25=50, city="Minneapolis", iso="2026-07-17T02:00:00+00:00"), _QLAT, _QLON)
+        assert result["station"] == "Minneapolis"
+        assert result["observed_at"] == "2026-07-17T02:00:00+00:00"
+
+    def test_missing_time_degrades_to_none_observed_at(self):
+        payload = json.loads(_feed(pm25=50))
+        del payload["data"]["time"]
+        result = q._parse(json.dumps(payload), _QLAT, _QLON)
+        assert result["observed_at"] is None
+
+    def test_non_ok_status_raises(self):
+        with pytest.raises(RuntimeError):
+            q._parse(_feed(pm25=50, status="error"), _QLAT, _QLON)
+
+    def test_bad_json_raises(self):
+        with pytest.raises(RuntimeError):
+            q._parse("not json", _QLAT, _QLON)
+
+    def test_far_station_rejected(self):
+        # Mirrors the real Kampala/Nairobi -> Mayotte case found in manual testing.
+        assert q._parse(_feed(pm25=200, geo=_FAR_GEO), _QLAT, _QLON) is None
+
+    def test_station_within_cutoff_accepted(self):
+        # ~55 km away, under the 100 km cutoff.
+        nearby = [45.48, -93.27]
+        result = q._parse(_feed(pm25=50, geo=nearby), _QLAT, _QLON)
+        assert result is not None and result["pm_value"] == 50
+
+    def test_missing_geo_treated_as_no_data(self):
+        assert q._parse(_feed(pm25=200, geo=None), _QLAT, _QLON) is None
+
+    def test_malformed_geo_treated_as_no_data(self):
+        payload = json.loads(_feed(pm25=200))
+        payload["data"]["city"]["geo"] = ["not", "numeric"]
+        assert q._parse(json.dumps(payload), _QLAT, _QLON) is None
+
+
+# ---------------------------------------------------------------------------
+# current_haze — fetch state machine (cache -> fetch -> stale fallback -> None)
+# ---------------------------------------------------------------------------
+
+class TestCurrentHaze:
+    def test_fresh_cache_hit_no_fetch(self):
+        cached = {"pm_value": 76, "pollutant": "pm25", "hazy": True,
+                  "station": "Minneapolis", "observed_at": "2026-07-17T02:00:00+00:00"}
+        mc = _mock_cache(get_val=cached)
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q, "_fetch_url") as fetch:
+            result = q.current_haze(_QLAT, _QLON)
+        assert result == {**cached, "stale": False}
+        fetch.assert_not_called()
+
+    def test_miss_fetches_and_caches(self):
+        mc = _mock_cache()
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q, "_fetch_url", return_value=_feed(pm25=76)):
+            result = q.current_haze(_QLAT, _QLON)
+        assert result["pm_value"] == 76 and result["stale"] is False
+        mc.set.assert_called_once()
+        assert mc.set.call_args.kwargs["ttl_seconds"] == q.AQICN_TTL
+
+    def test_fetch_failure_falls_back_stale(self):
+        stale = {"pm_value": 40, "pollutant": "pm25", "hazy": False,
+                  "station": None, "observed_at": None}
+        mc = _mock_cache(stale_val=stale)
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q, "_fetch_url", side_effect=RuntimeError("down")):
+            result = q.current_haze(_QLAT, _QLON)
+        assert result == {**stale, "stale": True}
+
+    def test_fetch_failure_no_stale_yields_none(self):
+        mc = _mock_cache()
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q, "_fetch_url", side_effect=RuntimeError("down")):
+            result = q.current_haze(_QLAT, _QLON)
+        assert result is None
+
+    def test_no_pm_data_at_station_yields_none_and_does_not_cache(self):
+        mc = _mock_cache()
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q, "_fetch_url", return_value=_feed()):
+            result = q.current_haze(_QLAT, _QLON)
+        assert result is None
+        mc.set.assert_not_called()
+
+    def test_far_station_yields_none_and_does_not_cache(self):
+        mc = _mock_cache()
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q, "_fetch_url", return_value=_feed(pm25=200, geo=_FAR_GEO)):
+            result = q.current_haze(_QLAT, _QLON)
+        assert result is None
+        mc.set.assert_not_called()
+
+    def test_no_token_returns_none_without_touching_cache_or_health(self):
+        mc = _mock_cache()
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", ""), \
+             mock.patch.object(q, "_ph") as ph:
+            result = q.current_haze(_QLAT, _QLON)
+        assert result is None
+        mc.get.assert_not_called()
+        ph.record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# provider_health accounting
+# ---------------------------------------------------------------------------
+
+class TestProviderHealth:
+    def test_ok_recorded_on_successful_parse(self):
+        with mock.patch.object(q, "_ph") as ph:
+            q._parse(_feed(pm25=50), _QLAT, _QLON)
+        ph.record.assert_called_once_with("waqi", "ok")
+
+    def test_ok_recorded_even_when_station_too_far(self):
+        # The API call itself succeeded — only the reading is discarded.
+        with mock.patch.object(q, "_ph") as ph:
+            q._parse(_feed(pm25=200, geo=_FAR_GEO), _QLAT, _QLON)
+        ph.record.assert_called_once_with("waqi", "ok")
+
+    def test_429_records_degraded(self):
+        err = urllib.error.HTTPError(q.WAQI_URL, 429, "rate limited", {}, io.BytesIO())
+        with mock.patch.object(q._http, "urlopen", side_effect=err), \
+             mock.patch.object(q, "_ph") as ph, \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             pytest.raises(RuntimeError):
+            q._fetch_url(_QLAT, _QLON)
+        ph.record.assert_called_once_with("waqi", "degraded", "HTTP 429")
+
+    def test_unreachable_records_error(self):
+        err = urllib.error.URLError("dns failure")
+        with mock.patch.object(q._http, "urlopen", side_effect=err), \
+             mock.patch.object(q, "_ph") as ph, \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             pytest.raises(RuntimeError):
+            q._fetch_url(_QLAT, _QLON)
+        assert ph.record.call_args.args[:2] == ("waqi", "error")
+
+    def test_non_ok_status_records_error(self):
+        with mock.patch.object(q, "_ph") as ph, \
+             pytest.raises(RuntimeError):
+            q._parse(_feed(pm25=50, status="error"), _QLAT, _QLON)
+        ph.record.assert_called_once_with("waqi", "error", "status=error")


### PR DESCRIPTION
## What changed

**Live haze cross-check (WAQI).** Open-Meteo's CAMS air-quality forecast sits on a coarse
45 km *global* grid outside Europe and can miss fast-moving events (wildfire smoke) that
ground stations already see. Adds a real-time PM2.5 (fallback PM10) station reading, shown
**only** on the Night Timeline's live "▶ Now" row when it crosses this app's own
forecast-side haze threshold — an informational cross-check, not a replacement for the
existing weather score or the hourly forecast-driven Haze icon (both untouched).

- Uses the pollutant-specific PM2.5/PM10 sub-index, never WAQI's blended top-level `aqi`
  (that's max() over all pollutants, including gas-phase ones like ozone that don't scatter
  starlight).
- Hazy cutoff: sub-index > 100 — EPA's PM2.5 breakpoint table puts AQI 100 at ~35.4 µg/m³,
  matching this app's existing forecast-side threshold (`icons.tsx` `pmHazy: pm25 > 35`).
- **Distance filter**: rejects WAQI's "nearest station" beyond 100 km (mirrors this app's
  own Find Sky Nearby default radius) — found live during testing that a Kampala/Nairobi
  query returned a station in Mayotte, ~14,700 km away.
- Badge + footer attribution only render when the Night Timeline's live "Now" row exists
  (i.e. actually nighttime) — the backend still fetches regardless of day/night (date-gated
  only), avoiding an orphaned attribution with nothing visible to explain it.
- Attribution to the World Air Quality Index Project in the badge tooltip, the weather
  provenance footer, README, ACKNOWLEDGMENTS.md, and the site footer.

**Provider health monitoring.** The existing 5-min provider-health Lambda only watched
Open-Meteo/7Timer. Added WAQI (with a body-aware check — it returns HTTP 200 even on an
invalid token, so a plain status check would never catch a revoked key) and NOAA SWPC
(the aurora forecast's data source, plain 200/404, no quirk). Celestrak stays excluded on
purpose — a 5-minute synthetic check risks its rate limits.

**Docs**: README, ACKNOWLEDGMENTS.md, and the site footer now credit WAQI and NOAA SWPC
(the latter was previously undocumented despite the aurora feature already shipping).

## Test plan

- [x] `python -m pytest -q` — 794 passed, 9 skipped (27 new tests in `test_aqicn.py`,
      including the distance-filter cases)
- [x] `tsc -b` clean
- [x] Live-verified against real WAQI data: Jakarta (hazy, nighttime) shows the full badge +
      footer; New York (hazy, but currently daytime) correctly shows neither; Kampala/Nairobi
      (previously misattributed to a Mayotte station) now correctly return no reading
- [x] `PyNightSkyProviderHealth` deployed and live-verified: manual Lambda invoke returns
      `{"checked": ["open-meteo", "7timer", "swpc", "waqi"]}`, DynamoDB shows all four `UP`,
      `waqiDownAlarm`/`swpcDownAlarm` exist in CloudWatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)