### PR TITLE
Fix /dark-sky/* returning 403 instead of 404 for missing pages

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -836,6 +836,35 @@ function handler(event) {
             },
         )
 
+        # with_origin_access_control() above only grants s3:GetObject, so a request for a
+        # /dark-sky/* key that doesn't exist (typo'd URL, not-yet-published destination
+        # page, stray /dark-sky/sitemap.xml probe) comes back as 403 rather than 404 — S3
+        # withholds the "not found" distinction from a principal that can't list the
+        # bucket. Googlebot then logs it as "blocked" instead of "not found", which is a
+        # worse Search Console signal. Granting ListBucket (on the bucket itself, not
+        # bucket/*) to the same OAC-scoped principal is the standard fix and only affects
+        # this one bucket of public static pages — deliberately not done via a
+        # distribution-level error_responses 403->404 remap, since that config applies to
+        # every behavior on `dist` and would also mask real 403s from the WAF rate-limit
+        # rules on /nearby, /calendar, and the site overall.
+        dest_bucket.add_to_resource_policy(
+            iam.PolicyStatement(
+                sid="AllowCloudFrontServicePrincipalListBucket",
+                effect=iam.Effect.ALLOW,
+                principals=[iam.ServicePrincipal("cloudfront.amazonaws.com")],
+                actions=["s3:ListBucket"],
+                resources=[dest_bucket.bucket_arn],
+                conditions={
+                    "StringEquals": {
+                        "AWS:SourceArn": (
+                            f"arn:aws:cloudfront::{self.account}:"
+                            f"distribution/{dist.distribution_id}"
+                        ),
+                    },
+                },
+            )
+        )
+
         # Upload the built SPA and invalidate the edge cache on every deploy. The asset
         # path is resolved relative to this file so it works regardless of cwd.
         spa_dist_path = os.path.join(os.path.dirname(__file__), "..", "apps", "web", "dist")


### PR DESCRIPTION
## Summary
- Google Search Console crawl stats for darkhours.app showed ~12% of requests as 4XX, bucketed as "Other client error" with no separate "Not found (404)" category — confirmed live that any missing key under `/dark-sky/*` (e.g. the wrong sitemap.xml path, a not-yet-published destination page, a typo'd URL) returns 403 rather than 404.
- Root cause: `S3BucketOrigin.with_origin_access_control()` only grants `s3:GetObject` to CloudFront's OAC principal on `DestinationsBucket`. Without `s3:ListBucket`, S3 can't confirm the object doesn't exist to that principal, so it returns 403 instead of 404 — a worse signal in Search Console (reads as "blocked" rather than "not found").
- Fix: grant `s3:ListBucket` on the bucket itself (not `bucket/*`) to the same OAC-scoped CloudFront service principal, scoped to `DestinationsBucket` only.
- Deliberately *not* done via a distribution-level `error_responses` 403→404 remap — that config applies to every behavior on the shared `Cdn` distribution and would also mask real WAF rate-limit 403s on the `/nearby` and `/calendar` API behaviors.

## Test plan
- [x] `python3 -m ast.parse` on the changed file (local CDK synth can't fully bundle on this machine — see `docs/` note on the Colima virtiofs limitation)
- [x] `python -m pytest -q` — 873 passed, 9 skipped
- [ ] After merge/deploy, confirm `curl -I https://darkhours.app/dark-sky/sitemap.xml` returns 404 instead of 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)