### PR TITLE
Wire the dark-sky destinations section into root robots.txt and llms.txt

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -8,10 +8,14 @@
 - [Blog](https://darkhours.app/blog/): Astrophotography trip reports, travel, and software notes from the app's creator
 - [Blog RSS feed](https://darkhours.app/blog/rss.xml): Full-text feed of blog posts
 - [Blog llms.txt](https://darkhours.app/blog/llms.txt): AI-crawler summary of the blog specifically
+- [Dark-sky destinations](https://darkhours.app/dark-sky/): Trip-planning guides for US dark-sky destinations
+- [Dark-sky llms.txt](https://darkhours.app/dark-sky/llms.txt): AI-crawler summary of the destinations guides specifically
 - [Sitemap](https://darkhours.app/sitemap.xml): App page URLs
 - [Blog sitemap](https://darkhours.app/blog/sitemap-index.xml): Blog post URLs
+- [Dark-sky sitemap](https://darkhours.app/dark-sky/sitemap-index.xml): Destination guide URLs
 
 ## Notes
 
 - DarkHours is free and open source.
 - The blog is a separate Astro site served at the `/blog/` path of this same domain.
+- The dark-sky destination guides are a separate Astro site served at the `/dark-sky/` path of this same domain.

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -3,3 +3,4 @@ Allow: /
 
 Sitemap: https://darkhours.app/sitemap.xml
 Sitemap: https://darkhours.app/blog/sitemap-index.xml
+Sitemap: https://darkhours.app/dark-sky/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Adds `Sitemap: https://darkhours.app/dark-sky/sitemap-index.xml` to `robots.txt`, matching the existing blog sitemap entry
- Adds dark-sky destinations/llms.txt/sitemap links and a notes line to root `llms.txt`, matching the existing blog entries

The dark-sky section (`darkhours-destinations` repo) already ships its own `sitemap-index.xml` and `llms.txt` on every build, but the root site never referenced them, so crawlers and AI tools had no path to the destination guides.

## Test plan
- [ ] After merge/deploy, confirm `https://darkhours.app/robots.txt` lists the dark-sky sitemap
- [ ] Confirm `https://darkhours.app/llms.txt` lists the dark-sky entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)