### PR TITLE
web: promote hidden differentiators + fix dashboard friction points

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -553,7 +553,9 @@ export default function App() {
                 ? <span className="scope-item scope-dim"><span className="scope-brk">[ ]</span>Weather<span className="scope-diag"> · Out of range</span></span>
                 : <span className="scope-item"><span className="scope-brk">[■]</span>Weather</span>
               }
-              <span className="scope-item"><span className="scope-brk">[■]</span>Sky Features</span>
+              <span className="scope-item"><span className="scope-brk">[■]</span>Targets &amp; Milky Way</span>
+              <span className="scope-item"><span className="scope-brk">[■]</span>Space Weather Events</span>
+              <span className="scope-item"><span className="scope-brk">[■]</span>Meteor Showers</span>
               {wxForecastUnavailable
                 ? <span className="scope-item scope-dim"><span className="scope-brk">[ ]</span>Clear Dark Hours<span className="scope-diag"> · Out of range</span></span>
                 : <span className="scope-item"><span className="scope-brk">[■]</span>Clear Dark Hours</span>
@@ -589,25 +591,23 @@ export default function App() {
 
           <div className="es-score-scale">
             <div className="es-score-bar" />
-            <div className="es-score-labels">
-              <span>Poor</span>
-              <span>Fair</span>
-              <span>Good</span>
-              <span>Excellent</span>
-            </div>
           </div>
 
           <span className="es-caps-label">Features</span>
 
-          {/* Ordered by differentiation, not data category: the four features no
-              competitor has lead; commodity metrics are swept into the
-              "fundamentals" line below rather than given tiles. */}
+          {/* Ordered by differentiation, not data category: exclusive differentiators
+              first, then distinctive modeling, then commodity metrics; the rest is
+              swept into the "fundamentals" line below rather than given tiles. */}
           <div className="es-caps">
             {([
               ['Target Windows',    'Every shootable target with its peak time and window, and why others are blocked due to clouds, moonwash, or light domes.'],
               ['Milky Way Planner', 'A 360° view of the galactic plane over your horizon—altitude, bearing, and the best minute to shoot.'],
               ['Sky & Horizon Glow', 'A horizon map of light domes around you. Know more than just the Bortle.'],
               ['Nearby Dark Sky',   'Search for low bortle locations you can actually reach, with routing to facilities like parking, campgrounds, and viewpoints. All sorted by drive times.'],
+              ['Moonlight Modeling', 'Most tools treat the moon as binary: up means ruined. DarkHours models real scattered moonlight brightening at your target from live aerosol data. A crescent barely registers. A bright gibbous gets called out.'],
+              ['360° Sky Simulation', "Drag around a rendered dome of tonight's actual sky: stars, Milky Way, moon phase, and light domes to scale. Scrub sunset to sunrise and watch visibility accurately change with conditions across the timeline"],
+              ['Aurora Forecast', 'NOAA space-weather data run through a geomagnetic visibility model for your exact location. Tiered honestly as overhead, naked eye, camera capture only, with the bearing to look toward.'],
+              ['Satellite Passes', "ISS, Hubble, and Tiangong passes with rise, peak, and set times. Newly launched Starlink trains are tracked while they're still bunched and bright."],
               ['30 Day Best Night', 'A 30 day outlook. Compare conditions across multiple nights to identify the best windows.'],
               ['Smoke & Haze Forecast',  'Wildfire smoke and upper-air aerosol data from ground sensors, and satellites.'],
               ['Meteor Shower Predictions', 'Know when the next meteor shower will peak, the estimated meteors per hour, and visibility from your location.'],
@@ -620,9 +620,12 @@ export default function App() {
             ))}
           </div>
 
-          <p className="es-caps-more">
-            Plus the fundamentals: Bortle class & SQM analysis, clear weather dark hours calcuations, seeing & transparency forecasts, and cloud layers by altitude. Every metric sourced and time-stamped. Free, open-source, no account required.
-          </p>
+          <div className="es-caps-more">
+            <span className="es-cap-k es-caps-more-label">Plus the fundamentals:</span>
+            <p className="es-caps-more-body">
+              Bortle class & SQM analysis, clear weather dark hours calculations, seeing & transparency forecasts, and cloud layers by altitude. Also a one-tap red night-vision mode for checking the forecast at 2 AM without losing your dark adaptation. Every metric sourced and time-stamped. Free, open-source, no account required.
+            </p>
+          </div>
 
           <div className="es-divider" />
 
@@ -663,34 +666,44 @@ export default function App() {
       )}
 
       <footer className="colophon">
-        Light pollution:{' '}
-        <a href="https://doi.org/10.5880/GFZ.1.4.2016.001" target="_blank" rel="noreferrer">Falchi et al. 2016</a>
-        {' / '}
-        <a href="https://www2.lightpollutionmap.info" target="_blank" rel="noreferrer">VIIRS Black Marble 2025</a>
-        {' · '}Weather:{' '}
-        <a href="https://open-meteo.com" target="_blank" rel="noreferrer">Open-Meteo</a>
-        {' / '}
-        <a href="https://github.com/Yeqzids/7timer-issues/wiki" target="_blank" rel="noreferrer">7Timer</a>
-        {' · '}Live haze:{' '}
-        <a href="https://waqi.info" target="_blank" rel="noreferrer">World Air Quality Index Project</a>
-        {' · '}Aurora:{' '}
-        <a href="https://www.swpc.noaa.gov/" target="_blank" rel="noreferrer">NOAA SWPC</a>
-        <br />
-        Satellites:{' '}
-        <a href="https://celestrak.org" target="_blank" rel="noreferrer">CelesTrak</a>
-        {' · '}Ephemeris:{' '}
-        <a href="https://ssd.jpl.nasa.gov/" target="_blank" rel="noreferrer">NASA/JPL DE421</a>
-        {' · '}Moon imagery:{' '}
-        <a href="https://svs.gsfc.nasa.gov/4874" target="_blank" rel="noreferrer">NASA SVS</a>
-        <br />
-        Nearby places:{' '}
-        <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">© OpenStreetMap contributors</a>
-        {' (ODbL)'}
-        <br />
-        Source:{' '}
-        <a href="https://github.com/mbeher2200/DarkHours" target="_blank" rel="noreferrer">GitHub</a>
-                <br /><br />
-        DarkHours is free, open source, and will never require your email address. Visit our <a href="/blog/" target="_blank" rel="noreferrer">blog</a>!
+        <div className="colophon-label">Data</div>
+        <div className="colophon-sources">
+          Light pollution:{' '}
+          <a href="https://doi.org/10.5880/GFZ.1.4.2016.001" target="_blank" rel="noreferrer">Falchi et al. 2016</a>
+          {' / '}
+          <a href="https://www2.lightpollutionmap.info" target="_blank" rel="noreferrer">VIIRS Black Marble 2025</a>
+          {' · '}Weather:{' '}
+          <a href="https://open-meteo.com" target="_blank" rel="noreferrer">Open-Meteo</a>
+          {' / '}
+          <a href="https://github.com/Yeqzids/7timer-issues/wiki" target="_blank" rel="noreferrer">7Timer</a>
+          {' · '}Live haze:{' '}
+          <a href="https://waqi.info" target="_blank" rel="noreferrer">World Air Quality Index Project</a>
+          {' · '}Aurora:{' '}
+          <a href="https://www.swpc.noaa.gov/" target="_blank" rel="noreferrer">NOAA SWPC</a>
+          <br />
+          Satellites:{' '}
+          <a href="https://celestrak.org" target="_blank" rel="noreferrer">CelesTrak</a>
+          {' · '}Ephemeris:{' '}
+          <a href="https://ssd.jpl.nasa.gov/" target="_blank" rel="noreferrer">NASA/JPL DE421</a>
+          {' · '}Moon imagery:{' '}
+          <a href="https://svs.gsfc.nasa.gov/4874" target="_blank" rel="noreferrer">NASA SVS</a>
+          <br />
+          Nearby places:{' '}
+          <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">© OpenStreetMap contributors</a>
+          {' (ODbL)'}
+        </div>
+
+        <p className="colophon-tagline">
+          DarkHours is free,{' '}
+          <a href="https://github.com/mbeher2200/DarkHours" target="_blank" rel="noreferrer">open source</a>
+          , and will never require your email address. Visit our{' '}
+          <a href="/blog/" target="_blank" rel="noreferrer">blog</a>!
+        </p>
+
+        <p className="colophon-legal">
+          © 2026 DarkHours contributors. Released under the{' '}
+          <a href="https://github.com/mbeher2200/DarkHours/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT License</a>.
+        </p>
       </footer>
     </div>
   )

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,6 +34,7 @@ export default function App() {
   const [lat, setLat] = useState('')
   const [lon, setLon] = useState('')
   const [date, setDate] = useState(tonightIso())
+  const [scopeOpen, setScopeOpen] = useState(true)
   const [imperial, setImperial] = useState<boolean>(defaultImperial)
   const [locating, setLocating] = useState(false)
   const [redMode, setRedMode] = useState<boolean>(() => localStorage.getItem('redMode') === '1')
@@ -98,6 +99,7 @@ export default function App() {
   })()
 
   async function runQuery(q: NightQuery) {
+    setScopeOpen(false)
     setLoading(true)
     setError(null)
     try {
@@ -204,6 +206,17 @@ export default function App() {
       q.lon = lo
     }
     runQuery(q)
+  }
+
+  // Jump to an alternate location (e.g. a "Find Sky Nearby" result) without losing
+  // the currently-viewed date or doing a full page reload — reuses the same
+  // runQuery path as every other in-app query trigger.
+  function selectNearbyLocation(la: number, lo: number) {
+    setMode('coords')
+    setLat(String(la))
+    setLon(String(lo))
+    const { wxUnavail, satUnavail } = availabilityFor(date)
+    runQuery({ lat: la, lon: lo, date, weather: !wxUnavail, targets: true, satellites: !satUnavail })
   }
 
   // Bubble-up target for ReportCard's "View Details" drill-in (a date-only
@@ -383,7 +396,7 @@ export default function App() {
                 type="text"
                 placeholder="e.g. Cherry Springs State Park"
                 value={place}
-                onChange={(e) => { setPlace(e.target.value); setActiveIndex(-1); setPlaceDropdown(true) }}
+                onChange={(e) => { setPlace(e.target.value); setActiveIndex(-1); setPlaceDropdown(true); setScopeOpen(true) }}
                 onFocus={() => setPlaceDropdown(true)}
                 onKeyDown={(e) => {
                   if (e.key === 'ArrowDown' && showDropdown) {
@@ -486,7 +499,7 @@ export default function App() {
                 step="any"
                 placeholder="40.7"
                 value={lat}
-                onChange={(e) => setLat(e.target.value)}
+                onChange={(e) => { setLat(e.target.value); setScopeOpen(true) }}
               />
             </label>
             <label className="field">
@@ -496,7 +509,7 @@ export default function App() {
                 step="any"
                 placeholder="-74.0"
                 value={lon}
-                onChange={(e) => setLon(e.target.value)}
+                onChange={(e) => { setLon(e.target.value); setScopeOpen(true) }}
               />
             </label>
           </div>
@@ -504,14 +517,24 @@ export default function App() {
 
         <div className="field">
           <label htmlFor="dp-trigger" className="field-label">Date</label>
-          <DatePicker value={date} min="1900-01-01" max="2050-12-31" onChange={setDate} />
+          <div className="date-nav-row">
+            <button type="button" className="day-nav" onClick={() => shiftDay(-1)} disabled={loading || locating} aria-label="Previous day">
+              <ChevronLeft size={18} strokeWidth={2.5} />
+            </button>
+            <DatePicker value={date} min="1900-01-01" max="2050-12-31" onChange={(d) => { setDate(d); setScopeOpen(true) }} />
+            <button type="button" className="day-nav" onClick={() => shiftDay(1)} disabled={loading || locating} aria-label="Next day">
+              <ChevronRight size={18} strokeWidth={2.5} />
+            </button>
+          </div>
         </div>
 
         <div className="scope-row">
-          {/* Scope indicators read as config noise before first use — collapsed
-              by default, with any availability diagnostic kept visible in the
-              summary line so date-range limits still surface without expanding. */}
-          <details className="scope-details">
+          {/* Expanded by default so the system's assumptions are visible before the
+              user commits to a search; collapses once a query actually fires
+              (see runQuery) and re-expands when the query target — date or
+              place/coords — changes, keeping the availability diagnostic reachable
+              without permanently cluttering the form. */}
+          <details className="scope-details" open={scopeOpen} onToggle={(e) => setScopeOpen(e.currentTarget.open)}>
             <summary className="scope-summary">
               Report scope
               {(wxForecastUnavailable || satUnavailable) && (
@@ -544,17 +567,9 @@ export default function App() {
           </details>
         </div>
 
-        <div className="submit-row">
-          <button type="button" className="day-nav" onClick={() => shiftDay(-1)} disabled={loading || locating} aria-label="Previous day">
-            <ChevronLeft size={18} strokeWidth={2.5} />
-          </button>
-          <button type="submit" className="submit" disabled={loading}>
-            {loading ? 'Scoring…' : 'Score the night'}
-          </button>
-          <button type="button" className="day-nav" onClick={() => shiftDay(1)} disabled={loading || locating} aria-label="Next day">
-            <ChevronRight size={18} strokeWidth={2.5} />
-          </button>
-        </div>
+        <button type="submit" className="submit" disabled={loading}>
+          {loading ? 'Scoring…' : 'Score the night'}
+        </button>
       </form>
 
       {error && <div className="card error">{error}</div>}
@@ -642,6 +657,8 @@ export default function App() {
           imperial={imperial}
           onToggleUnits={toggleUnits}
           onDateDetail={handleDateDetail}
+          onSelectLocation={selectNearbyLocation}
+          redMode={redMode}
         />
       )}
 

--- a/apps/web/src/OutlookTelemetryRibbon.tsx
+++ b/apps/web/src/OutlookTelemetryRibbon.tsx
@@ -22,15 +22,42 @@ function dateParts(iso: string): { dow: string; mmdd: string; long: string; long
   return { dow: DOW[d.getDay()], mmdd: `${mm}/${dd}`, long, longWithYear }
 }
 
-// Monochromatic luminance map: the raw score alone drives the cell wash's
-// opacity (continuous, not banded) — hue never changes, and higher scores
-// are darker/more saturated. A score of 0 is fully clear (no tint at all —
-// just the plain card background); opacity scales linearly up to ~15% for
-// the best possible night, maintaining contrast while preventing the pure
-// black wash from reading too heavily.
+// The raw score alone drives the cell wash's opacity (continuous, not banded).
+// A score of 0 is fully clear (no tint at all — just the plain card background);
+// opacity scales linearly up to ~15% for the best possible night, maintaining
+// contrast while preventing the wash from reading too heavily.
 function cellAlpha(score: number): number {
-  const clamped = Math.max(0, Math.min(9, score))
-  return (clamped / 9) * 0.15
+  const clamped = Math.max(0, Math.min(10, score))
+  return (clamped / 10) * 0.15
+}
+
+// Astronomy-themed hue gradient for the wash color itself: deep red (poor, score 0)
+// through amber (fair) to deep star-field green (excellent, score 10), interpolated
+// continuously rather than banded into four flat colors. Stops reuse the app's
+// existing semantic score tokens (--poor/--fair/--excellent) so the hue matches what
+// those words mean elsewhere in the UI. Red mode never sees this — it keeps the
+// neutral --dh-wash-rgb wash, which 02-red-mode.css already force-remaps to pure red;
+// this function's output is only wired up for the non-red-mode case (see below).
+const WASH_STOPS: [number, [number, number, number]][] = [
+  [0, [200, 86, 86]],    // --poor #C85656
+  [5, [217, 155, 65]],   // --fair #D99B41
+  [10, [58, 135, 114]],  // --excellent #3A8772
+]
+
+function cellWashColor(score: number): string {
+  const clamped = Math.max(0, Math.min(10, score))
+  let [loScore, loRgb] = WASH_STOPS[0]
+  let [hiScore, hiRgb] = WASH_STOPS[WASH_STOPS.length - 1]
+  for (let i = 0; i < WASH_STOPS.length - 1; i++) {
+    if (clamped >= WASH_STOPS[i][0] && clamped <= WASH_STOPS[i + 1][0]) {
+      ;[loScore, loRgb] = WASH_STOPS[i]
+      ;[hiScore, hiRgb] = WASH_STOPS[i + 1]
+      break
+    }
+  }
+  const t = hiScore === loScore ? 0 : (clamped - loScore) / (hiScore - loScore)
+  const rgb = loRgb.map((c, i) => Math.round(c + (hiRgb[i] - c) * t))
+  return rgb.join(', ')
 }
 
 /**
@@ -42,13 +69,14 @@ function cellAlpha(score: number): number {
  * factor in.
  */
 export default function OutlookTelemetryRibbon({
-  data, startExpanded, onViewDetails, isFetchingDetails, viewDetailsError,
+  data, startExpanded, onViewDetails, isFetchingDetails, viewDetailsError, redMode,
 }: {
   data: CalendarResult
   startExpanded?: boolean
   onViewDetails: (date: string) => void
   isFetchingDetails?: boolean
   viewDetailsError?: string | null
+  redMode?: boolean
 }) {
   const nights = useMemo(() => [...data.nights].sort((a, b) => a.date.localeCompare(b.date)), [data.nights])
   const best = data.ranked[0] as CalendarNight | undefined
@@ -119,7 +147,10 @@ export default function OutlookTelemetryRibbon({
                       isSelected ? 'selected' : '',
                       isBest ? 'best' : '',
                     ].filter(Boolean).join(' ')}
-                    style={n.score != null ? ({ '--cell-alpha': cellAlpha(n.score) } as CSSProperties) : undefined}
+                    style={n.score != null ? ({
+                      '--cell-alpha': cellAlpha(n.score),
+                      ...(redMode ? {} : { '--cell-wash-rgb': cellWashColor(n.score) }),
+                    } as CSSProperties) : undefined}
                     onClick={() => setSelectedDate(n.date)}
                     aria-pressed={isSelected}
                     title={`${dow} ${mmdd} — ${n.score != null ? n.score.toFixed(1) : 'N/A'}${isBest ? ' (best night)' : ''} · ${n.phase_name}${n.meteor_shower ? ` · ${n.meteor_shower.name} meteor shower (${n.meteor_shower.note})` : ''}${n.aurora ? ` · Aurora Kp ${n.aurora.kp_max}${n.aurora.noaa_scale ? ` (${n.aurora.noaa_scale})` : ''} — ${AURORA_TIER_LABELS[n.aurora.tier]}` : ''}`}

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -74,6 +74,8 @@ export default function ReportCard({
   imperial = false,
   onToggleUnits,
   onDateDetail,
+  onSelectLocation,
+  redMode,
 }: {
   report: NightReport
   showWeather?: boolean
@@ -82,6 +84,8 @@ export default function ReportCard({
   imperial?: boolean
   onToggleUnits?: (imp: boolean) => void
   onDateDetail?: (next: NightReport, date: string) => void
+  onSelectLocation?: (lat: number, lon: number) => void
+  redMode?: boolean
 }) {
   const [nearbyState, setNearbyState] = useState<
     | { phase: 'idle' }
@@ -578,7 +582,7 @@ export default function ReportCard({
                 <p className="sat-notice">{nearbyState.message}</p>
               )}
               {nearbyState.phase === 'done' && (
-                <NearbyResults data={nearbyState.data} imperial={imperial} originLat={report.lat} originLon={report.lon} />
+                <NearbyResults data={nearbyState.data} imperial={imperial} originLat={report.lat} originLon={report.lon} onSelectLocation={onSelectLocation} />
               )}
             </div>
           </div>
@@ -599,6 +603,7 @@ export default function ReportCard({
                   onViewDetails={handleViewDetails}
                   isFetchingDetails={isFetchingDetails}
                   viewDetailsError={dateFetch.phase === 'error' ? dateFetch.message : null}
+                  redMode={redMode}
                 />
               )}
             </div>

--- a/apps/web/src/report/Nearby.tsx
+++ b/apps/web/src/report/Nearby.tsx
@@ -15,8 +15,8 @@ export function nearbyBortleClass(bortleClass: number | null): string {
 }
 
 export function NearbyResults(
-  { data, imperial, originLat, originLon }:
-  { data: NearbyResult; imperial: boolean; originLat: number; originLon: number },
+  { data, imperial, originLat, originLon, onSelectLocation }:
+  { data: NearbyResult; imperial: boolean; originLat: number; originLon: number; onSelectLocation?: (lat: number, lon: number) => void },
 ) {
   const { origin_bortle, origin_sqm, radius_miles, results, light_domes, best_available } = data
   const sqmStr = origin_sqm != null ? ` (SQM ${origin_sqm.toFixed(1)})` : ''
@@ -53,8 +53,35 @@ export function NearbyResults(
     summer_camp: 'Summer camp', firepit: 'Fire pit', beach_resort: 'Beach resort',
     historic: 'Historic site',
   }
-  // Render a place name with a category badge (routable POIs) or a "Remote" tag (off-road
-  // fallbacks), plus a Google Maps driving-directions link on every result.
+  // A Google Maps driving-directions link, or a "no road access" notice when routing
+  // was attempted but couldn't reach this POI (e.g. a ferry-only crossing).
+  const mapLinkNode = (p: NearbyPlace) =>
+    routingActive && p.is_poi && p.drive_minutes == null ? (
+      <span className="poi-unroutable" title="No direct road access — routing avoided a ferry-only crossing">No road access</span>
+    ) : (
+      <a className="poi-maplink" href={dirLink(p)} target="_blank" rel="noopener noreferrer" aria-label="Directions" onClick={(e) => e.stopPropagation()}><Navigation size={12} strokeWidth={2} /></a>
+    )
+  // Category badge (routable POIs) or "Remote" tag (off-road fallbacks), any routing
+  // warnings, and a Maps link — shared by the prose call sites and the results table.
+  // `showMapLink` is false for the table, which renders its own Maps link in the Dir
+  // column instead, next to the drive-time estimate.
+  const poiMeta = (p: NearbyPlace, showMapLink: boolean) => (
+    <span className="poi-type-link">
+      {p.is_poi
+        ? (p.poi_type && <span className="poi-badge">{POI_TYPE_LABEL[p.poi_type] ?? p.poi_type}</span>)
+        : <span className="poi-remote">Remote</span>}
+      {p.warnings?.map((warn, idx) => (
+        <span key={idx} className="poi-warning">{warn}</span>
+      ))}
+      {p.tail_miles != null && (
+        <span className="poi-warning">Last {fmtMi(p.tail_miles)} not drivable</span>
+      )}
+      {showMapLink && mapLinkNode(p)}
+    </span>
+  )
+  // Render a place name (as a link) with its category badge/warnings and a Maps link —
+  // used by the prose highlight/empty-state lines, which have no table row to attach a
+  // click handler to and so keep the original click-through-to-app-link behavior.
   const placeNode = (p: NearbyPlace) => {
     // No name/area passed here — the destination report re-derives the same POI name
     // itself from lat/lon against the trusted local index (darkhours.location
@@ -64,22 +91,7 @@ export function NearbyResults(
       <>
         <a className="poi-namelink" href={appLink}>{placeStr(p)}</a>
         {p.area_name && <span className="poi-area">{p.area_name}</span>}
-        <span className="poi-type-link">
-          {p.is_poi
-            ? (p.poi_type && <span className="poi-badge">{POI_TYPE_LABEL[p.poi_type] ?? p.poi_type}</span>)
-            : <span className="poi-remote">Remote</span>}
-          {p.warnings?.map((warn, idx) => (
-            <span key={idx} className="poi-warning">{warn}</span>
-          ))}
-          {p.tail_miles != null && (
-            <span className="poi-warning">Last {fmtMi(p.tail_miles)} not drivable</span>
-          )}
-          {routingActive && p.is_poi && p.drive_minutes == null ? (
-            <span className="poi-unroutable" title="No direct road access — routing avoided a ferry-only crossing">No road access</span>
-          ) : (
-            <a className="poi-maplink" href={dirLink(p)} target="_blank" rel="noopener noreferrer" aria-label="Directions"><Navigation size={12} strokeWidth={2} /></a>
-          )}
-        </span>
+        {poiMeta(p, true)}
       </>
     )
   }
@@ -185,18 +197,35 @@ export function NearbyResults(
                       if (bd == null) return -1
                       return ad - bd || a.bortle_class - b.bortle_class
                     })
-                    .map((p, i) => (
-                      <tr key={i}>
-                        <td className={`${nearbyBortleClass(p.bortle_class)} nearby-area-td`}>
-                          <div className="nearby-area-inner">{placeNode(p)}</div>
-                        </td>
-                        <td className={`wx-num nearby-bortle-col ${nearbyBortleClass(p.bortle_class)}`}>{p.bortle_class}</td>
-                        <td className="wx-num nearby-sqm-col">{p.sqm != null ? p.sqm.toFixed(1) : '—'}</td>
-                        <td className="wx-num nearby-dist-col">{distOf(p)}</td>
-                        {routingActive && <td className="wx-num nearby-drive-col">{formatDriveTime(p.drive_minutes) ?? '—'}</td>}
-                        <td className="wx-num nearby-dir-col">{p.direction}</td>
-                      </tr>
-                    ))}
+                    .map((p, i) => {
+                      const activate = () => onSelectLocation?.(p.lat, p.lon)
+                      return (
+                        <tr
+                          key={i}
+                          className="nearby-row-clickable"
+                          onClick={activate}
+                          tabIndex={0}
+                          role="link"
+                          aria-label={`View night report for ${placeStr(p)}`}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate() }
+                          }}
+                        >
+                          <td className={`${nearbyBortleClass(p.bortle_class)} nearby-area-td`}>
+                            <div className="nearby-area-inner">
+                              <span className="poi-namelink">{placeStr(p)}</span>
+                              {p.area_name && <span className="poi-area">{p.area_name}</span>}
+                              {poiMeta(p, false)}
+                            </div>
+                          </td>
+                          <td className={`wx-num nearby-bortle-col ${nearbyBortleClass(p.bortle_class)}`}>{p.bortle_class}</td>
+                          <td className="wx-num nearby-sqm-col">{p.sqm != null ? p.sqm.toFixed(1) : '—'}</td>
+                          <td className="wx-num nearby-dist-col">{distOf(p)}</td>
+                          {routingActive && <td className="wx-num nearby-drive-col">{formatDriveTime(p.drive_minutes) ?? '—'}</td>}
+                          <td className="wx-num nearby-dir-col">{p.direction} {mapLinkNode(p)}</td>
+                        </tr>
+                      )
+                    })}
                 </tbody>
               </table>
             </div>

--- a/apps/web/src/styles/03-form.css
+++ b/apps/web/src/styles/03-form.css
@@ -205,6 +205,15 @@
   flex-direction: column;
   gap: 6px;
 }
+.date-nav-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.date-nav-row .dp-wrap {
+  flex: 1;
+  min-width: 0;
+}
 .field > span {
   font-size: 10px;
   font-family: var(--mono);
@@ -426,14 +435,6 @@ html.red-mode .info-tip-bubble {
   border: none;
 }
 
-.submit-row {
-  display: flex;
-  gap: 8px;
-  align-items: stretch;
-}
-.submit-row .submit {
-  flex: 1;
-}
 .submit {
   padding: 13px;
   border: 0;

--- a/apps/web/src/styles/06-planning.css
+++ b/apps/web/src/styles/06-planning.css
@@ -117,6 +117,20 @@
 .wx-table td.nearby-bortle-good      { color: var(--good); }
 .wx-table td.nearby-bortle-fair      { color: var(--fair); }
 .wx-table td.nearby-bortle-poor      { color: var(--poor); }
+/* Whole-row navigation: clicking anywhere in a result row jumps to that location
+   (see App.tsx's selectNearbyLocation). The shared .wx-table hover rule already
+   applies here (nearby-table carries the wx-table class); strengthen it slightly
+   since these rows are actionable, unlike the read-only weather table. */
+.nearby-table tbody tr.nearby-row-clickable {
+  cursor: pointer;
+}
+.nearby-table tbody tr.nearby-row-clickable:hover td {
+  background: rgba(var(--tint-rgb), 0.10);
+}
+.nearby-table tbody tr.nearby-row-clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .nearby-domes {
   font-size: 13px;
   display: flex;
@@ -328,7 +342,7 @@
   border: none;
   border-radius: 0;
   background-color: var(--card);
-  background-image: linear-gradient(rgba(var(--dh-wash-rgb), var(--cell-alpha, 0)), rgba(var(--dh-wash-rgb), var(--cell-alpha, 0)));
+  background-image: linear-gradient(rgba(var(--cell-wash-rgb, var(--dh-wash-rgb)), var(--cell-alpha, 0)), rgba(var(--cell-wash-rgb, var(--dh-wash-rgb)), var(--cell-alpha, 0)));
   color: var(--text-h);
   font-family: var(--mono);
   cursor: pointer;

--- a/apps/web/src/styles/07-targets-milkyway.css
+++ b/apps/web/src/styles/07-targets-milkyway.css
@@ -834,12 +834,35 @@ html.red-mode .tg-blocked-toggle:hover { color: var(--text); }
 .cond-glow { font-size: 11px; }
 
 .colophon {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   text-align: center;
-  color: var(--text-dim);
   font-size: 12px;
   line-height: 1.6;
   margin-top: 8px;
   padding-top: 10px;
   border-top: 1px solid rgba(0, 0, 0, 0.10);
   box-shadow: 0 -1px 0 rgba(255, 255, 255, 0.70);
+}
+.colophon-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-dim);
+  opacity: 0.65;
+}
+.colophon-sources {
+  color: var(--text-dim);
+}
+.colophon-tagline {
+  margin: 0;
+  color: var(--text-h);
+}
+.colophon-legal {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-dim);
+  opacity: 0.7;
 }

--- a/apps/web/src/styles/09-empty-state.css
+++ b/apps/web/src/styles/09-empty-state.css
@@ -28,7 +28,6 @@
   font-size: 13px;
   color: var(--text-dim);
   line-height: 1.65;
-  max-width: 56ch;
 }
 
 .es-score-scale {
@@ -48,16 +47,6 @@
   );
   opacity: 0.72;
 }
-.es-score-labels {
-  display: flex;
-  justify-content: space-between;
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  color: var(--text-dim);
-  opacity: 0.6;
-}
-
 .es-divider {
   height: 0;
   border: none;
@@ -156,15 +145,23 @@ html.red-mode .es-caps-label { color: var(--text-dim); }
   line-height: 1.55;
   color: var(--text-dim);
 }
-/* Table-stakes sweep: one quiet line under the differentiator tiles. */
+/* Table-stakes sweep: one quiet block under the differentiator tiles. */
 .es-caps-more {
   margin: -6px auto 0;
-  font-size: 11.5px;
-  line-height: 1.6;
-  color: var(--text-dim);
-  opacity: 0.85;
-  max-width: 72ch;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
   text-align: center;
 }
+.es-caps-more-label {
+  display: block;
+}
+.es-caps-more-body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-dim);
+}
 html.red-mode .es-cap-k { color: var(--accent); }
-html.red-mode .es-qs-hook, html.red-mode .es-cap-v, html.red-mode .es-caps-more { color: var(--text-dim); }
+html.red-mode .es-qs-hook, html.red-mode .es-cap-v, html.red-mode .es-caps-more-body { color: var(--text-dim); }


### PR DESCRIPTION
## Summary
- Promote four fully-implemented but never-marketed differentiators (moonlight modeling, 360° sky simulation, aurora forecast, satellite passes) into the landing page's feature-tile grid, and split the report-scope panel's generic "Sky Features" row so Targets & Milky Way, Space Weather Events, and Meteor Showers are each visible before a search runs.
- Widen the intro/fundamentals copy to the full card width on desktop, restyle the fundamentals lead-in to match the tile headers, drop the score bar's redundant Poor/Fair/Good/Excellent labels, and restructure the footer into a Data block, a bolded tagline, and a new copyright/license line.
- Also includes an earlier, separate fix: decouples the day-nav chevrons from "Score the night" onto the date field, makes the report-scope disclosure open by default (collapsing only once a search fires), gives the 30-day outlook heatmap a real red-to-green color scale in light mode, and makes Find Sky Nearby result rows fully clickable without a full page reload.

## Test plan
- [x] Verified in-browser at desktop (1440px) and mobile (375-420px) widths: 12-tile feature grid renders cleanly, 8-row report-scope panel wraps correctly, score bar/fundamentals/footer read as intended in both light and red night-vision mode.
- [ ] `python -m pytest -q` (no Python changes in this PR, web-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)