### PR TITLE
Wire monitor-driven circuit breaker recovery (IAM + env)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,4 +74,5 @@ jobs:
           PYNIGHTSKY_CACHE_TABLE: ${{ secrets.PYNIGHTSKY_CACHE_TABLE }}
           PYNIGHTSKY_BLOG_BUCKET: ${{ secrets.PYNIGHTSKY_BLOG_BUCKET }}
           AQICN_TOKEN: ${{ secrets.AQICN_TOKEN }}
+          PYNIGHTSKY_PROVIDER_HEALTH_TABLE: ${{ secrets.PYNIGHTSKY_PROVIDER_HEALTH_TABLE }}
         run: cdk deploy PyNightSkyLambda --require-approval never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,8 @@ test/scan use, which is also why `Dockerfile.worker` is in the repo at all):
 - `docs/OBSERVABILITY.md` — CloudWatch dashboard, alarms + SNS notification wiring, log groups,
   X-Ray scope, and the Application Insights shadow-alarm gap left open on purpose.
 - `docs/CIRCUIT_BREAKER.md` — provider circuit breaker: design, per-host keys, flags,
-  detection-latency budget, and the optional (not required) monitor-wiring follow-up.
+  detection-latency budget, and monitor-driven recovery wiring (IAM grant + env var are
+  in CDK; deploy order + post-deploy verification are still manual — see that doc).
 - `docs/FEATURES.md` — user-facing feature list (validated against code).
 - `apps/web/README.md` — the DarkHours SPA: dev setup, architecture, red-mode rules.
 - `docs/CLI.md`, `docs/TRIPBUILDER.md`, `PRODUCT.md`, `README.md` — product/engine overview.

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -104,6 +104,12 @@ class LambdaApiStack(Stack):
         # Optional (not a hard deploy dependency): aqicn.py degrades to "no live haze
         # data" when unset, so a missing secret shouldn't break the stack.
         aqicn_token = os.environ.get("AQICN_TOKEN", "")
+        # Optional, and deliberately NOT a CloudFormation export/import: that would
+        # couple this CI-deployed stack's deploy to the manually-deployed
+        # PyNightSkyProviderHealth stack. Passed as a plain env var/secret instead
+        # (see docs/CIRCUIT_BREAKER.md "Monitor-driven recovery wiring"); circuit_breaker.py
+        # already degrades to self-timed recovery when this is unset.
+        provider_health_table = os.environ.get("PYNIGHTSKY_PROVIDER_HEALTH_TABLE", "").strip()
 
         Tags.of(self).add("Project", "pynightsky")
         Tags.of(self).add("Env", "prod")
@@ -294,6 +300,26 @@ class LambdaApiStack(Stack):
         worker.add_environment("PYNIGHTSKY_PLACE_INDEX", place_index.index_name)
         worker.add_to_role_policy(route_policy)
         worker.add_event_source(lambda_events.SqsEventSource(jobs_queue, batch_size=1))
+
+        # --- Provider health monitor read (circuit breaker's monitor-driven recovery) ---
+        # Least-privilege on purpose: dynamodb:GetItem only (the breaker does single-key
+        # lookups, never Query/Scan), scoped to this one table's ARN. Referenced by name
+        # only — imported via from_table_name so this stack takes no CDK dependency on
+        # PyNightSkyProviderHealth (see the provider_health_table comment above). If the
+        # env var/secret is unset, no grant or env var is added and every provider falls
+        # back to self-timed recovery, exactly like today.
+        if provider_health_table:
+            health_table = dynamodb.Table.from_table_name(
+                self, "ProviderHealthTable", provider_health_table,
+            )
+            health_read_policy = iam.PolicyStatement(
+                actions=["dynamodb:GetItem"],
+                resources=[health_table.table_arn],
+            )
+            fn.add_to_role_policy(health_read_policy)
+            fn.add_environment("PYNIGHTSKY_PROVIDER_HEALTH_TABLE", provider_health_table)
+            worker.add_to_role_policy(health_read_policy)
+            worker.add_environment("PYNIGHTSKY_PROVIDER_HEALTH_TABLE", provider_health_table)
 
         # --- Scheduled worker warmup ping — keeps one worker container alive + primed ---
         # The worker is only invoked by SQS, so at sparse traffic nearly every job pays the

--- a/cdk/provider_health_stack.py
+++ b/cdk/provider_health_stack.py
@@ -17,6 +17,7 @@ import shutil
 
 from aws_cdk import (
     Stack,
+    CfnOutput,
     Duration,
     RemovalPolicy,
     Tags,
@@ -140,3 +141,9 @@ class ProviderHealthStack(Stack):
             treat_missing_data=cloudwatch.TreatMissingData.BREACHING,
         )
         dead_mans_switch.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+
+        # Plain stack output for an operator to read off the console/CLI and hand to the
+        # PyNightSkyLambda stack as the PYNIGHTSKY_PROVIDER_HEALTH_TABLE secret — NOT a
+        # CloudFormation Export (see lambda_api_stack.py: that would couple these two
+        # independently-deployed stacks' lifecycles).
+        CfnOutput(self, "ProviderHealthTableName", value=table.table_name)

--- a/docs/CIRCUIT_BREAKER.md
+++ b/docs/CIRCUIT_BREAKER.md
@@ -76,8 +76,11 @@ Read once at import (same idiom as `PYNIGHTSKY_NO_CACHE`):
 - `PYNIGHTSKY_CIRCUIT_BREAKER_ENABLED` — kill switch, **default enabled**.
 - `PYNIGHTSKY_CIRCUIT_BREAKER_<PROVIDER>_DISABLE` — per-key opt-out (key uppercased,
   e.g. `..._OPEN_METEO_ARCHIVE_DISABLE`). Bookkeeping still runs while disabled.
-- `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` — ProviderHealth DynamoDB table name.
-  **Currently unset everywhere** — see "Optional follow-up" below.
+- `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` — ProviderHealth DynamoDB table name. Wired in
+  `cdk/lambda_api_stack.py` (API + worker Lambda roles get a scoped `dynamodb:GetItem`
+  grant + this env var, gated on the `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` secret being
+  set) — see "Monitor-driven recovery wiring" below for what's deployed vs. still
+  manual.
 
 ## UI surfacing
 
@@ -99,20 +102,36 @@ keeps showing the last *real* observed status.
 - **Trip detection is always local** even in monitor-driven mode; only *recovery*
   defers to the monitor.
 
-## Optional follow-up: wire monitor-driven recovery (NOT required)
+## Monitor-driven recovery wiring
 
-The feature is complete without this. Wiring it upgrades recovery for the four
+The feature is complete without this (see Recovery above — unset env var degrades
+cleanly to self-timed everywhere). Wiring it upgrades recovery for the four
 monitor-tracked providers: recovery noticed on the monitor's 5-min schedule with zero
 user requests spent probing, consistent across all containers, and the basis for
-future flap detection. Steps:
+future flap detection.
 
-1. IAM: grant `dynamodb:GetItem` (only — single-key lookups) on the ProviderHealth
-   table to the API and worker Lambda roles.
-2. Env: set `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` on both Lambdas via CDK
-   context/parameter — **not** a CloudFormation export/import, which would couple the
+**Done (in CDK, this repo):**
+
+1. IAM: `cdk/lambda_api_stack.py` grants `dynamodb:GetItem` (only — single-key
+   lookups, scoped to the ProviderHealth table's ARN) on both the API and worker
+   Lambda roles, gated on `provider_health_table` (the `PYNIGHTSKY_PROVIDER_HEALTH_TABLE`
+   env var/secret) being non-empty.
+2. Env: the same var is set on both Lambdas from that env var/secret at synth time —
+   **not** a CloudFormation export/import, which would couple the
    independently-deployed `PyNightSkyProviderHealth` (manual) and `PyNightSkyLambda`
-   (CI) stacks. Never hardcode the table name (public repo).
-3. Deploy order: ProviderHealth stack must exist first.
+   (CI) stacks. The table name is never hardcoded (public repo);
+   `provider_health_stack.py` emits it as a plain `CfnOutput` (`ProviderHealthTableName`)
+   for an operator to read and hand to `PyNightSkyLambda` as the
+   `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` GitHub secret — `deploy.yml` passes that secret
+   through to `cdk deploy` unconditionally (empty/absent is a no-op, same as
+   `AQICN_TOKEN`).
+
+**Still manual, not yet done:**
+
+3. Deploy order: the `PyNightSkyProviderHealth` stack must exist first (`cdk deploy
+   PyNightSkyProviderHealth`, by hand — it is never touched by `deploy.yml`). Read its
+   `ProviderHealthTableName` output and set it as the `PYNIGHTSKY_PROVIDER_HEALTH_TABLE`
+   GitHub secret before (or as part of) the next `PyNightSkyLambda` deploy.
 4. **Post-deploy, verify a real read succeeds** (e.g. trip a breaker in a test
    invoke and confirm monitor-driven behavior, or check debug logs). The read is
    deliberately fail-*safe* (1s timeouts, 1 attempt, broad except → self-timed


### PR DESCRIPTION
## Summary
- Grants the API and worker Lambda roles a scoped `dynamodb:GetItem`-only read on the ProviderHealth table, gated on `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` being set.
- Sets that env var on both Lambdas from a plain env var/secret at synth time — deliberately **not** a CloudFormation export/import, so `PyNightSkyLambda` (CI-deployed) and `PyNightSkyProviderHealth` (manually-deployed) stay independently deployable.
- Adds a `CfnOutput` (`ProviderHealthTableName`) on the ProviderHealth stack so the table name can be read off and handed to CI as a secret, never hardcoded (public repo).
- `PYNIGHTSKY_PROVIDER_HEALTH_TABLE` GitHub secret has already been set to the live table name (`PyNightSkyProviderHealth-ProviderHealthTableFFEFDBD3-1BNIGA52VHPZ`), confirmed via `PyNightSkyProviderHealth` (already `UPDATE_COMPLETE` in the account) — deploy order is satisfied.
- Completes the "Optional follow-up" in `docs/CIRCUIT_BREAKER.md`; doc + `CLAUDE.md` pointer updated to reflect what's wired vs. still manual.

## Test plan
- [x] `python -m pytest -q` — 832 passed, 9 skipped (engine code untouched by this change)
- [x] Verified the new CDK constructs in isolation (Docker/Colima unavailable locally for full `cdk synth` asset bundling): confirmed the emitted IAM policy is exactly `dynamodb:GetItem` scoped to the table ARN (no Query/Scan/BatchGetItem) on both Lambda roles, and the `CfnOutput` renders correctly.
- [ ] Post-merge (CI deploys `PyNightSkyLambda`): verify the grant actually works in prod — trip a breaker in a test invoke or check debug logs. The read is deliberately fail-*safe*, so a broken grant would stay silent otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)