### PR TITLE
Fix dark-cycle window zeroing real dark nights at shoulder season

### DIFF
--- a/darkhours/predictor.py
+++ b/darkhours/predictor.py
@@ -496,9 +496,9 @@ def assemble_night(
     from lunar_cycle_dark_analysis()'s already-computed 30-night window instead
     of an independent sky_events() call. No event timeline, no moonrise/moonset —
     NightSummary (the calendar path's result type) doesn't carry any of those.
-    This extends the same fixed-twilight-offset approximation dark_score already
-    accepts (see sky_events.py) to moon_score/weather-windowing too, but only
-    for this path; output is otherwise unaffected.
+    The window's per-night twilight boundaries are exact (same dark_twilight_day
+    search sky_events uses — see sky_events.py), so this path differs from the
+    sky_events one only in what it omits, not in accuracy.
     """
     def _local(dt):
         return dt.astimezone(tz)
@@ -939,9 +939,7 @@ def assemble_night(
             log.debug("moon_altitude_track failed (non-fatal): %s", _mae)
 
     # --- Aurora outlook (fetches already resolved off-thread; per-location math
-    # is cheap). On the use_cycle_window path night_start/night_end come from
-    # the fixed-twilight-offset approximation — minutes-scale error against the
-    # 3-hour Kp bins, acceptable. Non-fatal on any failure.
+    # is cheap). Non-fatal on any failure.
     aurora_info = None
     if _aurora_future is not None and night_start and night_end:
         try:

--- a/darkhours/sky_events.py
+++ b/darkhours/sky_events.py
@@ -216,7 +216,12 @@ def _dark_cycle_db_key(lat: float, lon: float, window_start: date) -> str:
     # instead of a bare dark-hours float, so assemble_night()'s calendar path can
     # derive moon_score/weather-windowing inputs from this window instead of an
     # independent sky_events() call.
-    return f"dark_cycle_v2|{lat:.2f}|{lon:.2f}|{window_start.isoformat()}"
+    # v3: same shape, but twilight boundaries are now exact per night. v2 windows
+    # computed from a shoulder-season target_date were poisoned (every night
+    # zeroed when tonight lacked astronomical night — see _compute_dark_hours_cycle),
+    # and with no TTL they'd be served forever; the bump orphans them all at once
+    # (scripts/purge_dark_cycle_v2.py deletes the orphaned DynamoDB items).
+    return f"dark_cycle_v3|{lat:.2f}|{lon:.2f}|{window_start.isoformat()}"
 
 
 def _nights_to_json(nights: list[dict]) -> list[dict]:
@@ -259,16 +264,26 @@ def _nights_from_json(raw: list[dict]) -> list[dict]:
 def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> list:
     """Compute dark sky hours for 30 consecutive nights centred on target_date.
 
-    Two parallel find_discrete calls cover sunrise/sunset and moonrise/moonset
-    for the full 32-day window.  Astronomical twilight boundaries are derived
-    from tonight's sky_events (already cached) as a fixed offset applied to all
-    30 nights rather than 30 separate per-night find_discrete calls.  Drift is
-    ≤2 min/day so ≤30 min at the ±15-day edges; benchmark showed ≤0.25h array
-    drift at mid-latitudes, ≤0.75h at high latitude near solstice.  Saves the
-    ~300ms serial twilight-search loop from the previous implementation.
-    When no astronomical night exists tonight (high-lat summer), all nights
-    return 0 — correct for the solstice window where the whole 30-night window
-    also lacks astronomical darkness.
+    Two parallel find_discrete calls cover the full 32-day window: one
+    dark_twilight_day search yields sunset/sunrise (phase 3↔4, the same
+    −0.8333° boundary the old sun risings_and_settings search used — verified
+    identical to the second) *and* per-night astronomical-night boundaries
+    (phase 0↔1); the other covers moonrise/moonset.
+
+    Twilight boundaries are exact per night, not extrapolated. An earlier
+    version derived them from tonight's sky_events as a fixed offset applied
+    to all 30 nights; that broadcast turned "no astronomical night *tonight*"
+    into "no darkness for the whole window", zeroing real dark nights at
+    shoulder season (high-lat late summer, where darkness returns mid-window)
+    — and the poisoned windows were then served to every other date they
+    covered via the no-TTL caches. dark_twilight_day samples at 0.04 days
+    (~58 min), which also catches the sub-hour astro-night dips right at the
+    seasonal transition that a default 0.25-day risings_and_settings step
+    provably skips (4 consecutive real nights missed at 55°N, Aug 2026).
+
+    Cost: the twilight search is ~35 ms dearer than the old sun-horizon
+    search, but drops the internal sky_events() dependency, and runs once per
+    (location, window) before both cache layers make it permanent.
     """
     ts  = load.timescale()
     eph = _ephemeris()
@@ -279,9 +294,8 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
     t0 = ts.utc(d0.year, d0.month, d0.day)
     t1 = ts.utc(d1.year, d1.month, d1.day)
 
-    sun    = eph["sun"]
-    f_hor  = almanac.risings_and_settings(eph, sun,         observer, horizon_degrees=-0.8333)
-    f_moon = almanac.risings_and_settings(eph, eph["moon"], observer)
+    f_twilight = almanac.dark_twilight_day(eph, observer)
+    f_moon     = almanac.risings_and_settings(eph, eph["moon"], observer)
 
     def _timed(fn, *args):
         t0_ = _time.monotonic()
@@ -290,45 +304,39 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
 
     _t_wall0 = _time.monotonic()
     with _futures.ThreadPoolExecutor(max_workers=2) as _pool:
-        _hor_f  = _pool.submit(_timed, almanac.find_discrete, t0, t1, f_hor)
+        _tw_f   = _pool.submit(_timed, almanac.find_discrete, t0, t1, f_twilight)
         _moon_f = _pool.submit(_timed, almanac.find_discrete, t0, t1, f_moon)
-        (hor_times,  hor_rising),  _hor_ms  = _hor_f.result()
+        (tw_times,   tw_phases),   _tw_ms   = _tw_f.result()
         (moon_times, moon_rising), _moon_ms = _moon_f.result()
     _wall_ms = round((_time.monotonic() - _t_wall0) * 1000)
 
-    log.info("dark_cycle threads hor=%dms moon=%dms wall=%dms",
-             _hor_ms, _moon_ms, _wall_ms)
+    log.info("dark_cycle threads twilight=%dms moon=%dms wall=%dms",
+             _tw_ms, _moon_ms, _wall_ms)
 
     all_events = []
-    for t, rising in zip(hor_times, hor_rising):
-        all_events.append({"time": t.utc_datetime(),
-                           "label": "Sunrise" if rising else "Sunset"})
+    # Phase 3↔4 transitions are sunset/sunrise; 0↔1 are astronomical-night
+    # boundaries. The very first transition after t0 has no predecessor to
+    # classify it and is dropped — harmless, because the earliest event the
+    # night loop consumes (sunset of target−14) lies ≥29 h into the window,
+    # with the full morning twilight ladder of target−15 in between. Same
+    # convention as _compute_sky_events.
+    prev = None
+    for t, phase in zip(tw_times, tw_phases):
+        if prev is not None:
+            pair = {int(phase), int(prev)}
+            if pair == {3, 4}:
+                all_events.append({"time": t.utc_datetime(),
+                                   "label": "Sunrise" if phase == 4 else "Sunset"})
+            elif pair == {0, 1}:
+                all_events.append({"time": t.utc_datetime(),
+                                   "label": "Astronomical night begins" if phase == 0
+                                            else "Astronomical night ends"})
+        prev = phase
     for t, rising in zip(moon_times, moon_rising):
         all_events.append({"time": t.utc_datetime(),
                            "label": "Moonrise" if rising else "Moonset"})
 
     all_events.sort(key=lambda e: e["time"])
-
-    # Twilight offsets from tonight's sky_events (warm cache hit after sky_events
-    # runs earlier in assemble_night).  None when no astronomical night tonight.
-    _sky_ev = sky_events(lat, lon, target_date)
-    _t_set  = next((e["time"] for e in _sky_ev
-                    if e["label"] == "Sunset"
-                    and e["time"].astimezone(tz).date() == target_date), None)
-    _t_rise = find_event(_sky_ev, "Sunrise", after=_t_set)                      if _t_set else None
-    _t_nb   = find_event(_sky_ev, "Astronomical night begins", after=_t_set)    if _t_set else None
-    _t_ne   = find_event(_sky_ev, "Astronomical night ends", after=_t_nb or _t_set) if _t_set else None
-
-    tw_after  = (_t_nb   - _t_set ).total_seconds() if (_t_set and _t_nb)   else None
-    tw_before = (_t_rise - _t_ne  ).total_seconds() if (_t_rise and _t_ne)  else None
-
-    # Sanity bound for the fixed twilight-offset approximation applied below: a
-    # real astronomical-twilight duration is minutes to a couple hours, never
-    # anywhere close to this. If it ever is, something's wrong with the inputs
-    # (e.g. bad ephemeris data) — log it and treat that night as degenerate
-    # rather than silently emit a night_start/night_end that could have drifted
-    # onto the wrong calendar day.
-    _MAX_SANE_TWILIGHT_OFFSET_S = 6 * 3600
 
     _t_loop0 = _time.monotonic()
     nights = []
@@ -344,27 +352,22 @@ def _compute_dark_hours_cycle(lat: float, lon: float, target_date: date, tz) -> 
 
         night_start = night_end = None
         dark_hours  = 0.0
-        if (sunset and sunrise and tw_after is not None and tw_before is not None
-                and tw_after <= _MAX_SANE_TWILIGHT_OFFSET_S
-                and tw_before <= _MAX_SANE_TWILIGHT_OFFSET_S):
-            night_start = sunset  + timedelta(seconds=tw_after)
-            night_end   = sunrise - timedelta(seconds=tw_before)
-            if night_end > night_start:
+        if sunset and sunrise:
+            night_start = find_event(all_events, "Astronomical night begins",
+                                     after=sunset, before=sunrise)
+            if night_start is not None:
+                night_end = find_event(all_events, "Astronomical night ends",
+                                       after=night_start, before=sunrise)
+            if night_start is not None and night_end is None:
+                # The sun must recross −18° before it can reach the horizon, so
+                # a begins without an ends means clipped input, not geometry.
+                log.warning("dark_cycle: unpaired astro-night begins for %s at offset %+d",
+                            night_date, offset)
+                night_start = None
+            if night_start and night_end:
                 intervals  = dark_moon_intervals(all_events, night_start, night_end)
                 total_secs = sum((e - s).total_seconds() for s, e in intervals)
                 dark_hours = total_secs / 3600
-            else:
-                # Degenerate window (offset pushed past a real boundary) — don't
-                # expose a night_start/night_end that's no longer meaningful.
-                log.warning(
-                    "dark_cycle: degenerate window for %s at offset %+d (night_end <= night_start)",
-                    night_date, offset,
-                )
-                night_start = night_end = None
-        elif tw_after is not None and (
-                tw_after > _MAX_SANE_TWILIGHT_OFFSET_S or (tw_before or 0) > _MAX_SANE_TWILIGHT_OFFSET_S):
-            log.warning("dark_cycle: implausible twilight offset for %s (tw_after=%s tw_before=%s) — skipping",
-                        night_date, tw_after, tw_before)
 
         nights.append({
             "sunset":      sunset,

--- a/scripts/purge_dark_cycle_v2.py
+++ b/scripts/purge_dark_cycle_v2.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Delete orphaned dark_cycle_v2 cache items from the DynamoDB cache table.
+
+The v2 -> v3 key bump in sky_events._dark_cycle_db_key (see that function's
+comment) orphaned every v2 window: some were poisoned by the fixed
+twilight-offset broadcast (a shoulder-season target_date zeroed all 30 nights),
+and none carry a TTL, so they never expire on their own. This script physically
+removes them to reclaim storage. It is safe to run at any time after the v3
+code is deployed -- nothing reads v2 keys anymore.
+
+The table name comes from PYNIGHTSKY_CACHE_TABLE (never hardcoded -- public
+repo). Dry-run is the default; pass --delete to actually remove items.
+
+Usage:
+  export PYNIGHTSKY_CACHE_TABLE=<table>   # discover per docs/ or cdk.out
+  python scripts/purge_dark_cycle_v2.py            # count + list, no writes
+  python scripts/purge_dark_cycle_v2.py --delete   # actually delete
+"""
+
+import argparse
+import os
+import sys
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+from botocore.exceptions import ClientError
+
+PREFIX = "dark_cycle_v2|"
+
+
+def find_v2_keys(table) -> list[str]:
+    """Scan for cache keys beginning with the orphaned v2 prefix."""
+    paginator = table.meta.client.get_paginator("scan")
+    keys = []
+    for page in paginator.paginate(
+        TableName=table.name,
+        FilterExpression=Attr("cache_key").begins_with(PREFIX),
+        ProjectionExpression="cache_key",
+    ):
+        keys.extend(item["cache_key"] for item in page["Items"])
+    return keys
+
+
+def delete_keys(table, keys: list[str]) -> None:
+    """Batch-delete the given cache keys (auto-chunked, unprocessed retried)."""
+    with table.batch_writer() as batch:
+        for key in keys:
+            batch.delete_item(Key={"cache_key": key})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--delete", action="store_true",
+                        help="actually delete the items (default: dry run)")
+    args = parser.parse_args()
+
+    table_name = os.environ.get("PYNIGHTSKY_CACHE_TABLE")
+    if not table_name:
+        print("PYNIGHTSKY_CACHE_TABLE is not set.", file=sys.stderr)
+        return 1
+
+    table = boto3.resource("dynamodb").Table(table_name)
+    try:
+        keys = find_v2_keys(table)
+        if not keys:
+            print("No dark_cycle_v2 items found -- nothing to do.")
+            return 0
+        for key in keys:
+            print(key)
+        if args.delete:
+            delete_keys(table, keys)
+            print(f"Deleted {len(keys)} dark_cycle_v2 items.")
+        else:
+            print(f"Dry run: {len(keys)} dark_cycle_v2 items would be deleted "
+                  f"(re-run with --delete).")
+        return 0
+    except ClientError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sky_events.py
+++ b/tests/test_sky_events.py
@@ -394,3 +394,110 @@ class TestLunarCycleDarkAnalysis:
         assert r2["tonight"]["sunset"] != "corrupted"
         assert r2["tonight"]["dark_hours"] == 5.0
         assert "new_key" not in r2["tonight"]
+
+    def test_cache_key_is_v3(self):
+        """v2 windows could be poisoned by the fixed twilight-offset broadcast
+        (see _compute_dark_hours_cycle) and carry no TTL; the v3 bump is what
+        orphans them everywhere at once. Guard against an accidental revert."""
+        import darkhours.sky_events as se
+        key = se._dark_cycle_db_key(40.0, -105.0, date(2026, 7, 2))
+        assert key.startswith("dark_cycle_v3|")
+
+
+# ---------------------------------------------------------------------------
+# _compute_dark_hours_cycle — exact per-night twilight (shoulder-season
+# regression). Calls the compute function directly: no cache layers involved.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.eph
+class TestDarkHoursCycleShoulderSeason:
+    """Regression for the fixed twilight-offset broadcast bug: when the
+    *target* night had no astronomical night (high-lat late summer), every
+    night in the 30-night window was zeroed — including real dark nights
+    later in the window — and the poisoned window was then cached with no
+    TTL and served, via the overlap hit, to dates that would have computed
+    correct values themselves. At 55°N astronomical darkness returns the
+    night of Aug 5–6 2026 (a ~1 h dip below −18°) and grows from there."""
+
+    LAT, LON = 55.0, 0.0
+
+    @staticmethod
+    def _tz(name="UTC"):
+        from zoneinfo import ZoneInfo
+        return ZoneInfo(name)
+
+    def test_shoulder_window_reports_returning_darkness(self):
+        from darkhours.sky_events import _compute_dark_hours_cycle
+        target = date(2026, 8, 1)  # no astronomical night this night
+        nights = _compute_dark_hours_cycle(self.LAT, self.LON, target, self._tz())
+        by_date = {target + timedelta(days=i - 14): n for i, n in enumerate(nights)}
+
+        # Tonight and the nights just after genuinely lack astronomical night.
+        for d in [date(2026, 8, 1), date(2026, 8, 2), date(2026, 8, 3), date(2026, 8, 4)]:
+            assert by_date[d]["dark_hours"] == 0.0
+            assert by_date[d]["night_start"] is None
+
+        # Astronomical night exists again from early August (moon may still be
+        # up: night_start must be set even where dark_hours stays 0)…
+        for d in [date(2026, 8, 6), date(2026, 8, 7), date(2026, 8, 8)]:
+            assert by_date[d]["night_start"] is not None, f"no astro night reported for {d}"
+
+        # …and real moonless dark hours accumulate later in the window. The
+        # old broadcast reported 0.0 for every one of these.
+        for d in [date(2026, 8, 9) + timedelta(days=i) for i in range(8)]:
+            assert by_date[d]["dark_hours"] > 0.5, (
+                f"{d}: expected real dark hours, got {by_date[d]['dark_hours']}"
+            )
+
+    def test_same_calendar_night_agrees_across_windows(self):
+        """The poisoning repro: a night's dark_hours must not depend on which
+        target_date's window computed it. (Aug 12's window computes Aug 10
+        correctly; Aug 1's window used to zero it.)"""
+        from darkhours.sky_events import _compute_dark_hours_cycle
+        t1, t2 = date(2026, 8, 1), date(2026, 8, 12)
+        w1 = _compute_dark_hours_cycle(self.LAT, self.LON, t1, self._tz())
+        w2 = _compute_dark_hours_cycle(self.LAT, self.LON, t2, self._tz())
+        checked = 0
+        for i, n in enumerate(w1):
+            d = t1 + timedelta(days=i - 14)
+            j = (d - (t2 - timedelta(days=14))).days
+            if 0 <= j < 30:
+                assert abs(n["dark_hours"] - w2[j]["dark_hours"]) < 0.01, (
+                    f"{d}: {n['dark_hours']} (window {t1}) vs "
+                    f"{w2[j]['dark_hours']} (window {t2})"
+                )
+                checked += 1
+        assert checked >= 15  # windows overlap by 19 nights
+
+    def test_true_solstice_high_lat_is_legitimately_all_zero(self):
+        """At 60°N around the June solstice the whole window really has no
+        astronomical night — all-zero output is correct there, with no
+        fabricated night_start/night_end."""
+        from darkhours.sky_events import _compute_dark_hours_cycle
+        nights = _compute_dark_hours_cycle(60.0, 0.0, date(2026, 6, 21), self._tz())
+        assert all(n["dark_hours"] == 0.0 for n in nights)
+        assert all(n["night_start"] is None and n["night_end"] is None for n in nights)
+
+    def test_boundaries_match_sky_events_exactly(self):
+        """Per-night night_start/night_end must agree with the single-night
+        sky_events path (the parity oracle) to find_discrete precision — the
+        old approximation drifted by up to ~30 min at the window edges."""
+        from darkhours.sky_events import (
+            _compute_dark_hours_cycle, _compute_sky_events, find_event,
+        )
+        lat, lon = 39.74, -104.98  # Denver
+        tz = self._tz("America/Denver")
+        target = date(2026, 7, 26)
+        nights = _compute_dark_hours_cycle(lat, lon, target, tz)
+
+        for offset in (-14, 0, 15):  # both window edges + centre
+            d = target + timedelta(days=offset)
+            n = nights[offset + 14]
+            events = _compute_sky_events(lat, lon, d)
+            sunset = next(e["time"] for e in events
+                          if e["label"] == "Sunset"
+                          and e["time"].astimezone(tz).date() == d)
+            nb = find_event(events, "Astronomical night begins", after=sunset)
+            ne = find_event(events, "Astronomical night ends", after=nb)
+            assert abs((n["night_start"] - nb).total_seconds()) < 30
+            assert abs((n["night_end"] - ne).total_seconds()) < 30


### PR DESCRIPTION
## Summary
- `_compute_dark_hours_cycle` derived astronomical-twilight boundaries from *tonight's* sky_events as a fixed offset broadcast across the whole 30-night window. When tonight had no astronomical night (high-lat late summer), that broadcast zeroed every night in the window — including genuinely dark nights later in it (55N, Aug 1 2026: all 30 nights reported 0.0h, while Aug 9-16 actually offer 1.5-3.5h).
- The poisoned window was then cached with no TTL (in-process + DynamoDB) and served via the overlap-hit path to *other* dates, so a night's score ended up depending on which target_date happened to populate the cache first. `dark_score` feeds `rate_night()` at 25% weight on every path (CLI, `/night`, `/calendar`, trip planner).
- Replaced the broadcast with exact per-night twilight boundaries via a single `dark_twilight_day` search over the same window (sunset/sunrise at the same -0.8333° boundary as before, astro-night at -18°, 0.04-day sampling — catches sub-hour shoulder-season dips a 0.25-day step provably misses). Boundaries now match the single-night `sky_events` reference path to <2s across the window (previously up to ~30 min drift), and the internal `sky_events()` dependency is gone.
- Cache key bumped `dark_cycle_v2` -> `dark_cycle_v3` to orphan every stored v2 window atomically at deploy. `scripts/purge_dark_cycle_v2.py` (new) will physically remove the orphaned DynamoDB items after deploy.

## Test plan
- [x] Full suite green: `python -m pytest -q` (873 passed, 9 skipped — aws/live auto-skip)
- [x] New regression coverage in `tests/test_sky_events.py`: shoulder-season window reports returning darkness, same calendar night agrees regardless of which window computed it (the cache-poisoning repro), true-solstice-at-60N stays legitimately all-zero, per-night boundaries match the `sky_events` parity oracle, cache key stays v3
- [x] Benchmarked before/after (local): cold window compute 65ms -> 95ms, paid once per (location, window) before the no-TTL caches make it permanent; warm path unchanged
- [x] Reviewed via `/code-review ultra` — 0 confirmed findings after verification
- [ ] Run `scripts/purge_dark_cycle_v2.py` (dry run, then `--delete`) against the real cache table after this deploys to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)