### PR TITLE
Bump transitive postcss to patch path-traversal CVE

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -2514,9 +2514,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -2638,9 +2638,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2657,7 +2657,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert [#3](https://github.com/mbeher2200/DarkHours/security/dependabot/3) (high): PostCSS path traversal in source-map auto-loading, resolved version 8.5.15 was below the 8.5.18 patch.
- Both parents pulling it in (`vite` directly, and `rrweb-snapshot` transitively via `aws-rum-web`) already declare semver ranges that permit the patched version — this is a pure lockfile bump (now resolves to 8.5.23), no direct dependency version changed.

Related: alert [#1](https://github.com/mbeher2200/DarkHours/security/dependabot/1) (uuid, moderate, also transitive via `aws-rum-web`) has been dismissed separately with a documented reason — the vulnerable code path (`v3()`/`v5()`/`v6()`) is never called; every call site in `@aws-rum/web-core` exclusively uses `v4()`, which the advisory explicitly excludes.

## Test plan
- [x] `npm ls postcss` confirms both `vite` and `rrweb-snapshot` now resolve to `postcss@8.5.23`
- [x] `npm run build` succeeds unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)