### PR TITLE
Prerender apps/web's landing content for crawlers

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "CI=true vite",
-    "build": "tsc -b && vite build",
+    "build:client": "tsc -b && vite build",
+    "build:ssr": "vite build --ssr src/entry-server.tsx --outDir dist-ssr",
+    "prerender": "node scripts/prerender.mjs",
+    "build": "npm run build:client && npm run build:ssr && npm run prerender",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/apps/web/scripts/prerender.mjs
+++ b/apps/web/scripts/prerender.mjs
@@ -1,0 +1,54 @@
+// Runs after build:client + build:ssr, as part of `npm run build`. Renders the
+// app's deterministic initial (no-report) state via the SSR bundle and bakes
+// it into dist/index.html, so crawlers that don't execute JavaScript see real
+// content instead of an empty <div id="root">.
+//
+// Every check below fails the build loudly (non-zero exit) rather than
+// shipping a silently-degraded snapshot — this runs before `cdk deploy` in CI,
+// so a failure here blocks the deploy entirely.
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const webDir = new URL('..', import.meta.url).pathname
+const { render } = await import(join(webDir, 'dist-ssr', 'entry-server.js'))
+
+const appHtml = render()
+
+// PR2 replaces this literal with FEATURES.length once content/features.ts
+// exists, so this count can't silently drift from the real feature list.
+const EXPECTED_FEATURE_COUNT = 12
+
+function fail(message) {
+  console.error(`[prerender] ${message}`)
+  process.exit(1)
+}
+
+if (appHtml.length < 1500) {
+  fail(`rendered HTML is suspiciously small (${appHtml.length} chars) — expected the full marketing/empty-state view.`)
+}
+
+const capCount = (appHtml.match(/class="es-cap"/g) ?? []).length
+if (capCount !== EXPECTED_FEATURE_COUNT) {
+  fail(`expected ${EXPECTED_FEATURE_COUNT} feature tiles (class="es-cap"), found ${capCount}.`)
+}
+
+if (appHtml.includes('class="report-head"')) {
+  fail('rendered HTML contains ReportCard markup ("report-head") — the initial-render/deterministic-null-report assumption no longer holds.')
+}
+
+const indexPath = join(webDir, 'dist', 'index.html')
+const template = readFileSync(indexPath, 'utf-8')
+
+const EMPTY_ROOT = '<div id="root"></div>'
+if (!template.includes(EMPTY_ROOT)) {
+  fail(`could not find the literal "${EMPTY_ROOT}" in dist/index.html — has the Vite template changed?`)
+}
+
+const html = template.replace(EMPTY_ROOT, `<div id="root">${appHtml}</div>`)
+
+if (html.includes(EMPTY_ROOT)) {
+  fail('replace produced no change — dist/index.html still contains an empty root div.')
+}
+
+writeFileSync(indexPath, html)
+console.log(`[prerender] injected ${appHtml.length} chars into dist/index.html (${capCount} feature tiles).`)

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { tonightIso, toIsoDate, defaultImperial, availabilityFor } from './forma
 import ReportCard from './ReportCard'
 import DatePicker from './DatePicker'
 import type { NightReport } from './types'
+import { readLocalStorage } from './env'
 
 type Mode = 'place' | 'coords'
 
@@ -21,7 +22,7 @@ const HISTORY_KEY = 'search-history'
 const HISTORY_MAX = 12
 
 function loadHistory(): HistoryEntry[] {
-  try { return JSON.parse(localStorage.getItem(HISTORY_KEY) ?? '[]') } catch { return [] }
+  try { return JSON.parse(readLocalStorage(HISTORY_KEY) ?? '[]') } catch { return [] }
 }
 function saveHistory(entries: HistoryEntry[]) {
   localStorage.setItem(HISTORY_KEY, JSON.stringify(entries))
@@ -37,7 +38,7 @@ export default function App() {
   const [scopeOpen, setScopeOpen] = useState(true)
   const [imperial, setImperial] = useState<boolean>(defaultImperial)
   const [locating, setLocating] = useState(false)
-  const [redMode, setRedMode] = useState<boolean>(() => localStorage.getItem('redMode') === '1')
+  const [redMode, setRedMode] = useState<boolean>(() => readLocalStorage('redMode') === '1')
   const [searchHistory, setSearchHistory] = useState<HistoryEntry[]>(loadHistory)
   const [placeDropdown, setPlaceDropdown] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)

--- a/apps/web/src/entry-server.tsx
+++ b/apps/web/src/entry-server.tsx
@@ -1,0 +1,18 @@
+// Build-time-only entry point (run under Node via `vite build --ssr`, never
+// shipped to the browser). Renders App's initial state — `report` is always
+// null before any effect/fetch runs, so this deterministically produces the
+// marketing/empty-state view, which is what scripts/prerender.mjs injects into
+// dist/index.html for crawlers that don't execute JavaScript.
+//
+// Invariant: everything transitively imported from App (including all of
+// ./report/*) must not touch window/document/navigator/localStorage at module
+// scope. Component bodies are fine — they never execute here, since `report`
+// stays null and ReportCard's `{report && ...}` gate keeps it unmounted — but
+// top-level statements run at import time regardless of whether the
+// component they belong to ever renders.
+import { renderToString } from 'react-dom/server'
+import App from './App'
+
+export function render(): string {
+  return renderToString(<App />)
+}

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,0 +1,9 @@
+// SSR-safe browser-environment detection. Node (used for build-time prerendering
+// via entry-server.tsx) has no `window` — unlike `navigator`, which Node 21+
+// partially stubs with a bare `.userAgent`, `window` is never defined outside a
+// real browser/DOM environment, so it's the reliable sentinel.
+export const isBrowser = typeof window !== 'undefined'
+
+export function readLocalStorage(key: string): string | null {
+  return isBrowser ? localStorage.getItem(key) : null
+}

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -2,12 +2,13 @@
 // not the viewer's, so "Sunset 8:32 PM" reads correctly for the queried location.
 
 import type { WeatherPoint, LightPollution, NightReport } from './types'
+import { isBrowser, readLocalStorage } from './env'
 
 // Mirror CLI detect_units(): imperial for en-US locale, SI otherwise.
 // Used only to seed the initial default; components receive `imperial` as a prop.
 export function defaultImperial(): boolean {
-  if (typeof navigator === 'undefined') return false
-  const saved = localStorage.getItem('units')
+  if (!isBrowser) return false
+  const saved = readLocalStorage('units')
   if (saved) return saved === 'imperial'
   return navigator.language === 'en-US' || navigator.language.startsWith('en-US')
 }


### PR DESCRIPTION
## Summary
- `apps/web` shipped as an empty `<div id="root"></div>` — non-JS crawlers (GPTBot, ClaudeBot, PerplexityBot, and most AI-answer bots) saw zero page content, only `<head>` meta tags.
- Adds a build-time prerender step using React 19's `renderToString` + Vite's `--ssr` build mode (no headless browser, no new dependencies). `App`'s `report` state starts `null` and stays `null` through any synchronous render, so `renderToString(<App/>)` deterministically captures the marketing/empty-state view — one snapshot matching the single canonical URL in `sitemap.xml`.
- `main.tsx` still uses `createRoot` (not `hydrateRoot`) — the client fully remounts over the prerendered markup rather than hydrating it, avoiding the entire class of hydration-mismatch errors since nothing needs to reconcile.
- Fixes 3 render-phase `localStorage`/`navigator` reads that would otherwise throw under Node's `renderToString` (Node 21+ partially stubs `navigator`, so the existing `typeof navigator === 'undefined'` guard in `defaultImperial()` no longer reliably detects a non-browser environment — `window` is the reliable sentinel).
- `scripts/prerender.mjs` fails the build loudly if the rendered HTML is too small, the expected feature-tile count is missing, or `ReportCard` markup leaked into what should be a deterministic logged-out render — so a future regression can't silently ship an empty `#root` again.
- No CI/CD or CDK changes: `.github/workflows/deploy.yml` already just runs `npm run build`, and `BucketDeployment` already reads whatever is in `apps/web/dist` at synth time.

Follow-up (separate PR): semantic heading hierarchy, crawlable sample-report links, a named author credit in the footer, and a `featureList` JSON-LD field — now provable via this prerendered snapshot.

## Test plan
- [x] `npm run build` (chained `build:client` → `build:ssr` → `prerender`) succeeds from a clean `dist/`
- [x] `dist/index.html` contains 12 `class="es-cap"` feature tiles, no leftover empty `<div id="root"></div>`, no `ReportCard` markup, valid JSON-LD
- [x] `curl` against `vite preview` (zero JS executed) shows the same 12 feature tiles — the actual proof a non-JS crawler would see real content
- [x] Real browser: zero console errors, typed input correctly bound to React state after the client `createRoot` mount takes over, confirming full interactivity survives the swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)