### PR TITLE
Semantic headings, crawlable sample links, author credit

### DIFF
--- a/apps/web/scripts/prerender.mjs
+++ b/apps/web/scripts/prerender.mjs
@@ -10,13 +10,9 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const webDir = new URL('..', import.meta.url).pathname
-const { render } = await import(join(webDir, 'dist-ssr', 'entry-server.js'))
+const { render, FEATURES } = await import(join(webDir, 'dist-ssr', 'entry-server.js'))
 
 const appHtml = render()
-
-// PR2 replaces this literal with FEATURES.length once content/features.ts
-// exists, so this count can't silently drift from the real feature list.
-const EXPECTED_FEATURE_COUNT = 12
 
 function fail(message) {
   console.error(`[prerender] ${message}`)
@@ -28,8 +24,8 @@ if (appHtml.length < 1500) {
 }
 
 const capCount = (appHtml.match(/class="es-cap"/g) ?? []).length
-if (capCount !== EXPECTED_FEATURE_COUNT) {
-  fail(`expected ${EXPECTED_FEATURE_COUNT} feature tiles (class="es-cap"), found ${capCount}.`)
+if (capCount !== FEATURES.length) {
+  fail(`expected ${FEATURES.length} feature tiles (class="es-cap"), found ${capCount}.`)
 }
 
 if (appHtml.includes('class="report-head"')) {
@@ -50,5 +46,25 @@ if (html.includes(EMPTY_ROOT)) {
   fail('replace produced no change — dist/index.html still contains an empty root div.')
 }
 
-writeFileSync(indexPath, html)
-console.log(`[prerender] injected ${appHtml.length} chars into dist/index.html (${capCount} feature tiles).`)
+// Keep the WebApplication JSON-LD's featureList mechanically in sync with the
+// actual feature grid — a featureList that drifts from real page content is
+// exactly the kind of sloppy structured data that undermines the trust this
+// whole prerendering effort is meant to build.
+const jsonLdMatch = html.match(/(<script type="application\/ld\+json">)([\s\S]*?)(<\/script>)/)
+if (!jsonLdMatch) {
+  fail('could not find the WebApplication JSON-LD <script> block in dist/index.html.')
+}
+let jsonLd
+try {
+  jsonLd = JSON.parse(jsonLdMatch[2])
+} catch (e) {
+  fail(`WebApplication JSON-LD did not parse before mutation: ${e.message}`)
+}
+jsonLd.featureList = FEATURES.map(([title]) => title)
+if (jsonLd.featureList.length !== FEATURES.length) {
+  fail(`featureList length mismatch after sync: expected ${FEATURES.length}, got ${jsonLd.featureList.length}.`)
+}
+const finalHtml = html.replace(jsonLdMatch[0], `${jsonLdMatch[1]}\n    ${JSON.stringify(jsonLd, null, 2)}\n    ${jsonLdMatch[3]}`)
+
+writeFileSync(indexPath, finalHtml)
+console.log(`[prerender] injected ${appHtml.length} chars into dist/index.html (${capCount} feature tiles, featureList synced).`)

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import ReportCard from './ReportCard'
 import DatePicker from './DatePicker'
 import type { NightReport } from './types'
 import { readLocalStorage } from './env'
+import { FEATURES } from './content/features'
 
 type Mode = 'place' | 'coords'
 
@@ -594,28 +595,12 @@ export default function App() {
             <div className="es-score-bar" />
           </div>
 
-          <span className="es-caps-label">Features</span>
+          <h2 className="es-caps-label">Features</h2>
 
-          {/* Ordered by differentiation, not data category: exclusive differentiators
-              first, then distinctive modeling, then commodity metrics; the rest is
-              swept into the "fundamentals" line below rather than given tiles. */}
           <div className="es-caps">
-            {([
-              ['Target Windows',    'Every shootable target with its peak time and window, and why others are blocked due to clouds, moonwash, or light domes.'],
-              ['Milky Way Planner', 'A 360° view of the galactic plane over your horizon—altitude, bearing, and the best minute to shoot.'],
-              ['Sky & Horizon Glow', 'A horizon map of light domes around you. Know more than just the Bortle.'],
-              ['Nearby Dark Sky',   'Search for low bortle locations you can actually reach, with routing to facilities like parking, campgrounds, and viewpoints. All sorted by drive times.'],
-              ['Moonlight Modeling', 'Most tools treat the moon as binary: up means ruined. DarkHours models real scattered moonlight brightening at your target from live aerosol data. A crescent barely registers. A bright gibbous gets called out.'],
-              ['360° Sky Simulation', "Drag around a rendered dome of tonight's actual sky: stars, Milky Way, moon phase, and light domes to scale. Scrub sunset to sunrise and watch visibility accurately change with conditions across the timeline"],
-              ['Aurora Forecast', 'NOAA space-weather data run through a geomagnetic visibility model for your exact location. Tiered honestly as overhead, naked eye, camera capture only, with the bearing to look toward.'],
-              ['Satellite Passes', "ISS, Hubble, and Tiangong passes with rise, peak, and set times. Newly launched Starlink trains are tracked while they're still bunched and bright."],
-              ['30 Day Best Night', 'A 30 day outlook. Compare conditions across multiple nights to identify the best windows.'],
-              ['Smoke & Haze Forecast',  'Wildfire smoke and upper-air aerosol data from ground sensors, and satellites.'],
-              ['Meteor Shower Predictions', 'Know when the next meteor shower will peak, the estimated meteors per hour, and visibility from your location.'],
-              ['Tailored Weather Forecasts', 'A two week, hour by hour forecast for: cloud cover, temperature, wind and humidity cloud layers, and wind - updated twice an hour. Plus three day atmospheric seeing, and transparency provided by 7Timer.'],
-            ] as [string, string][]).map(([k, v]) => (
+            {FEATURES.map(([k, v]) => (
               <div key={k} className="es-cap">
-                <span className="es-cap-k">{k}</span>
+                <h3 className="es-cap-k">{k}</h3>
                 <span className="es-cap-v">{v}</span>
               </div>
             ))}
@@ -638,15 +623,19 @@ export default function App() {
                 ['Death Valley, CA',   'Death Valley, California',                 'Bortle 1 — pristine desert benchmark'],
                 ['Cherry Springs, PA', 'Cherry Springs State Park, Pennsylvania',  'Bortle 2 — the East Coast classic'],
               ] as [string, string, string][]).map(([label, query, hook]) => (
-                <button
+                <a
                   key={query}
-                  type="button"
                   className="es-qs-btn"
-                  onClick={() => quickSearch(query)}
+                  href={`/?q=${encodeURIComponent(query)}`}
+                  onClick={(e) => {
+                    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+                    e.preventDefault()
+                    quickSearch(query)
+                  }}
                 >
                   <span className="es-qs-name">{label}</span>
                   <span className="es-qs-hook">{hook}</span>
-                </button>
+                </a>
               ))}
             </div>
           </div>
@@ -697,7 +686,9 @@ export default function App() {
         <p className="colophon-tagline">
           DarkHours is free,{' '}
           <a href="https://github.com/mbeher2200/DarkHours" target="_blank" rel="noreferrer">open source</a>
-          , and will never require your email address. Visit our{' '}
+          , and will never require your email address. Built by{' '}
+          <a href="/blog/about" target="_blank" rel="noreferrer">Miguel Beher</a>
+          , a landscape astrophotographer — read more on the{' '}
           <a href="/blog/" target="_blank" rel="noreferrer">blog</a>!
         </p>
 

--- a/apps/web/src/content/features.ts
+++ b/apps/web/src/content/features.ts
@@ -1,0 +1,21 @@
+// Single source of truth for the empty-state feature grid, shared with
+// entry-server.tsx so the WebApplication JSON-LD's featureList (synced by
+// scripts/prerender.mjs) can't silently drift from what's actually on the page.
+//
+// Ordered by differentiation, not data category: exclusive differentiators
+// first, then distinctive modeling, then commodity metrics; the rest is
+// swept into the "fundamentals" line in App.tsx rather than given tiles.
+export const FEATURES: [string, string][] = [
+  ['Target Windows',    'Every shootable target with its peak time and window, and why others are blocked due to clouds, moonwash, or light domes.'],
+  ['Milky Way Planner', 'A 360° view of the galactic plane over your horizon—altitude, bearing, and the best minute to shoot.'],
+  ['Sky & Horizon Glow', 'A horizon map of light domes around you. Know more than just the Bortle.'],
+  ['Nearby Dark Sky',   'Search for low bortle locations you can actually reach, with routing to facilities like parking, campgrounds, and viewpoints. All sorted by drive times.'],
+  ['Moonlight Modeling', 'Most tools treat the moon as binary: up means ruined. DarkHours models real scattered moonlight brightening at your target from live aerosol data. A crescent barely registers. A bright gibbous gets called out.'],
+  ['360° Sky Simulation', "Drag around a rendered dome of tonight's actual sky: stars, Milky Way, moon phase, and light domes to scale. Scrub sunset to sunrise and watch visibility accurately change with conditions across the timeline"],
+  ['Aurora Forecast', 'NOAA space-weather data run through a geomagnetic visibility model for your exact location. Tiered honestly as overhead, naked eye, camera capture only, with the bearing to look toward.'],
+  ['Satellite Passes', "ISS, Hubble, and Tiangong passes with rise, peak, and set times. Newly launched Starlink trains are tracked while they're still bunched and bright."],
+  ['30 Day Best Night', 'A 30 day outlook. Compare conditions across multiple nights to identify the best windows.'],
+  ['Smoke & Haze Forecast',  'Wildfire smoke and upper-air aerosol data from ground sensors, and satellites.'],
+  ['Meteor Shower Predictions', 'Know when the next meteor shower will peak, the estimated meteors per hour, and visibility from your location.'],
+  ['Tailored Weather Forecasts', 'A two week, hour by hour forecast for: cloud cover, temperature, wind and humidity cloud layers, and wind - updated twice an hour. Plus three day atmospheric seeing, and transparency provided by 7Timer.'],
+]

--- a/apps/web/src/entry-server.tsx
+++ b/apps/web/src/entry-server.tsx
@@ -16,3 +16,10 @@ import App from './App'
 export function render(): string {
   return renderToString(<App />)
 }
+
+// Re-exported so scripts/prerender.mjs (plain Node, no TS loader) can read the
+// same feature data already compiled into this bundle, instead of importing
+// content/features.ts directly from raw source — keeps the JSON-LD
+// featureList and the guardrail's expected tile count in sync with the
+// actual page content by construction, not by manual duplication.
+export { FEATURES } from './content/features'

--- a/apps/web/src/styles/09-empty-state.css
+++ b/apps/web/src/styles/09-empty-state.css
@@ -86,6 +86,7 @@
   font: inherit;
   font-size: 13px;
   text-align: left;
+  text-decoration: none;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s, background 0.15s, box-shadow 0.15s;
 }
@@ -118,7 +119,7 @@
   letter-spacing: 0.07em;
   color: var(--text-dim);
   opacity: 0.65;
-  margin-bottom: -6px;
+  margin: 0 0 -6px;
 }
 html.red-mode .es-caps-label { color: var(--text-dim); }
 .es-caps {
@@ -133,6 +134,7 @@ html.red-mode .es-caps-label { color: var(--text-dim); }
   min-width: 0;
 }
 .es-cap-k {
+  margin: 0;
   font-family: var(--mono);
   font-size: 10px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
Depends on #150 (targets that branch, not `main`, since it extends `entry-server.tsx`/`prerender.mjs`). Now that the empty-state view is actually prerendered, makes it worth crawling:

- Feature-grid titles were plain `<span>`s under one page-wide `<h1>` — promotes "Features" to `<h2>` and each of the 12 tiles to `<h3>`, giving crawlers a real outline instead of a flat wall of styled text.
- The 3 sample-report buttons had no `href` at all — not links in any sense a crawler could follow. Converts them to real `<a href="/?q=...">` anchors (matching the existing `?q=` URL-param scheme `App.tsx` already parses on mount), with a modifier-key-aware `onClick` so ctrl/cmd/middle-click still opens a new tab instead of being swallowed by the in-page search handler.
- Footer now names and links the author (Miguel Beher, `/blog/about`) instead of just "DarkHours contributors" — makes the authorship already encoded in the `WebApplication` JSON-LD's `author` field (#149) visible in actual page content, which matters for an audience that needs to trust a named author before adopting a tool.
- Pulled the 12 `[title, description]` feature tuples into `content/features.ts`, re-exported from `entry-server.tsx`, so `prerender.mjs` syncs the JSON-LD's `featureList` and sizes its guardrail check off the real data instead of a hardcoded count that could silently drift from the actual page.
- CSS: margin resets this codebase already uses whenever a plain span becomes a heading, plus `text-decoration: none` on the sample-report anchors.

## Test plan
- [x] `npm run build` — `dist/index.html` has `<h2>`/`<h3>` headings, 3 real `href="/?q=..."` links, footer names Miguel Beher, `featureList` (12 entries) synced into the JSON-LD
- [x] Real browser: clicked a sample-report link — confirmed `location.href` stays on `/` (no full navigation) while the `/night` fetch fires directly, proving the anchor is both a real crawlable link and still an instant in-page action for users
- [x] Zero console errors; visual layout unchanged after the span→heading/button→anchor conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)