### PR TITLE
rebrand: FastAPI OpenAPI title + Postman file rename

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -83,7 +83,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="PyNightSky API", version="0.1.0",
+app = FastAPI(title="DarkHours API", version="0.1.0",
               description="Night-sky quality scoring for astrophotography planning.",
               lifespan=lifespan)
 

--- a/postman/DarkHours.local.postman_environment.json
+++ b/postman/DarkHours.local.postman_environment.json
@@ -1,6 +1,6 @@
 {
   "id": "b1c2d3e4-0000-4000-8000-pynightskyloc",
-  "name": "PyNightSky — Local",
+  "name": "DarkHours — Local",
   "values": [
     {
       "key": "baseUrl",

--- a/postman/DarkHours.postman_collection.json
+++ b/postman/DarkHours.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "name": "PyNightSky API",
+    "name": "DarkHours API",
     "_postman_id": "a1b2c3d4-0000-4000-8000-pynightsky01",
     "description": "Night-sky quality scoring API (FastAPI). All endpoints are GET, no auth (CloudFront→Lambda is signed by OAC, transparent to the client).\n\n## Setup\nSet the `baseUrl` variable via an Environment:\n- Local:  http://localhost:8080  (run: `uvicorn apps.api.main:app --reload --port 8080`)\n- AWS:    the CloudFront URL (kept out of the repo — paste it into a Postman environment)\n\n## Notes\n- **Weather/forecast horizon:** `weather=true` only fills in once the date is within ~7 days of today; further out you'll see `wx_pending: true` (not an error). Past dates use the ERA5 archive (no seeing).\n- **CloudFront caching:** responses are cached ~5 min keyed on the full query string. To force a fresh Lambda hit, enable the disabled `_` (cache-bust) param on a request.\n- **Validation:** bad/missing inputs return 4xx with a JSON `detail` message — see the 'Validation (expect 4xx)' folder.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"


### PR DESCRIPTION
## Summary
- `FastAPI(title=...)` drives the live `/docs` Swagger UI page title, seen by anyone hitting the API directly — updated from "PyNightSky API" to "DarkHours API".
- Renames the Postman collection/environment files to match (`DarkHours.*.json`) and updates their internal display `name` fields. The `.aws` environment file is gitignored (holds the real CloudFront URL) so it's untracked either way.
- Leaves the internal `id`/`_postman_id` UUID-style fields untouched since changing them could make Postman treat a re-import as a new collection.

Independent of the other rebrand PRs (#127, #128, #129) — branched off main directly.

## Test plan
- [x] Full `pytest -q` suite green
- [x] `app.title` confirmed "DarkHours API" in-process
- [x] Postman JSON files validated as parseable

🤖 Generated with [Claude Code](https://claude.com/claude-code)