### PR TITLE
Link the dark-sky destination guides from the footer

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -691,7 +691,8 @@ export default function App() {
           DarkHours is free,{' '}
           <a href="https://github.com/mbeher2200/DarkHours" target="_blank" rel="noreferrer">open source</a>
           , and will never require your email address. Follow our{' '}
-          <a href="/blog/" target="_blank" rel="noreferrer">blog</a>!
+          <a href="/blog/" target="_blank" rel="noreferrer">blog</a>, or browse our{' '}
+          <a href="/dark-sky/" target="_blank" rel="noreferrer">dark sky guides</a>!
         </p>
 
         <p className="colophon-legal">


### PR DESCRIPTION
## Summary
- The destinations repo (darkhours-destinations) now has real content live at darkhours.app/dark-sky/ (Joshua Tree and Zion, more shipping incrementally) but nothing in this app linked to it — the pages were orphaned, reachable only by direct URL.
- Added "browse our dark sky guides" to the existing footer tagline, alongside the blog link.

## Test plan
- [x] `npm run build` (apps/web) — builds clean, prerendered output confirmed to include the new link
- [x] `npm run lint` — no new lint errors introduced (verified by diffing lint output against the unmodified file)
- [ ] Visual check on the deployed site once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)