### PR TITLE
Add Plausible analytics to web app

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -58,6 +58,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-dNdadDzL5KmlgdiqqJYJx.js"></script>
+    <script>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds the Plausible privacy-friendly analytics snippet to `apps/web/index.html`, matching the same snippet added to the darkhours-blog repo, so pageviews across app + blog roll up under one `darkhours.app` property.
- Confirmed the script survives the SSR/prerender pipeline into `dist/index.html` and initializes correctly in dev.

## Test plan
- [x] `npm run build` in `apps/web` completes and `dist/index.html` contains the Plausible script tag
- [x] Verified in dev server that `window.plausible` initializes

🤖 Generated with [Claude Code](https://claude.com/claude-code)