### PR TITLE
docs: add visible captions between README GIFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ DarkHours gives astrophotographers the information they need to decide when and 
 
 ### See it in action
 
+**360° simulated sky** — drag to pan, scrub through the night.
 ![360° simulated sky — drag to pan, scrub through the night](docs/images/skydome.gif)
 
+**Red night-vision mode** — one tap, the whole UI flips.
 ![Red night-vision mode — one tap, the whole UI flips](docs/images/redmode.gif)
 
+**Find darker sky nearby** — search, compare, click through.
 ![Find darker sky nearby — search, compare, click through](docs/images/nearby.gif)
 
 ---


### PR DESCRIPTION
## Summary
- The three feature GIFs in the README had captions only in alt text, which isn't visible in the rendered page unless an image fails to load — they read as an unlabeled wall of images.
- Add a bold one-line caption above each GIF.

This was already fixed on the `seo-and-readme-overhaul` branch, but #133 was merged before that follow-up commit landed, so it never made it to `main`. Re-applying it here as a clean, isolated PR.

## Test plan
- [x] Diff is scoped to exactly the 3 caption lines, no other changes
- [x] Rendered locally to confirm markdown syntax (bold line + image, no formatting issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)