### PR TITLE
Link homepage story to blog post; polish README fallback copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![DarkHours night report for Knolls, UT, a Bortle 1 site, with the horizon light dome panel showing the real light dome from Salt Lake City](docs/images/hero.png)
 
-Pick a place and a date. DarkHours presents a score, an hour by hour plan of what to shoot and when, and a list of darker spots to drive to if local conditions don't hold up.
+Pick a place and a date. DarkHours presents a score, an hour by hour plan of what to shoot and when, and a list of darker spots to drive to if you need to change plans.
 
 **Visit at: [https://darkhours.app](https://darkhours.app)**
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -587,7 +587,11 @@ export default function App() {
           <div className="es-copy">
             <p className="es-headline">Built for landscape astrophotography. Not for subscriptions.</p>
             <p className="es-body">
-              Most of us only get a handful of clear, dark hours each month to do what we love. I built DarkHours because I needed a highly precise predictive tool for my own landscape astrophotography. It's open-source, free, and designed to help make the most of every dark hour.
+              Most of us only get a handful of clear, dark hours each month to do what we love.{' '}
+              <a href="/blog/my-astrophotography-origin-story-and-a-new-app" target="_blank" rel="noreferrer">
+                I built DarkHours because I needed a highly precise predictive tool for my own landscape astrophotography
+              </a>
+              . It's open-source, free, and designed to help make the most of every dark hour.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Link the homepage founder-story blurb to its matching blog post — closes an internal-linking gap flagged in the SEO audit (the two told the same story with zero links between them)
- Soften README's fallback-location phrasing ("if local conditions don't hold up" → "if you need to change plans")

## Test plan
- [x] Verified locally in a dev server: link renders correctly, `href="/blog/my-astrophotography-origin-story-and-a-new-app"`, opens in a new tab consistent with the other `/blog/*` links in the footer, no console errors
- [ ] Skim README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)