### PR TITLE
Circuit breaker for 3rd-party provider calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,8 @@ test/scan use, which is also why `Dockerfile.worker` is in the repo at all):
 - `docs/TARGETS.md` — target catalog schema + meteor-shower ZHR decay model.
 - `docs/OBSERVABILITY.md` — CloudWatch dashboard, alarms + SNS notification wiring, log groups,
   X-Ray scope, and the Application Insights shadow-alarm gap left open on purpose.
+- `docs/CIRCUIT_BREAKER.md` — provider circuit breaker: design, per-host keys, flags,
+  detection-latency budget, and the optional (not required) monitor-wiring follow-up.
 - `docs/FEATURES.md` — user-facing feature list (validated against code).
 - `apps/web/README.md` — the DarkHours SPA: dev setup, architecture, red-mode rules.
 - `docs/CLI.md`, `docs/TRIPBUILDER.md`, `PRODUCT.md`, `README.md` — product/engine overview.

--- a/apps/web/src/OutlookTelemetryRibbon.tsx
+++ b/apps/web/src/OutlookTelemetryRibbon.tsx
@@ -193,7 +193,9 @@ export default function OutlookTelemetryRibbon({
                 {!selected.weather_informed && (
                   <p className="sat-notice">
                     Astronomy-only estimate —{' '}
-                    {selected.wx_pending
+                    {selected.wx_error
+                      ? 'weather providers are temporarily unavailable'
+                      : selected.wx_pending
                       ? 'forecast not yet available for this date'
                       : selected.wx_no_data
                       ? 'weather provider returned no data for this date'

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -387,6 +387,9 @@ export interface CalendarNight {
   weather_informed: boolean
   wx_pending: boolean
   wx_no_data: boolean
+  // Provider failure detail (mirrors NightReport.wx_error); set when the
+  // weather fetch failed or was skipped by an open circuit breaker.
+  wx_error: string | null
   meteor_shower: ActiveShower | null
   aurora: CalendarAurora | null
 }

--- a/darkhours/aqicn.py
+++ b/darkhours/aqicn.py
@@ -41,6 +41,7 @@ import urllib.error
 
 from . import _http
 from . import cache as _cache
+from . import circuit_breaker as _cb
 from . import provider_health as _ph
 
 log = logging.getLogger(__name__)
@@ -102,15 +103,22 @@ def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 def _fetch_url(lat: float, lon: float, timeout: int = 10) -> str:
     """GET the WAQI feed for (lat, lon); provider-health accounting."""
     url = WAQI_URL.format(lat=lat, lon=lon, token=_TOKEN)
+    if not _cb.allow("waqi"):
+        raise _cb.unavailable("waqi")
     try:
         with _http.urlopen(url, timeout=timeout) as resp:
             text = resp.read().decode("utf-8")
+        # Reachability success for the breaker; content-level verdicts (bad
+        # JSON, non-"ok" status in _parse) are deliberately not counted.
+        _cb.on_success("waqi")
         return text
     except urllib.error.HTTPError as e:
         _ph.record("waqi", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+        _cb.on_failure("waqi")
         raise RuntimeError(f"WAQI HTTP {e.code}") from e
     except urllib.error.URLError as e:
         _ph.record("waqi", "error", str(e.reason)[:120])
+        _cb.on_failure("waqi")
         raise RuntimeError(f"WAQI unreachable: {e.reason}") from e
 
 

--- a/darkhours/aurora.py
+++ b/darkhours/aurora.py
@@ -50,6 +50,7 @@ import urllib.request
 from datetime import date, datetime, timedelta, timezone
 
 from . import cache as _cache
+from . import circuit_breaker as _cb
 from . import _http
 from . import light_dome as _ld
 from . import moonlight as _ml
@@ -194,16 +195,21 @@ def kp_to_g_scale(kp: float) -> str | None:
 def _fetch_url(url: str, timeout: int = 10) -> str:
     """GET *url* with the project User-Agent; provider-health accounting."""
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    if not _cb.allow("swpc"):
+        raise _cb.unavailable("swpc")
     try:
         with _http.urlopen(req, timeout=timeout) as resp:
             text = resp.read().decode("utf-8")
         _ph.record("swpc", "ok")
+        _cb.on_success("swpc")
         return text
     except urllib.error.HTTPError as e:
         _ph.record("swpc", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+        _cb.on_failure("swpc")
         raise RuntimeError(f"SWPC HTTP {e.code} for {url}") from e
     except urllib.error.URLError as e:
         _ph.record("swpc", "error", str(e.reason)[:120])
+        _cb.on_failure("swpc")
         raise RuntimeError(f"SWPC unreachable: {e.reason}") from e
 
 

--- a/darkhours/circuit_breaker.py
+++ b/darkhours/circuit_breaker.py
@@ -1,0 +1,311 @@
+"""Circuit breaker for 3rd-party provider calls.
+
+Sits alongside provider_health.py (the passive "what happened last" registry
+that feeds /healthz); this module is the "should I even try" decision point.
+Provider modules call allow() before an outbound call and on_success()/
+on_failure() after it, as siblings to their existing provider_health.record()
+calls. When a provider has failed FAILURE_THRESHOLD times in a row the breaker
+opens and calls are skipped instantly (ProviderUnavailableError, no network
+I/O) instead of making every user wait through the provider's timeout.
+
+Recovery — how an OPEN breaker closes again — has two modes, chosen per call:
+
+* Monitor-driven (open_meteo, seven_timer, swpc, waqi): defer to the synthetic
+  health-check Lambda (apps/provider_health/handler.py), which probes those
+  providers every 5 minutes and writes UP/DOWN to a DynamoDB table named by
+  PYNIGHTSKY_PROVIDER_HEALTH_TABLE. A fresh DOWN blocks without spending any
+  user request on the dead provider; a fresh UP grants a single probe call —
+  the breaker only actually closes when a real call succeeds (on_success is
+  the sole OPEN->CLOSED transition), so a monitor false-UP can't silently
+  neuter the breaker. Probes are rate-limited by _PROBE_GUARD_SECONDS.
+
+* Self-timed (every other provider, and the fallback whenever no fresh
+  monitor signal exists — env var unset, read failure, stale entry): after
+  the provider's cooldown, grant a single probe; success closes, failure
+  re-arms a fresh cooldown. This is classic half-open behavior folded into
+  the OPEN state check rather than tracked as a third state.
+
+"No signal" always degrades to self-timed, never to "blocked forever" — with
+PYNIGHTSKY_PROVIDER_HEALTH_TABLE unset (the default), every provider self-times
+and this module needs no AWS access at all. Probe grants are atomic: granting
+re-arms the clock inside the state lock, so concurrent threads (predictor's
+I/O fan-out) can't all probe at once.
+
+Breaker keys are per-host, because reachability is a host property — e.g.
+open_meteo (api.open-meteo.com) vs open_meteo_archive
+(archive-api.open-meteo.com), which the codebase documents as failing
+independently. Keys match provider_health.record() names.
+
+State is in-process (per warm Lambda container), like provider_health's
+registry. Call sites only ever touch allow/on_success/on_failure — that
+indirection is what would let this state move to DynamoDB later (the deferred
+storm-throttling work) without touching any provider module, mirroring the
+local/aws adapter swaps in ports.py. A future call-metrics layer (latency,
+volume) hooks into the same three functions.
+
+Flags (read once at import, same idiom as PYNIGHTSKY_NO_CACHE):
+  PYNIGHTSKY_CIRCUIT_BREAKER_ENABLED             kill switch, default enabled
+  PYNIGHTSKY_CIRCUIT_BREAKER_<PROVIDER>_DISABLE  per-provider opt-out
+  PYNIGHTSKY_PROVIDER_HEALTH_TABLE               monitor table (optional)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------
+# Tunables
+# --------------------------------------------------------------------------
+
+FAILURE_THRESHOLD = 3     # consecutive failures before the breaker opens
+COOLDOWN_SECONDS = 60.0   # self-timed wait before granting a probe
+
+# Bound on how often a monitor false-UP can cost a user request: while OPEN
+# with the monitor reporting UP, at most one probe is granted per this many
+# seconds (per container).
+_PROBE_GUARD_SECONDS = 15.0
+
+# Per-provider (threshold, cooldown) overrides. Celestrak trips on the first
+# failure and waits 5 minutes: its TLE cache is global (one success serves all
+# users for 6h), a failed fetch never refreshes it, and Celestrak's anti-abuse
+# policy punishes exactly the concentrated-retry pattern that emerges at cache
+# expiry — while get_tle()'s stale-cache fallback makes patience free.
+_OVERRIDES: dict[str, tuple[int, float]] = {
+    "celestrak": (1, 300.0),
+}
+
+_ALL_PROVIDERS = (
+    "open_meteo",
+    "open_meteo_archive",
+    "open_meteo_air_quality",
+    "seven_timer",
+    "celestrak",
+    "waqi",
+    "swpc",
+    "nominatim",
+    "aws_location",
+    "aws_georoutes",
+)
+
+# Breaker key -> provider_id in the synthetic monitor's table. Only these four
+# are ever probed by apps/provider_health/handler.py; everything else (and any
+# read miss/staleness/error) falls back to self-timed recovery.
+_SYNTHETIC_MONITOR_ID = {
+    "open_meteo": "open-meteo",
+    "seven_timer": "7timer",
+    "swpc": "swpc",
+    "waqi": "waqi",
+}
+
+_MONITOR_STALE_AFTER = 20 * 60   # ignore monitor entries older than this (4x its schedule)
+_MONITOR_CACHE_TTL = 60.0        # in-process cache of monitor reads
+
+
+def _flag(name: str, default: str = "") -> bool:
+    return os.environ.get(name, default).strip().lower() in ("1", "true", "yes", "on")
+
+
+_ENABLED = _flag("PYNIGHTSKY_CIRCUIT_BREAKER_ENABLED", "1")
+_DISABLED_PROVIDERS = frozenset(
+    p for p in _ALL_PROVIDERS if _flag(f"PYNIGHTSKY_CIRCUIT_BREAKER_{p.upper()}_DISABLE")
+)
+_HEALTH_TABLE = os.environ.get("PYNIGHTSKY_PROVIDER_HEALTH_TABLE", "").strip()
+
+
+# --------------------------------------------------------------------------
+# State
+# --------------------------------------------------------------------------
+
+@dataclass
+class _State:
+    consecutive_failures: int = 0
+    # Monotonic timestamp of the last open/probe-grant/failed-probe event;
+    # None = CLOSED. Re-armed on every probe grant so concurrent callers block.
+    opened_at: float | None = None
+
+
+_lock = threading.Lock()
+_states: dict[str, _State] = {}
+
+# monitor_id -> (status_or_None, fetched_at_monotonic); None results are cached
+# too, so a broken table read costs its timeout once per TTL, not per call.
+_monitor_cache: dict[str, tuple[str | None, float]] = {}
+_ddb_table = None
+_ddb_lock = threading.Lock()
+
+
+class ProviderUnavailableError(RuntimeError):
+    """Raised instead of calling a provider whose breaker is open.
+
+    Subclasses RuntimeError so every existing `except RuntimeError` up the
+    stack (predictor, weather fallback chain, TLE stale-cache fallback)
+    handles a skipped call exactly like a failed one.
+    """
+
+    def __init__(self, provider: str, retry_after_seconds: float):
+        self.provider = provider
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(
+            f"{provider} unavailable (circuit open, retry in {retry_after_seconds:.0f}s)"
+        )
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+def allow(provider: str) -> bool:
+    """True if a call to *provider* should be attempted now.
+
+    CLOSED (or breaker disabled) -> True. OPEN -> False, except when a probe
+    is granted: monitor-driven (fresh UP, probe-guard elapsed) or self-timed
+    (cooldown elapsed). Granting atomically re-arms the clock so exactly one
+    concurrent caller wins the probe.
+    """
+    if not _ENABLED or provider in _DISABLED_PROVIDERS:
+        return True
+    with _lock:
+        st = _states.get(provider)
+        if st is None or st.opened_at is None:
+            return True
+    # OPEN. Consult the monitor outside the lock — the (rare, cached) table
+    # read may block ~1-2s and must not stall other providers' allow() calls.
+    monitor = _synthetic_status(provider) if provider in _SYNTHETIC_MONITOR_ID else None
+    now = time.monotonic()
+    _, cooldown = _limits(provider)
+    with _lock:
+        st = _states.get(provider)
+        if st is None or st.opened_at is None:   # closed while we were reading
+            return True
+        if monitor == "DOWN":
+            return False
+        wait = _PROBE_GUARD_SECONDS if monitor == "UP" else cooldown
+        if now - st.opened_at >= wait:
+            st.opened_at = now   # claim the probe; concurrent callers stay blocked
+            return True
+        return False
+
+
+def on_success(provider: str) -> None:
+    """Record a successful call: reset the failure streak, close if open."""
+    with _lock:
+        st = _states.get(provider)
+        if st is not None:
+            st.consecutive_failures = 0
+            st.opened_at = None
+
+
+def on_failure(provider: str) -> None:
+    """Record a failed call: count it, open at the threshold, re-arm if open."""
+    threshold, _ = _limits(provider)
+    with _lock:
+        st = _states.setdefault(provider, _State())
+        st.consecutive_failures += 1
+        if st.consecutive_failures >= threshold:
+            st.opened_at = time.monotonic()
+
+
+def is_open(provider: str) -> bool:
+    """Read-only state check for diagnostics — never mutates."""
+    with _lock:
+        st = _states.get(provider)
+        return st is not None and st.opened_at is not None
+
+
+def retry_after(provider: str) -> float:
+    """Seconds until the next self-timed probe would be granted (0 if closed)."""
+    _, cooldown = _limits(provider)
+    with _lock:
+        st = _states.get(provider)
+        if st is None or st.opened_at is None:
+            return 0.0
+        return max(0.0, cooldown - (time.monotonic() - st.opened_at))
+
+
+def unavailable(provider: str) -> ProviderUnavailableError:
+    """Build the skip exception with the current retry-after estimate."""
+    return ProviderUnavailableError(provider, retry_after(provider))
+
+
+def reset() -> None:
+    """Clear all breaker state (test isolation; mirrors ports.reset_backend)."""
+    global _ddb_table
+    with _lock:
+        _states.clear()
+        _monitor_cache.clear()
+    _ddb_table = None
+
+
+# --------------------------------------------------------------------------
+# Internals
+# --------------------------------------------------------------------------
+
+def _limits(provider: str) -> tuple[int, float]:
+    return _OVERRIDES.get(provider, (FAILURE_THRESHOLD, COOLDOWN_SECONDS))
+
+
+def _synthetic_status(provider: str) -> str | None:
+    """'UP'/'DOWN' from the synthetic monitor table, or None for "no fresh signal".
+
+    None — env var unset, provider not monitored, read error of any kind, or
+    entry older than _MONITOR_STALE_AFTER — always means "fall back to
+    self-timed recovery", never "stay blocked". Never raises.
+    """
+    if not _HEALTH_TABLE:
+        return None
+    monitor_id = _SYNTHETIC_MONITOR_ID.get(provider)
+    if monitor_id is None:
+        return None
+    now = time.monotonic()
+    with _lock:
+        cached = _monitor_cache.get(monitor_id)
+        if cached is not None and now - cached[1] < _MONITOR_CACHE_TTL:
+            return cached[0]
+    status: str | None = None
+    try:
+        item = _table().get_item(Key={"provider_id": monitor_id}).get("Item")
+        if item:
+            checked = float(item.get("last_checked", 0))
+            if time.time() - checked <= _MONITOR_STALE_AFTER:
+                raw = str(item.get("status", "")).upper()
+                if raw in ("UP", "DOWN"):
+                    status = raw
+    except Exception as e:  # any failure degrades to self-timed, never breaks a request
+        log.debug("provider-health table read failed for %s: %s", monitor_id, e)
+        status = None
+    with _lock:
+        _monitor_cache[monitor_id] = (status, now)
+    return status
+
+
+def _table():
+    """Lazy DynamoDB table handle with tight fail-fast bounds.
+
+    The 1s connect/read timeouts + single attempt are load-bearing: a
+    misconfigured IAM grant or unreachable endpoint must cost ~1-2s once per
+    cache TTL and then degrade to self-timed mode — not hang requests on
+    botocore's default 60s timeouts on exactly the path this module exists to
+    keep fast.
+    """
+    global _ddb_table
+    if _ddb_table is None:
+        with _ddb_lock:
+            if _ddb_table is None:
+                import boto3
+                from botocore.config import Config
+                # total_max_attempts (not max_attempts, which botocore reads
+                # as a RETRY count) — exactly one attempt, no retry storm.
+                _ddb_table = boto3.resource(
+                    "dynamodb",
+                    config=Config(
+                        connect_timeout=1.0,
+                        read_timeout=1.0,
+                        retries={"total_max_attempts": 1, "mode": "standard"},
+                    ),
+                ).Table(_HEALTH_TABLE)
+    return _ddb_table

--- a/darkhours/darksky.py
+++ b/darkhours/darksky.py
@@ -39,7 +39,9 @@ import zipfile
 from pathlib import Path
 
 from . import cache
+from . import circuit_breaker as _cb
 from . import ports
+from . import provider_health as _ph
 from . import _http
 
 log = logging.getLogger(__name__)
@@ -617,9 +619,14 @@ def _location():
                     region_name=region,
                     # Pool ≥ fan-out width so parallel calls don't queue on connections;
                     # adaptive retries absorb ThrottlingException near the TPS quota.
+                    # Timeouts + attempt count are bounded so a real outage surfaces
+                    # to the circuit breaker in ~15s, not minutes — the breaker's
+                    # time-to-trip is threshold × worst-case call latency.
                     config=Config(
                         max_pool_connections=max(_GEOCODE_MAX_WORKERS + 2, 10),
-                        retries={"max_attempts": 5, "mode": "adaptive"},
+                        connect_timeout=2.0,
+                        read_timeout=5.0,
+                        retries={"total_max_attempts": 2, "mode": "adaptive"},
                     ),
                 )
     return _location_client
@@ -643,9 +650,12 @@ def _georoutes():
                 _georoutes_client = boto3.client(
                     "geo-routes",
                     region_name=region,
+                    # Same latency bounds as _location() — see the comment there.
                     config=Config(
                         max_pool_connections=max(_GEOCODE_MAX_WORKERS + 2, 10),
-                        retries={"max_attempts": 5, "mode": "adaptive"},
+                        connect_timeout=2.0,
+                        read_timeout=5.0,
+                        retries={"total_max_attempts": 2, "mode": "adaptive"},
                     ),
                 )
     return _georoutes_client
@@ -791,6 +801,12 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
             misses.append(c)
     if not misses:
         return
+    # Circuit breaker: one gate per batch (a granted probe covers the whole
+    # bounded fan-out); skipped legs keep the None fields set above, matching
+    # the "silently None on API failure" contract.
+    if not _cb.allow("aws_georoutes"):
+        log.debug("GeoRoutes drive times skipped — circuit open")
+        return
     # 2. Parallel GeoRoutes point-to-point calls, one per uncached leg; cache each result.
     #    On a per-leg API error, leave that leg's fields None and DON'T cache it, so a
     #    transient failure isn't sticky — other legs in the same batch are unaffected.
@@ -809,7 +825,11 @@ def _aws_drive_times(origin_lat: float, origin_lon: float, clusters: list) -> No
             c = futures[fut]
             try:
                 mins, miles, warnings, tail_miles = fut.result()
+                _ph.record("aws_georoutes", "ok")
+                _cb.on_success("aws_georoutes")
             except Exception as e:
+                _ph.record("aws_georoutes", "error", str(e)[:120])
+                _cb.on_failure("aws_georoutes")
                 log.debug("GeoRoutes calculate_routes failed: %s", e)
                 continue
             c["drive_minutes"], c["drive_miles"] = mins, miles
@@ -1471,6 +1491,11 @@ def _nominatim_settlement(lat: float, lon: float) -> str | None:
     if cached is not None:
         return cached or None
 
+    # Before the rate-limit sleep: a skipped call shouldn't pay the pacing cost.
+    if not _cb.allow("nominatim"):
+        log.debug("Nominatim reverse geocode skipped — circuit open")
+        return None
+
     # Thread-safe rate limiting
     global _last_nominatim_call
     with _nominatim_lock:
@@ -1491,7 +1516,11 @@ def _nominatim_settlement(lat: float, lon: float) -> str | None:
         )
         with _http.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
+        _ph.record("nominatim", "ok")
+        _cb.on_success("nominatim")
     except Exception as e:
+        _ph.record("nominatim", "error", str(e)[:120])
+        _cb.on_failure("nominatim")
         log.debug("Nominatim lookup failed for (%.4f, %.4f): %s", lat, lon, e)
         return None
 
@@ -1544,6 +1573,10 @@ def _aws_location_settlement(lat: float, lon: float) -> str | None:
     if cached is not None:
         return cached or None
 
+    if not _cb.allow("aws_location"):
+        log.debug("AWS Location reverse geocode skipped — circuit open")
+        return None
+
     index_name = os.environ.get("PYNIGHTSKY_PLACE_INDEX", "pynightsky-place-index")
     try:
         client = _location()
@@ -1552,7 +1585,11 @@ def _aws_location_settlement(lat: float, lon: float) -> str | None:
             Position=[lon, lat],        # AWS expects [lon, lat]
             MaxResults=1,
         )
+        _ph.record("aws_location", "ok")
+        _cb.on_success("aws_location")
     except Exception as e:
+        _ph.record("aws_location", "error", str(e)[:120])
+        _cb.on_failure("aws_location")
         log.debug("AWS Location reverse geocode failed for (%.4f, %.4f): %s", lat, lon, e)
         return None
 

--- a/darkhours/location.py
+++ b/darkhours/location.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 from geopy.geocoders import Nominatim
 from geopy.exc import GeocoderTimedOut, GeocoderServiceError, GeocoderRateLimited
 
+from . import circuit_breaker as _cb
 from . import provider_health as _ph
 from timezonefinder import TimezoneFinder
 
@@ -114,20 +115,26 @@ def _tz_name_for(lat: float, lon: float) -> str:
 def _geocode_via_nominatim(name: str, query: str) -> dict | None:
     """Forward-geocode using the public Nominatim API (local backend only)."""
     log.debug("Cache miss for '%s', geocoding via Nominatim (query: '%s')...", name, query)
+    if not _cb.allow("nominatim"):
+        raise _cb.unavailable("nominatim")
     try:
         geolocator = Nominatim(user_agent=USER_AGENT)
         result = geolocator.geocode(query, timeout=10)
         _ph.record("nominatim", "ok")
+        _cb.on_success("nominatim")
     except GeocoderRateLimited as e:
         _ph.record("nominatim", "degraded", "rate limited")
+        _cb.on_failure("nominatim")
         log.error("Nominatim geocode rate limited for %r", name, extra={"service": "nominatim"})
         raise RuntimeError(f"Geocoding rate limited for {name!r}. Try again later.")
     except GeocoderTimedOut:
         _ph.record("nominatim", "error", "timed out")
+        _cb.on_failure("nominatim")
         log.error("Nominatim geocode timed out for %r", name, extra={"service": "nominatim"})
         raise RuntimeError(f"Geocoding timed out for {name!r}. Check your connection.")
     except GeocoderServiceError as e:
         _ph.record("nominatim", "error", str(e)[:120])
+        _cb.on_failure("nominatim")
         log.error("Nominatim geocode service error: %s", e, extra={"service": "nominatim"})
         raise RuntimeError(f"Geocoding service error: {e}")
 
@@ -146,6 +153,8 @@ def _geocode_via_aws(name: str, query: str) -> dict | None:
     from . import darksky  # reuse the process-wide pooled 'location' client
     index_name = os.environ.get("PYNIGHTSKY_PLACE_INDEX", "pynightsky-place-index")
     log.debug("Cache miss for '%s', geocoding via AWS Location (query: '%s')...", name, query)
+    if not _cb.allow("aws_location"):
+        raise _cb.unavailable("aws_location")
     try:
         client = darksky._location()
         resp = client.search_place_index_for_text(
@@ -153,7 +162,11 @@ def _geocode_via_aws(name: str, query: str) -> dict | None:
             Text=query,
             MaxResults=1,
         )
+        _ph.record("aws_location", "ok")
+        _cb.on_success("aws_location")
     except Exception as e:
+        _ph.record("aws_location", "error", str(e)[:120])
+        _cb.on_failure("aws_location")
         log.error("AWS Location geocode error for %r: %s", name, e, extra={"service": "aws-location"})
         raise RuntimeError(f"Geocoding error: {e}")
 
@@ -175,12 +188,18 @@ def _suggest_via_aws(query: str, max_results: int) -> list[str]:
     """Typeahead suggestions via AWS Location SearchPlaceIndexForSuggestions."""
     from . import darksky  # reuse the process-wide pooled 'location' client
     index_name = os.environ.get("PYNIGHTSKY_PLACE_INDEX", "pynightsky-place-index")
+    if not _cb.allow("aws_location"):
+        raise _cb.unavailable("aws_location")
     try:
         client = darksky._location()
         resp = client.search_place_index_for_suggestions(
             IndexName=index_name, Text=query, MaxResults=max_results,
         )
+        _ph.record("aws_location", "ok")
+        _cb.on_success("aws_location")
     except Exception as e:
+        _ph.record("aws_location", "error", str(e)[:120])
+        _cb.on_failure("aws_location")
         log.error("AWS Location suggest error for %r: %s", query, e,
                   extra={"service": "aws-location"})
         raise RuntimeError(f"Suggestion error: {e}")
@@ -198,13 +217,18 @@ def _suggest_via_nominatim(query: str, max_results: int) -> list[str]:
     Best-effort: a timeout/rate-limit returns no suggestions rather than raising,
     so a slow geocoder never blocks typing.
     """
+    if not _cb.allow("nominatim"):
+        # Same best-effort contract as a failed fetch: no suggestions, no error.
+        return []
     try:
         geolocator = Nominatim(user_agent=USER_AGENT)
         results = geolocator.geocode(
             _geocode_query(query), exactly_one=False, limit=max_results, timeout=10,
         ) or []
         _ph.record("nominatim", "ok")
+        _cb.on_success("nominatim")
     except (GeocoderTimedOut, GeocoderServiceError, GeocoderRateLimited) as e:
+        _cb.on_failure("nominatim")
         log.debug("Nominatim suggest failed for %r: %s", query, e)
         return []
     seen: set[str] = set()

--- a/darkhours/tle_provider.py
+++ b/darkhours/tle_provider.py
@@ -22,6 +22,7 @@ import urllib.request
 from dataclasses import dataclass
 
 from . import cache as _cache
+from . import circuit_breaker as _cb
 from . import _http
 from . import provider_health as _ph
 
@@ -66,22 +67,29 @@ def _fetch_tle_raw(norad_id: int) -> str:
     """
     url = f"https://celestrak.org/NORAD/elements/gp.php?CATNR={norad_id}&FORMAT=TLE"
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    if not _cb.allow("celestrak"):
+        raise _cb.unavailable("celestrak")
     try:
         with _http.urlopen(req, timeout=15) as resp:
             text = resp.read().decode("utf-8").strip()
         lines = [l for l in text.splitlines() if l.strip()]
         if len(lines) < 3:
+            # Content-level failure: Celestrak was reached, so this does not
+            # count toward the breaker.
             raise RuntimeError(
                 f"Celestrak returned fewer than 3 TLE lines for NORAD {norad_id}"
             )
         log.debug("Fetched fresh TLE for NORAD %d (%d bytes)", norad_id, len(text))
         _ph.record("celestrak", "ok")
+        _cb.on_success("celestrak")
         return text
     except urllib.error.HTTPError as e:
         _ph.record("celestrak", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+        _cb.on_failure("celestrak")
         raise RuntimeError(f"Celestrak HTTP {e.code} for NORAD {norad_id}") from e
     except urllib.error.URLError as e:
         _ph.record("celestrak", "error", str(e.reason)[:120])
+        _cb.on_failure("celestrak")
         raise RuntimeError(f"Celestrak unreachable: {e.reason}") from e
 
 
@@ -238,23 +246,35 @@ def get_starlink_train_tles() -> tuple[list[tuple[str, str, str]], bool, str | N
 
     if raw is None:
         # 2. Fetch fresh
-        req = urllib.request.Request(_STARLINK_GROUP_URL, headers={"User-Agent": _USER_AGENT})
-        try:
-            with _http.urlopen(req, timeout=30) as resp:
-                raw = resp.read().decode("utf-8").strip()
-            _cache.set(key, raw, ttl_seconds=TLE_TTL)
-            log.debug("Fetched Starlink group TLE (%d bytes)", len(raw))
-        except urllib.error.HTTPError as e:
-            if e.code == 403:
-                # Celestrak's one-download-per-update policy: data hasn't changed
-                # since our last successful fetch. Stale cache is still current.
-                log.info("Celestrak Starlink group 403 — data unchanged since last fetch, using cache")
-            else:
-                err_msg = f"Celestrak HTTP {e.code} for Starlink group"
+        if not _cb.allow("celestrak"):
+            log.debug("Starlink group fetch skipped — celestrak circuit open")
+        else:
+            req = urllib.request.Request(_STARLINK_GROUP_URL, headers={"User-Agent": _USER_AGENT})
+            try:
+                with _http.urlopen(req, timeout=30) as resp:
+                    raw = resp.read().decode("utf-8").strip()
+                _cache.set(key, raw, ttl_seconds=TLE_TTL)
+                log.debug("Fetched Starlink group TLE (%d bytes)", len(raw))
+                _ph.record("celestrak", "ok")
+                _cb.on_success("celestrak")
+            except urllib.error.HTTPError as e:
+                if e.code == 403:
+                    # Celestrak's one-download-per-update policy: data hasn't changed
+                    # since our last successful fetch. Stale cache is still current —
+                    # the provider is reachable and healthy, not failing.
+                    log.info("Celestrak Starlink group 403 — data unchanged since last fetch, using cache")
+                    _ph.record("celestrak", "ok")
+                    _cb.on_success("celestrak")
+                else:
+                    err_msg = f"Celestrak HTTP {e.code} for Starlink group"
+                    log.warning("%s", err_msg)
+                    _ph.record("celestrak", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+                    _cb.on_failure("celestrak")
+            except urllib.error.URLError as e:
+                err_msg = f"Celestrak unreachable (Starlink group): {e.reason}"
                 log.warning("%s", err_msg)
-        except urllib.error.URLError as e:
-            err_msg = f"Celestrak unreachable (Starlink group): {e.reason}"
-            log.warning("%s", err_msg)
+                _ph.record("celestrak", "error", str(e.reason)[:120])
+                _cb.on_failure("celestrak")
 
     if raw is None:
         # 3. Stale fallback — always try this; on 403 the stale data IS current

--- a/darkhours/trip.py
+++ b/darkhours/trip.py
@@ -54,6 +54,7 @@ class NightSummary:
     weather_informed: bool          # True if weather data was included in score
     wx_pending:       bool
     wx_no_data:       bool
+    wx_error:         str | None = None  # provider failure detail (mirrors NightReport.wx_error)
     meteor_shower:    dict | None = None  # single best active shower (ActiveShower shape), or None
     aurora:           dict | None = None  # {kp_max, tier, noaa_scale, source}, or None
 
@@ -121,6 +122,7 @@ def _to_dict(s: NightSummary) -> dict:
         "weather_informed": s.weather_informed,
         "wx_pending":       s.wx_pending,
         "wx_no_data":       s.wx_no_data,
+        "wx_error":         s.wx_error,
         "meteor_shower":    s.meteor_shower,
         "aurora":           s.aurora,
     }
@@ -145,6 +147,7 @@ def _from_dict(d: dict) -> NightSummary:
         weather_informed = d["weather_informed"],
         wx_pending       = d.get("wx_pending", False),
         wx_no_data       = d.get("wx_no_data", False),
+        wx_error         = d.get("wx_error"),   # .get: pre-deploy cache entries lack it
         meteor_shower    = d.get("meteor_shower"),
         aurora           = d.get("aurora"),
     )
@@ -238,11 +241,14 @@ def fetch_night(
         weather_informed = weather_informed,
         wx_pending       = report.wx_pending,
         wx_no_data       = report.wx_no_data,
+        wx_error         = report.wx_error,
         meteor_shower    = _best_shower(report.active_showers),
         aurora           = aurora,
     )
 
-    ttl = _WEATHER_TTL if weather_informed else _ASTRO_TTL
+    # wx_error nights take the short TTL too: a provider outage must age out of
+    # the calendar within the hour, not be pinned there for the 24h astro TTL.
+    ttl = _WEATHER_TTL if (weather_informed or report.wx_error) else _ASTRO_TTL
     _cache.set(key, _to_dict(summary), ttl_seconds=ttl)
     return summary
 

--- a/darkhours/weather.py
+++ b/darkhours/weather.py
@@ -50,6 +50,7 @@ def lock_for(lat: float, lon: float) -> threading.Lock:
         if lock is None:
             lock = _fetch_locks[key] = threading.Lock()
         return lock
+from . import circuit_breaker as _cb
 from . import provider_health as _ph
 from dataclasses import dataclass, replace as _dc_replace
 from datetime import datetime, timezone, timedelta
@@ -191,17 +192,22 @@ class OpenMeteoProvider(WeatherProvider):
         url = self._URL.format(lat=lat, lon=lon)
         log.debug("Open-Meteo request: %s", url)
 
+        if not _cb.allow("open_meteo"):
+            raise _cb.unavailable("open_meteo")
         try:
             with _http.urlopen(url, timeout=10) as resp:
                 data = json.loads(resp.read())
         except urllib.error.HTTPError as e:
             _ph.record("open_meteo", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+            _cb.on_failure("open_meteo")
             raise RuntimeError(f"Open-Meteo request failed: {e}")
         except Exception as e:
             _ph.record("open_meteo", "error", str(e)[:120])
+            _cb.on_failure("open_meteo")
             raise RuntimeError(f"Open-Meteo request failed: {e}")
 
         _ph.record("open_meteo", "ok")
+        _cb.on_success("open_meteo")
         h = data["hourly"]
         log.debug("Open-Meteo returned %d hourly points", len(h["time"]))
         return _parse_open_meteo_hourly(h)
@@ -245,12 +251,20 @@ class OpenMeteoPastProvider(WeatherProvider):
         url = self._URL.format(lat=lat, lon=lon, past_days=self.past_days)
         log.debug("Open-Meteo Recent request: %s", url)
 
+        # Shares the "open_meteo" breaker key with the forecast provider:
+        # same host (api.open-meteo.com), same reachability.
+        if not _cb.allow("open_meteo"):
+            raise _cb.unavailable("open_meteo")
         try:
             with _http.urlopen(url, timeout=10) as resp:
                 data = json.loads(resp.read())
         except Exception as e:
+            _ph.record("open_meteo", "error", str(e)[:120])
+            _cb.on_failure("open_meteo")
             raise RuntimeError(f"Open-Meteo Recent request failed: {e}")
 
+        _ph.record("open_meteo", "ok")
+        _cb.on_success("open_meteo")
         h = data["hourly"]
         log.debug("Open-Meteo Recent returned %d hourly points", len(h["time"]))
         return _parse_open_meteo_hourly(h)
@@ -302,12 +316,20 @@ class OpenMeteoHistoricalProvider(WeatherProvider):
                                start=self.start_date, end=self.end_date)
         log.debug("Open-Meteo Historical request: %s", url)
 
+        # Separate breaker key from "open_meteo": archive-api.open-meteo.com
+        # is a different host with independently documented outages.
+        if not _cb.allow("open_meteo_archive"):
+            raise _cb.unavailable("open_meteo_archive")
         try:
             with _http.urlopen(url, timeout=10) as resp:
                 data = json.loads(resp.read())
         except Exception as e:
+            _ph.record("open_meteo_archive", "error", str(e)[:120])
+            _cb.on_failure("open_meteo_archive")
             raise RuntimeError(f"Open-Meteo Historical request failed: {e}")
 
+        _ph.record("open_meteo_archive", "ok")
+        _cb.on_success("open_meteo_archive")
         h = data["hourly"]
         log.debug("Open-Meteo Historical returned %d hourly points", len(h["time"]))
         return _parse_open_meteo_hourly(h)
@@ -341,17 +363,22 @@ class SevenTimerProvider(WeatherProvider):
         url = self._URL.format(lat=lat, lon=lon)
         log.debug("7Timer request: %s", url)
 
+        if not _cb.allow("seven_timer"):
+            raise _cb.unavailable("seven_timer")
         try:
             with _http.urlopen(url, timeout=10) as resp:
                 data = json.loads(resp.read())
         except urllib.error.HTTPError as e:
             _ph.record("seven_timer", "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+            _cb.on_failure("seven_timer")
             raise RuntimeError(f"7Timer request failed: {e}")
         except Exception as e:
             _ph.record("seven_timer", "error", str(e)[:120])
+            _cb.on_failure("seven_timer")
             raise RuntimeError(f"7Timer request failed: {e}")
 
         _ph.record("seven_timer", "ok")
+        _cb.on_success("seven_timer")
         init_str = data["init"]
         init = datetime(
             int(init_str[0:4]), int(init_str[4:6]), int(init_str[6:8]),
@@ -442,13 +469,18 @@ def _fetch_air_quality(lat: float, lon: float) -> list:
     API. Returns [] on any failure — air quality is optional enrichment, never a hard
     dependency for the rest of the forecast pipeline."""
     url = _AQ_URL.format(lat=lat, lon=lon)
+    if not _cb.allow("open_meteo_air_quality"):
+        log.debug("Air quality skipped — circuit open")
+        return []
     try:
         with _http.urlopen(url, timeout=10) as resp:
             data = json.loads(resp.read())
         h = data["hourly"]
         _ph.record("open_meteo_air_quality", "ok")
+        _cb.on_success("open_meteo_air_quality")
     except Exception as e:
         _ph.record("open_meteo_air_quality", "error", str(e)[:120])
+        _cb.on_failure("open_meteo_air_quality")
         log.warning("Air quality fetch failed — proceeding without AOD/PM2.5: %s", e,
                     extra={"service": "open_meteo_air_quality"})
         return []

--- a/docs/CIRCUIT_BREAKER.md
+++ b/docs/CIRCUIT_BREAKER.md
@@ -1,0 +1,132 @@
+# Circuit breaker for 3rd-party provider calls
+
+Implemented in `darkhours/circuit_breaker.py` (PR #136). Skips calls to a provider that
+has just failed repeatedly, instead of making every user wait through its timeout, and
+surfaces the skip to the UI through the existing "temporarily unavailable" messaging.
+
+## Why it exists
+
+Before this, nothing ever decided *not* to call a provider: `darkhours/provider_health.py`
+passively recorded outcomes for `/healthz`, but every request always attempted the live
+call. A down provider cost each request its full timeout (10–15s for the urllib
+providers; **minutes** for the AWS clients, which ran botocore's 60s/60s defaults × 5
+adaptive retries) before the app fell back or degraded.
+
+## How it works
+
+Two states per provider key, in-process (per warm Lambda container), thread-safe.
+
+- **CLOSED** — calls proceed. `FAILURE_THRESHOLD` (3) *consecutive* failures → OPEN.
+  Any success resets the count. Celestrak overrides to threshold 1 (see below).
+- **OPEN** — calls are skipped instantly with `ProviderUnavailableError` (a
+  `RuntimeError` subclass, so every existing `except RuntimeError` handles a skipped
+  call exactly like a failed one; carries `.provider` and `.retry_after_seconds`).
+
+**Recovery** (OPEN → CLOSED) happens only in `on_success()` — a real call must succeed.
+Which calls get attempted while OPEN depends on the mode, chosen per call at runtime:
+
+1. **Monitor-driven** — only when `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` is set AND the
+   provider is one of the four the synthetic ProviderHealth Lambda probes
+   (`open_meteo`, `seven_timer`, `swpc`, `waqi`) AND its table entry is fresh (≤20 min).
+   Fresh DOWN → block, no user request spent probing. Fresh UP → grant one probe,
+   rate-limited to one per 15s (`_PROBE_GUARD_SECONDS`) so a monitor false-UP can't
+   thrash the breaker open/closed while the provider is really down for us.
+2. **Self-timed** — everything else, and the automatic fallback whenever no fresh
+   monitor signal exists (env var unset, read error, stale/missing entry): after the
+   cooldown (60s; Celestrak 300s), grant one probe. Probe failure re-arms a fresh
+   cooldown; the block→probe cycle repeats for as long as the outage lasts.
+
+Probe grants are atomic — granting re-arms the clock inside the state lock, so
+concurrent threads (predictor's I/O fan-out) can't all probe at once.
+
+## Provider keys (per-host, because reachability is a host property)
+
+| Key | Call sites | Notes |
+|---|---|---|
+| `open_meteo` | weather.py forecast + past providers | api.open-meteo.com |
+| `open_meteo_archive` | weather.py historical (ERA5) | archive-api.open-meteo.com — different host, fails independently (see OpenMeteoPastProvider docstring) |
+| `open_meteo_air_quality` | weather.py `_fetch_air_quality` | own host; skip returns `[]` (never a hard dependency) |
+| `seven_timer` | weather.py SevenTimerProvider | |
+| `celestrak` | tle_provider.py single + Starlink group | threshold 1 / cooldown 300s: global TLE cache concentrates retries at expiry, and Celestrak punishes exactly that; stale-cache fallback makes patience free. Starlink 403 = "unchanged", **not** a failure |
+| `waqi` | aqicn.py `_fetch_url` | parse-level failures (bad JSON, non-ok status) do **not** count — provider was reached |
+| `swpc` | aurora.py `_fetch_url` | covers both Kp products |
+| `nominatim` | location.py geocode + suggest (geopy), darksky.py settlement (raw HTTP) | one key across both access mechanisms — same upstream |
+| `aws_location` | location.py aws geocode/suggest, darksky.py settlement | |
+| `aws_georoutes` | darksky.py `_aws_drive_times` | one gate per bounded fan-out batch |
+
+Skips preserve each site's existing degrade contract (suggest → `[]`, air quality →
+`[]`, `get_tle()` → stale cache, drive times → `None` fields, reverse geocode → `None`).
+
+## Detection-latency budget
+
+Time-to-trip = threshold × worst-case single-call latency, so every gated call must
+fail fast. The urllib/geopy sites were already bounded (10–15s). The AWS clients were
+not: `_location()`/`_georoutes()` now run `connect_timeout=2.0, read_timeout=5.0,
+retries={"total_max_attempts": 2, "mode": "adaptive"}` (~15s worst case, ~45s to trip;
+adaptive kept so `find_nearby`'s fan-out still absorbs ThrottlingException).
+`tests/test_circuit_breaker.py::test_location_clients_have_bounded_latency` pins these
+values — a future "bump the retries" edit fails a test instead of silently making the
+breaker minutes-slow. Note: botocore's `Config(retries={"max_attempts": N})` means N
+*retries* (N+1 attempts); use `total_max_attempts`.
+
+## Flags
+
+Read once at import (same idiom as `PYNIGHTSKY_NO_CACHE`):
+
+- `PYNIGHTSKY_CIRCUIT_BREAKER_ENABLED` — kill switch, **default enabled**.
+- `PYNIGHTSKY_CIRCUIT_BREAKER_<PROVIDER>_DISABLE` — per-key opt-out (key uppercased,
+  e.g. `..._OPEN_METEO_ARCHIVE_DISABLE`). Bookkeeping still runs while disabled.
+- `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` — ProviderHealth DynamoDB table name.
+  **Currently unset everywhere** — see "Optional follow-up" below.
+
+## UI surfacing
+
+Single-night `/night`: already worked (`NightReport.wx_error` → `ReportCard.tsx`).
+This change closed the calendar gap: `NightSummary` now carries `wx_error` through
+`trip._to_dict/_from_dict` → `CalendarNight` (types.ts) → `OutlookTelemetryRibbon.tsx`
+("weather providers are temporarily unavailable"). `wx_error` nights cache at the 1h
+weather TTL, not the 24h astro TTL, so an outage message ages out within the hour.
+`/healthz` is unchanged: a skipped call writes no `provider_health.record()`, so it
+keeps showing the last *real* observed status.
+
+## Known limits (accepted)
+
+- **State is per-container.** A cold-start fan-out of N containers each pays its own
+  failure streak before tripping locally; state resets on recycle. Cross-container
+  shared state is the deferred storm-throttling use case (which would also add call
+  volume/latency metrics — the `allow`/`on_success`/`on_failure` seam is where both
+  hook in).
+- **Trip detection is always local** even in monitor-driven mode; only *recovery*
+  defers to the monitor.
+
+## Optional follow-up: wire monitor-driven recovery (NOT required)
+
+The feature is complete without this. Wiring it upgrades recovery for the four
+monitor-tracked providers: recovery noticed on the monitor's 5-min schedule with zero
+user requests spent probing, consistent across all containers, and the basis for
+future flap detection. Steps:
+
+1. IAM: grant `dynamodb:GetItem` (only — single-key lookups) on the ProviderHealth
+   table to the API and worker Lambda roles.
+2. Env: set `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` on both Lambdas via CDK
+   context/parameter — **not** a CloudFormation export/import, which would couple the
+   independently-deployed `PyNightSkyProviderHealth` (manual) and `PyNightSkyLambda`
+   (CI) stacks. Never hardcode the table name (public repo).
+3. Deploy order: ProviderHealth stack must exist first.
+4. **Post-deploy, verify a real read succeeds** (e.g. trip a breaker in a test
+   invoke and confirm monitor-driven behavior, or check debug logs). The read is
+   deliberately fail-*safe* (1s timeouts, 1 attempt, broad except → self-timed
+   fallback), which means a broken grant is silent — it must be checked for, it will
+   never announce itself.
+5. Flap detection remains a further step even after wiring: the monitor's table only
+   stores latest status (overwritten each run). It needs either a rolling history in
+   the table or queries against the `ProviderUp` EMF metric (a real time series).
+
+## Tests
+
+`tests/test_circuit_breaker.py` — state machine, monitor UP/DOWN/None semantics,
+probe-guard thrash bound, probe atomicity (16 threads → one grant), fail-fast on broken
+table reads, client Config pins, cross-module integration (shared nominatim key, trip
+serialization). Breaker-open short-circuit tests live in each provider's own test file.
+`tests/conftest.py` resets breaker state around every test (state is module-global;
+celestrak trips on a single failure). All hermetic — no network, no AWS.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -100,6 +100,27 @@ worth tracing). `patch_all()` is used rather than a module allowlist — see the
 `ProviderUp`, `HTTPVerificationLatency`, `DynamoDBWriteFailure` per provider. `PyNightSky`
 namespace: `UpstreamErrors` (log-metric-filter derived, see above).
 
+## Circuit breaker (request-path, not an alarm)
+
+`darkhours/circuit_breaker.py` gates every outbound provider call (weather, TLE, WAQI,
+SWPC, Nominatim, AWS Location/GeoRoutes): 3 consecutive failures (Celestrak: 1) open the
+breaker and calls are skipped instantly instead of eating the provider's timeout. Recovery
+is self-timed (60s cooldown + one probe; Celestrak 300s) — unless
+`PYNIGHTSKY_PROVIDER_HEALTH_TABLE` is set, in which case the four providers the synthetic
+monitor covers (`open-meteo`, `7timer`, `swpc`, `waqi`) defer to its UP/DOWN signal
+instead: fresh DOWN blocks without probing, fresh UP grants a probe (only a real success
+closes the breaker). **The env var is not wired in CDK yet** — until that follow-up (IAM
+`dynamodb:GetItem` on the ProviderHealth table + the env var on the API/worker Lambdas),
+everything self-times, which is safe: the monitor read fails fast (1s timeouts, 1 attempt)
+and degrades to self-timed on any error, so a missing/wrong grant can't hang requests.
+
+Flags: `PYNIGHTSKY_CIRCUIT_BREAKER_ENABLED` (default on),
+`PYNIGHTSKY_CIRCUIT_BREAKER_<PROVIDER>_DISABLE` per provider key. Breaker state is
+per-container and in-memory (same caveat as `darkhours/provider_health.py`); a skipped
+call writes no `provider_health.record()`, so `/healthz` keeps showing the last real
+observed status. Skips surface to users as the existing `wx_error` "temporarily
+unavailable" messaging (single-night report and, since this change, the calendar view).
+
 ## Known gap, left open on purpose
 
 **AWS Application Insights** is enabled account-wide for a resource group named after the app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,20 @@ _AURORA_OPT_OUT = {"test_aurora_provider", "test_provider_smoke"}
 
 
 @pytest.fixture(autouse=True)
+def _fresh_circuit_breaker():
+    """Reset circuit-breaker state around every test.
+
+    Breaker state is module-global; without this, a test that simulates
+    provider failures could trip a breaker and short-circuit provider calls
+    in unrelated later tests (celestrak trips on a single failure).
+    """
+    from darkhours import circuit_breaker as _cb
+    _cb.reset()
+    yield
+    _cb.reset()
+
+
+@pytest.fixture(autouse=True)
 def _offline_aurora(request, monkeypatch):
     """Keep the default test run offline: assemble_night()/fetch_night() gained a
     default-on SWPC fetch whose date gate doesn't protect tests that use today's

--- a/tests/test_aqicn.py
+++ b/tests/test_aqicn.py
@@ -248,3 +248,48 @@ class TestProviderHealth:
              pytest.raises(RuntimeError):
             q._parse(_feed(pm25=50, status="error"), _QLAT, _QLON)
         ph.record.assert_called_once_with("waqi", "error", "status=error")
+
+
+# ---------------------------------------------------------------------------
+# circuit breaker integration
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreaker:
+    def _trip(self):
+        from darkhours import circuit_breaker as cb
+        for _ in range(3):
+            cb.on_failure("waqi")
+        return cb
+
+    def test_open_breaker_short_circuits_without_http(self):
+        self._trip()
+        with mock.patch.object(q._http, "urlopen") as urlopen, \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             pytest.raises(RuntimeError, match="circuit open"):
+            q._fetch_url(_QLAT, _QLON)
+        urlopen.assert_not_called()
+
+    def test_current_haze_never_raises_when_open(self):
+        """The 'never a hard dependency' contract holds for a skipped call."""
+        self._trip()
+        mc = _mock_cache()
+        with mock.patch.object(q, "_cache", mc), \
+             mock.patch.object(q, "_TOKEN", "tok"), \
+             mock.patch.object(q._http, "urlopen") as urlopen:
+            result = q.current_haze(_QLAT, _QLON)
+        assert result is None
+        urlopen.assert_not_called()
+
+    def test_network_failures_trip_then_skip(self):
+        """Three real network failures open the breaker; the fourth call makes
+        no HTTP attempt."""
+        err = urllib.error.URLError("dns failure")
+        with mock.patch.object(q._http, "urlopen", side_effect=err) as urlopen, \
+             mock.patch.object(q, "_TOKEN", "tok"):
+            for _ in range(3):
+                with pytest.raises(RuntimeError):
+                    q._fetch_url(_QLAT, _QLON)
+            assert urlopen.call_count == 3
+            with pytest.raises(RuntimeError, match="circuit open"):
+                q._fetch_url(_QLAT, _QLON)
+            assert urlopen.call_count == 3

--- a/tests/test_aurora_provider.py
+++ b/tests/test_aurora_provider.py
@@ -165,3 +165,31 @@ class TestProviderHealth:
              pytest.raises(RuntimeError):
             a._fetch_url(a.KP_URL)
         assert ph.record.call_args.args[:2] == ("swpc", "error")
+
+
+# ---------------------------------------------------------------------------
+# circuit breaker integration
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreaker:
+    def _trip(self):
+        from darkhours import circuit_breaker as cb
+        for _ in range(3):
+            cb.on_failure("swpc")
+
+    def test_open_breaker_short_circuits_without_http(self):
+        self._trip()
+        with mock.patch.object(a._http, "urlopen") as urlopen, \
+             pytest.raises(RuntimeError, match="circuit open"):
+            a._fetch_url(a.KP_URL)
+        urlopen.assert_not_called()
+
+    def test_kp_forecast_degrades_gracefully_when_open(self):
+        """Same empty-result contract as any other total fetch failure."""
+        self._trip()
+        mc = _mock_cache()
+        with mock.patch.object(a, "_cache", mc), \
+             mock.patch.object(a._http, "urlopen") as urlopen:
+            rows, stale = a.fetch_kp_forecast()
+        assert rows == [] and stale is False
+        urlopen.assert_not_called()

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,403 @@
+"""
+Tests for circuit_breaker.py — state machine (trip/reset/probe cycle), flag
+handling, monitor-driven vs self-timed recovery, probe atomicity, fail-fast
+monitor reads, and the AWS client latency bounds the breaker's detection
+speed depends on. All hermetic: no network, no real AWS.
+"""
+import threading
+import types
+import time as real_time
+from unittest import mock
+
+import pytest
+
+from darkhours import circuit_breaker as cb
+
+
+class FakeClock:
+    """Controllable stand-in for time.monotonic / time.time."""
+
+    def __init__(self, start=1_000.0):
+        self.t = start
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Fresh breaker state + a controllable clock scoped to the module."""
+    c = FakeClock()
+    monkeypatch.setattr(cb, "time", types.SimpleNamespace(monotonic=c, time=c))
+    cb.reset()
+    yield c
+    cb.reset()
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_flags(monkeypatch):
+    """Tests must not depend on the developer's environment."""
+    monkeypatch.setattr(cb, "_ENABLED", True)
+    monkeypatch.setattr(cb, "_DISABLED_PROVIDERS", frozenset())
+    monkeypatch.setattr(cb, "_HEALTH_TABLE", "")
+
+
+def _trip(provider, clock=None):
+    threshold, _ = cb._limits(provider)
+    for _ in range(threshold):
+        cb.on_failure(provider)
+
+
+# ---------------------------------------------------------------------------
+# Core state machine
+# ---------------------------------------------------------------------------
+
+def test_closed_by_default(clock):
+    assert cb.allow("open_meteo")
+    assert not cb.is_open("open_meteo")
+
+
+def test_opens_after_threshold_consecutive_failures(clock):
+    cb.on_failure("open_meteo")
+    cb.on_failure("open_meteo")
+    assert cb.allow("open_meteo")          # 2 < threshold of 3
+    cb.on_failure("open_meteo")
+    assert cb.is_open("open_meteo")
+    assert not cb.allow("open_meteo")
+
+
+def test_success_resets_consecutive_count(clock):
+    cb.on_failure("open_meteo")
+    cb.on_failure("open_meteo")
+    cb.on_success("open_meteo")
+    cb.on_failure("open_meteo")
+    cb.on_failure("open_meteo")
+    assert not cb.is_open("open_meteo")    # never 3 in a row
+
+
+def test_cooldown_grants_exactly_one_probe(clock):
+    _trip("open_meteo")
+    assert not cb.allow("open_meteo")
+    clock.advance(cb.COOLDOWN_SECONDS + 1)
+    assert cb.allow("open_meteo")          # the probe
+    assert not cb.allow("open_meteo")      # grant re-armed the clock
+
+
+def test_probe_failure_rearms_fresh_cooldown(clock):
+    _trip("open_meteo")
+    clock.advance(cb.COOLDOWN_SECONDS + 1)
+    assert cb.allow("open_meteo")
+    cb.on_failure("open_meteo")            # probe failed
+    clock.advance(cb.COOLDOWN_SECONDS - 1)
+    assert not cb.allow("open_meteo")      # still inside the fresh cooldown
+    clock.advance(2)
+    assert cb.allow("open_meteo")
+
+
+def test_probe_success_closes(clock):
+    _trip("open_meteo")
+    clock.advance(cb.COOLDOWN_SECONDS + 1)
+    assert cb.allow("open_meteo")
+    cb.on_success("open_meteo")
+    assert not cb.is_open("open_meteo")
+    assert cb.allow("open_meteo")
+    assert cb.allow("open_meteo")          # fully closed, not probe-limited
+
+
+def test_kill_switch_bypasses_gating(clock, monkeypatch):
+    _trip("open_meteo")
+    monkeypatch.setattr(cb, "_ENABLED", False)
+    assert cb.allow("open_meteo")
+
+
+def test_per_provider_disable(clock, monkeypatch):
+    monkeypatch.setattr(cb, "_DISABLED_PROVIDERS", frozenset({"open_meteo"}))
+    _trip("open_meteo")
+    _trip("waqi")
+    assert cb.allow("open_meteo")          # disabled: never gated
+    assert not cb.allow("waqi")            # others still trip normally
+
+
+def test_keys_are_independent(clock):
+    _trip("open_meteo_archive")
+    assert not cb.allow("open_meteo_archive")
+    assert cb.allow("open_meteo")
+    assert not cb.is_open("open_meteo")
+
+
+def test_celestrak_override_trips_on_first_failure(clock):
+    cb.on_failure("celestrak")
+    assert cb.is_open("celestrak")
+    clock.advance(60 + 1)
+    assert not cb.allow("celestrak")       # 60s default doesn't apply
+    clock.advance(300)
+    assert cb.allow("celestrak")
+
+
+def test_celestrak_never_consults_monitor(clock, monkeypatch):
+    monitor = mock.MagicMock(return_value="UP")
+    monkeypatch.setattr(cb, "_synthetic_status", monitor)
+    cb.on_failure("celestrak")
+    cb.allow("celestrak")
+    monitor.assert_not_called()
+
+
+def test_provider_unavailable_error_attributes(clock):
+    _trip("open_meteo")
+    err = cb.unavailable("open_meteo")
+    assert isinstance(err, RuntimeError)
+    assert err.provider == "open_meteo"
+    assert 0 < err.retry_after_seconds <= cb.COOLDOWN_SECONDS
+    assert "open_meteo" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Monitor-driven recovery
+# ---------------------------------------------------------------------------
+
+def test_deadlock_regression_no_signal_self_times(clock):
+    """Env var unset (shipped default): a tripped monitor-eligible provider
+    must recover via self-timed cooldown, never stay blocked forever."""
+    _trip("open_meteo")
+    assert not cb.allow("open_meteo")
+    clock.advance(cb.COOLDOWN_SECONDS + 1)
+    assert cb.allow("open_meteo")
+
+
+def test_monitor_down_blocks_past_cooldown(clock, monkeypatch):
+    monkeypatch.setattr(cb, "_synthetic_status", lambda p: "DOWN")
+    _trip("open_meteo")
+    clock.advance(cb.COOLDOWN_SECONDS * 10)
+    assert not cb.allow("open_meteo")      # fresh DOWN outranks the local timer
+
+
+def test_monitor_up_grants_probe_but_only_success_closes(clock, monkeypatch):
+    monkeypatch.setattr(cb, "_synthetic_status", lambda p: "UP")
+    _trip("open_meteo")
+    clock.advance(cb._PROBE_GUARD_SECONDS + 1)
+    assert cb.allow("open_meteo")          # probe granted well before cooldown
+    assert cb.is_open("open_meteo")        # UP alone must not close the breaker
+    cb.on_success("open_meteo")
+    assert not cb.is_open("open_meteo")
+
+
+def test_monitor_stuck_up_bounded_by_probe_guard(clock, monkeypatch):
+    """Monitor says UP but the provider keeps failing for us: at most one
+    probe per guard interval, not one per request."""
+    monkeypatch.setattr(cb, "_synthetic_status", lambda p: "UP")
+    _trip("open_meteo")
+    clock.advance(cb._PROBE_GUARD_SECONDS + 1)
+    assert cb.allow("open_meteo")
+    cb.on_failure("open_meteo")
+    for _ in range(20):
+        assert not cb.allow("open_meteo")  # within the guard window
+    clock.advance(cb._PROBE_GUARD_SECONDS + 1)
+    assert cb.allow("open_meteo")
+
+
+def test_monitor_none_falls_back_to_self_timed(clock, monkeypatch):
+    monkeypatch.setattr(cb, "_synthetic_status", lambda p: None)
+    _trip("open_meteo")
+    clock.advance(cb._PROBE_GUARD_SECONDS + 1)
+    assert not cb.allow("open_meteo")      # guard interval is a monitor-UP privilege
+    clock.advance(cb.COOLDOWN_SECONDS)
+    assert cb.allow("open_meteo")
+
+
+# ---------------------------------------------------------------------------
+# Probe atomicity
+# ---------------------------------------------------------------------------
+
+def test_concurrent_allow_grants_exactly_one_probe(clock):
+    _trip("open_meteo")
+    clock.advance(cb.COOLDOWN_SECONDS + 1)
+
+    n = 16
+    barrier = threading.Barrier(n)
+    results = []
+
+    def worker():
+        barrier.wait()
+        results.append(cb.allow("open_meteo"))
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert results.count(True) == 1
+
+
+# ---------------------------------------------------------------------------
+# _synthetic_status: read semantics + fail-fast
+# ---------------------------------------------------------------------------
+
+def _table_returning(item):
+    table = mock.MagicMock()
+    table.get_item.return_value = {"Item": item} if item is not None else {}
+    return table
+
+
+def test_synthetic_status_unset_table_reads_nothing(clock, monkeypatch):
+    table_factory = mock.MagicMock()
+    monkeypatch.setattr(cb, "_table", table_factory)
+    assert cb._synthetic_status("open_meteo") is None
+    table_factory.assert_not_called()      # env unset: no AWS touch at all
+
+
+def test_synthetic_status_fresh_entry(clock, monkeypatch):
+    monkeypatch.setattr(cb, "_HEALTH_TABLE", "tbl")
+    item = {"provider_id": "open-meteo", "status": "UP", "last_checked": int(clock.t)}
+    monkeypatch.setattr(cb, "_table", lambda: _table_returning(item))
+    assert cb._synthetic_status("open_meteo") == "UP"
+
+
+def test_synthetic_status_stale_entry_is_none(clock, monkeypatch):
+    monkeypatch.setattr(cb, "_HEALTH_TABLE", "tbl")
+    stale = int(clock.t) - cb._MONITOR_STALE_AFTER - 60
+    item = {"provider_id": "open-meteo", "status": "UP", "last_checked": stale}
+    monkeypatch.setattr(cb, "_table", lambda: _table_returning(item))
+    assert cb._synthetic_status("open_meteo") is None
+
+
+def test_synthetic_status_read_error_returns_none_and_caches(clock, monkeypatch):
+    """A broken read (missing IAM, network) degrades to None and is cached —
+    the cost is paid once per cache TTL, not per request."""
+    monkeypatch.setattr(cb, "_HEALTH_TABLE", "tbl")
+    table = mock.MagicMock()
+    table.get_item.side_effect = RuntimeError("simulated AccessDenied/conn failure")
+    monkeypatch.setattr(cb, "_table", lambda: table)
+    assert cb._synthetic_status("open_meteo") is None
+    assert cb._synthetic_status("open_meteo") is None
+    assert table.get_item.call_count == 1  # second call served from cache
+
+
+def test_synthetic_status_client_error_returns_none(clock, monkeypatch):
+    botocore_exc = pytest.importorskip("botocore.exceptions")
+    monkeypatch.setattr(cb, "_HEALTH_TABLE", "tbl")
+    table = mock.MagicMock()
+    table.get_item.side_effect = botocore_exc.ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "denied"}}, "GetItem"
+    )
+    monkeypatch.setattr(cb, "_table", lambda: table)
+    assert cb._synthetic_status("open_meteo") is None
+
+
+def test_ddb_client_has_fail_fast_bounds():
+    """The lazy DynamoDB handle must be built with tight timeouts — botocore's
+    60s defaults would reintroduce the hang this module exists to remove."""
+    boto3 = pytest.importorskip("boto3")
+    with mock.patch.object(cb, "_HEALTH_TABLE", "tbl"), \
+         mock.patch.dict("os.environ", {"AWS_DEFAULT_REGION": "us-east-1"}):
+        cb._ddb_table = None
+        try:
+            table = cb._table()
+            config = table.meta.client.meta.config
+            assert config.connect_timeout == 1.0
+            assert config.read_timeout == 1.0
+            # botocore normalizes retries to total_max_attempts; one total
+            # attempt is the whole point (fail fast, no retry storm).
+            assert config.retries["total_max_attempts"] == 1
+            assert config.retries["mode"] == "standard"
+        finally:
+            cb._ddb_table = None
+
+
+# ---------------------------------------------------------------------------
+# AWS Location / GeoRoutes client latency bounds (detection-latency budget)
+# ---------------------------------------------------------------------------
+
+def test_location_clients_have_bounded_latency():
+    """Breaker detection speed = threshold x worst-case call latency; the AWS
+    clients must be configured to fail fast (2s/5s, max 2 attempts) or the
+    breaker is minutes-slow exactly when it matters."""
+    pytest.importorskip("boto3")
+    from darkhours import darksky
+
+    with mock.patch.dict("os.environ", {"AWS_DEFAULT_REGION": "us-east-1"}):
+        darksky._reset_location_client()
+        try:
+            for client in (darksky._location(), darksky._georoutes()):
+                config = client.meta.config
+                assert config.connect_timeout == 2.0
+                assert config.read_timeout == 5.0
+                # adaptive mode: max_attempts is the total (2 = 1 retry).
+                assert config.retries["total_max_attempts"] == 2
+                assert config.retries["mode"] == "adaptive"
+        finally:
+            darksky._reset_location_client()
+
+
+# ---------------------------------------------------------------------------
+# Cross-module integration
+# ---------------------------------------------------------------------------
+
+def test_air_quality_skipped_when_open(clock):
+    """_fetch_air_quality honors its 'never a hard dependency' contract when
+    skipped: empty list, no HTTP attempt, no exception."""
+    from darkhours import weather as wx
+
+    for _ in range(3):
+        cb.on_failure("open_meteo_air_quality")
+    with mock.patch.object(wx._http, "urlopen") as urlopen:
+        assert wx._fetch_air_quality(40.0, -105.0) == []
+    urlopen.assert_not_called()
+
+
+def test_nominatim_key_shared_across_call_sites(clock):
+    """A failure streak recorded via one Nominatim access path (geopy forward
+    geocode) blocks the other (raw-HTTP reverse geocode in darksky) — same
+    upstream, same breaker key, regardless of HTTP mechanism."""
+    from darkhours import darksky, location as loc
+
+    for _ in range(3):
+        cb.on_failure("nominatim")
+
+    # geopy path: raises without ever constructing a geocoder
+    with mock.patch.object(loc, "Nominatim") as geocoder, \
+         pytest.raises(RuntimeError, match="circuit open"):
+        loc._geocode_via_nominatim("Denver", "Denver")
+    geocoder.assert_not_called()
+
+    # raw-HTTP path: returns None (its degrade contract) without HTTP
+    with mock.patch.object(darksky.cache, "get", return_value=None), \
+         mock.patch.object(darksky._http, "urlopen") as urlopen:
+        assert darksky._nominatim_settlement(39.7392, -104.9903) is None
+    urlopen.assert_not_called()
+
+
+def test_aws_location_gate_skips_client_entirely(clock):
+    from darkhours import darksky, location as loc
+
+    for _ in range(3):
+        cb.on_failure("aws_location")
+    with mock.patch.object(darksky, "_location") as client_factory, \
+         pytest.raises(RuntimeError, match="circuit open"):
+        loc._geocode_via_aws("Denver", "Denver")
+    client_factory.assert_not_called()
+
+
+def test_trip_summary_serializes_wx_error(clock):
+    """NightSummary round-trips wx_error, and tolerates pre-deploy cache
+    entries that lack the field."""
+    from datetime import date
+    from darkhours import trip
+
+    s = trip.NightSummary(
+        date=date(2026, 7, 21), display_name="Test", lat=40.0, lon=-105.0,
+        score=5.0, score_components={}, phase_name="New Moon",
+        illumination_pct=1.0, moon_distance_km=384_400, moon_special=None,
+        moon_eclipses=[], dark_hours=6.0, bortle_score=3.0,
+        weather_score=None, weather_informed=False,
+        wx_pending=False, wx_no_data=False,
+        wx_error="open_meteo unavailable (circuit open, retry in 60s)",
+    )
+    d = trip._to_dict(s)
+    assert d["wx_error"] == s.wx_error
+    assert trip._from_dict(d).wx_error == s.wx_error
+
+    d.pop("wx_error")            # pre-deploy cached blob
+    assert trip._from_dict(d).wx_error is None

--- a/tests/test_tle_provider.py
+++ b/tests/test_tle_provider.py
@@ -228,3 +228,48 @@ class TestGetTle:
         assert result.lines is None
         assert result.error is not None
         assert result.stale is False
+
+
+# ---------------------------------------------------------------------------
+# circuit breaker integration
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreaker:
+    @staticmethod
+    def _mock_cache(get_val=None, stale_val=None):
+        c = mock.MagicMock()
+        c.get.return_value = get_val
+        c.get_stale.return_value = stale_val
+        return c
+
+    def test_single_failure_trips_then_skips_http(self):
+        """Celestrak's (1, 300) override: one real failure opens the breaker;
+        the next fetch makes no HTTP attempt and still serves stale cache."""
+        import urllib.error
+        from darkhours import circuit_breaker as cb
+
+        mc = self._mock_cache(get_val=None, stale_val=_ISS_RAW)
+        with mock.patch.object(tle_mod, '_cache', mc), \
+             mock.patch.object(tle_mod._http, 'urlopen',
+                               side_effect=urllib.error.URLError("dns failure")):
+            r1 = get_tle(25544)
+        assert r1.stale is True
+        assert cb.is_open("celestrak")
+
+        with mock.patch.object(tle_mod, '_cache', mc), \
+             mock.patch.object(tle_mod._http, 'urlopen') as urlopen:
+            r2 = get_tle(25544)
+        urlopen.assert_not_called()
+        assert r2.stale is True and r2.lines is not None
+        assert "circuit open" in r2.error
+
+    def test_starlink_group_skipped_when_open(self):
+        from darkhours import circuit_breaker as cb
+
+        cb.on_failure("celestrak")           # threshold 1: open
+        mc = self._mock_cache(get_val=None, stale_val=None)
+        with mock.patch.object(tle_mod, '_cache', mc), \
+             mock.patch.object(tle_mod._http, 'urlopen') as urlopen:
+            tles, stale, error = tle_mod.get_starlink_train_tles()
+        urlopen.assert_not_called()
+        assert tles == [] and error is None   # silent-skip contract preserved

--- a/tests/test_weather_fallback.py
+++ b/tests/test_weather_fallback.py
@@ -132,3 +132,41 @@ def test_all_forecast_provider_urls_include_wind_gusts():
     assert "wind_gusts_10m" in wx.OpenMeteoProvider._URL
     assert "wind_gusts_10m" in wx.OpenMeteoPastProvider._URL
     assert "wind_gusts_10m" in wx.OpenMeteoHistoricalProvider._URL
+
+
+# ---------------------------------------------------------------------------
+# circuit breaker integration
+# ---------------------------------------------------------------------------
+
+def test_open_breaker_falls_back_to_7timer(monkeypatch):
+    """An open open_meteo breaker behaves like any Open-Meteo failure: 7Timer
+    serves the forecast — but with zero HTTP attempts against Open-Meteo."""
+    from unittest import mock
+    from darkhours import circuit_breaker as cb
+
+    for _ in range(3):
+        cb.on_failure("open_meteo")
+    monkeypatch.setattr(wx.SevenTimerProvider, "forecast",
+                        lambda self, lat, lon: [_pt()])
+    with mock.patch.object(wx._http, "urlopen") as urlopen:
+        points, source, _fetched = wx.forecast(40.0, -105.0)
+    assert source == "7Timer" and len(points) == 1
+    urlopen.assert_not_called()
+
+
+def test_repeated_failures_trip_breaker_and_skip_http():
+    """Three real network failures open the breaker; the fourth forecast call
+    short-circuits without touching the network."""
+    import urllib.error
+    from unittest import mock
+
+    provider = wx.OpenMeteoProvider()
+    err = urllib.error.URLError("dns failure")
+    with mock.patch.object(wx._http, "urlopen", side_effect=err) as urlopen:
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                provider.forecast(40.0, -105.0)
+        assert urlopen.call_count == 3
+        with pytest.raises(RuntimeError, match="circuit open"):
+            provider.forecast(40.0, -105.0)
+        assert urlopen.call_count == 3


### PR DESCRIPTION
## What

Adds a reachability circuit breaker (`darkhours/circuit_breaker.py`) in front of every outbound provider call — weather (Open-Meteo forecast/past/historical, 7Timer, air quality), Celestrak TLE, WAQI, NOAA SWPC, Nominatim, AWS Location, and GeoRoutes. After 3 consecutive failures (Celestrak: 1), calls are skipped instantly with `ProviderUnavailableError` instead of making every user wait through the provider's timeout, and the skip surfaces to users through the existing "temporarily unavailable" messaging — now including the calendar view, which previously dropped `wx_error` entirely.

## Why

A down provider previously cost every request a 10–15s timeout (worse for the AWS clients — see below) before the app fell back or degraded. The passive `provider_health.py` registry recorded failures but nothing consulted it before attempting a call.

## Design notes for review

- **Two recovery modes.** Self-timed: cooldown (60s; Celestrak 300s) then one atomically-claimed probe — only a real success closes the breaker. Monitor-driven: for the four providers the synthetic ProviderHealth Lambda covers, a fresh DOWN blocks without spending a user request, a fresh UP grants a probe (rate-limited to one per 15s so a monitor false-UP can't thrash). "No signal" always degrades to self-timed — never "blocked forever."
- **Ships inert on the monitor path.** `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` is not set anywhere yet; wiring it (IAM `dynamodb:GetItem` + env var in CDK) is a specced follow-up. Until then everything self-times, and the table read is fail-fast (1s timeouts, 1 attempt, broad except) so a misconfigured grant can't hang requests.
- **Per-host breaker keys.** `open_meteo_archive` is split from `open_meteo` — `archive-api.open-meteo.com` is a different host the repo already documents as failing independently.
- **AWS client latency bounds.** `_location()`/`_georoutes()` previously ran botocore defaults (60s connect/60s read) × 5 adaptive retries — minutes per failed call, making breaker detection uselessly slow. Now 2s/5s × 2 total attempts (~15s worst case, ~45s to trip), keeping adaptive mode so fan-out throttling is still absorbed. A test pins these values.
- **Celestrak** trips on the first failure and never gets probed on a schedule (its anti-abuse policy is why it's also excluded from the synthetic monitor); the Starlink-group 403 ("data unchanged") correctly does not count as a failure. Also adds previously-missing `provider_health.record()` calls at several sites (past/archive weather, Starlink group, settlement lookups, AWS Location/GeoRoutes).
- **Flags:** `PYNIGHTSKY_CIRCUIT_BREAKER_ENABLED` (default on), `PYNIGHTSKY_CIRCUIT_BREAKER_<PROVIDER>_DISABLE` per key.
- **Known limit:** breaker state is per-container (in-memory), same as `provider_health.py`. Cross-container state is the deferred storm-throttling work.

## Testing

- 832 passed, 9 skipped (baseline 803) — includes 29 new tests: state machine, monitor UP/DOWN/None semantics, probe-guard thrash bound, probe atomicity under 16 threads, fail-fast on broken table reads, per-provider short-circuit + degrade contracts, and a shared-key test proving geopy and raw-HTTP Nominatim paths trip together.
- Real-socket E2E: providers pointed at a closed port — three genuine failures in ~20ms, breaker tripped, fourth call short-circuited in <1ms.
- `tsc --noEmit` clean for the web app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)