### PR TITLE
Add lightweight custom 404 page for /dark-sky/*

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -836,6 +836,35 @@ function handler(event) {
             },
         )
 
+        # with_origin_access_control() above only grants s3:GetObject, so a request for a
+        # /dark-sky/* key that doesn't exist (typo'd URL, not-yet-published destination
+        # page, stray /dark-sky/sitemap.xml probe) comes back as 403 rather than 404 — S3
+        # withholds the "not found" distinction from a principal that can't list the
+        # bucket. Googlebot then logs it as "blocked" instead of "not found", which is a
+        # worse Search Console signal. Granting ListBucket (on the bucket itself, not
+        # bucket/*) to the same OAC-scoped principal is the standard fix and only affects
+        # this one bucket of public static pages — deliberately not done via a
+        # distribution-level error_responses 403->404 remap, since that config applies to
+        # every behavior on `dist` and would also mask real 403s from the WAF rate-limit
+        # rules on /nearby, /calendar, and the site overall.
+        dest_bucket.add_to_resource_policy(
+            iam.PolicyStatement(
+                sid="AllowCloudFrontServicePrincipalListBucket",
+                effect=iam.Effect.ALLOW,
+                principals=[iam.ServicePrincipal("cloudfront.amazonaws.com")],
+                actions=["s3:ListBucket"],
+                resources=[dest_bucket.bucket_arn],
+                conditions={
+                    "StringEquals": {
+                        "AWS:SourceArn": (
+                            f"arn:aws:cloudfront::{self.account}:"
+                            f"distribution/{dist.distribution_id}"
+                        ),
+                    },
+                },
+            )
+        )
+
         # Upload the built SPA and invalidate the edge cache on every deploy. The asset
         # path is resolved relative to this file so it works regardless of cwd.
         spa_dist_path = os.path.join(os.path.dirname(__file__), "..", "apps", "web", "dist")

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -765,10 +765,48 @@ function handler(event) {
             code=cloudfront.FunctionCode.from_inline(_dark_sky_rewrite_js),
             runtime=cloudfront.FunctionRuntime.JS_2_0,
         )
-        dark_sky_fn_assoc = [cloudfront.FunctionAssociation(
-            event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
-            function=dark_sky_rewrite_fn,
-        )]
+
+        # Swaps S3's raw NoSuchKey/AccessDenied XML body (which echoes the S3 key plus
+        # AWS's own RequestId/HostId — see the ListBucket grant below for why 404 is now
+        # reachable at all) for a static, empty-of-request-data page. Only touches 404s:
+        # a distribution-level error_responses remap was deliberately avoided elsewhere in
+        # this file for touching every behavior on `dist`, and the same reasoning applies
+        # here — leave WAF-block 403s and every other behavior's error body untouched.
+        # Only content-type is overwritten (not the whole headers object), so the security
+        # headers already added by base_headers_policy below survive unchanged.
+        _dark_sky_error_page_js = """
+function handler(event) {
+  var response = event.response;
+
+  if (response.statusCode === 404) {
+    response.statusDescription = 'Not Found';
+    response.headers['content-type'] = { value: 'text/html; charset=UTF-8' };
+    response.body = {
+      encoding: 'text',
+      data: '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        + '<title>404 Not Found</title></head><body><h1>404 Not Found</h1>'
+        + '<p>The page you requested does not exist.</p></body></html>'
+    };
+  }
+
+  return response;
+}
+"""
+        dark_sky_error_page_fn = cloudfront.Function(
+            self, "DarkSkyErrorPage",
+            code=cloudfront.FunctionCode.from_inline(_dark_sky_error_page_js),
+            runtime=cloudfront.FunctionRuntime.JS_2_0,
+        )
+        dark_sky_fn_assoc = [
+            cloudfront.FunctionAssociation(
+                event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
+                function=dark_sky_rewrite_fn,
+            ),
+            cloudfront.FunctionAssociation(
+                event_type=cloudfront.FunctionEventType.VIEWER_RESPONSE,
+                function=dark_sky_error_page_fn,
+            ),
+        ]
 
         # --- Access logs (standard logs) to S3 ---
         # Free from CloudFront itself; only S3 storage/request costs apply, which at this


### PR DESCRIPTION
## Summary
- Follow-up to #164 (the ListBucket fix that made missing `/dark-sky/*` keys return 404 instead of 403). That fix surfaces S3's raw `NoSuchKey` XML body, which includes `RequestId`, `HostId`, and the requested `Key` — not sensitive data, but not something to show visitors either.
- Adds a `VIEWER_RESPONSE` CloudFront Function on the `/dark-sky*` behavior (alongside the existing `VIEWER_REQUEST` rewrite function) that replaces the body with a static, minimal 404 page whenever `statusCode === 404`. No request-specific data (path, key, request id) is included in the replacement body.
- Scoped narrowly on purpose: only touches 404, only on this one behavior. WAF-block 403s on other behaviors, and every other status code, pass through untouched — same reasoning as #164 for not using a distribution-level `error_responses` remap.
- Only the `content-type` header is overwritten (not the whole headers object), so the existing security headers from `base_headers_policy` (HSTS, X-Frame-Options, etc.) still apply to the substituted response.
- CloudFront Functions (not Lambda@Edge) — sub-millisecond execution at the edge, no cold starts, negligible cost, matches the pattern already used for `DarkSkyIndexRewrite` and `AstroBlogIndexRewrite`.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` on the changed file (local CDK synth can't fully bundle on this machine)
- [x] `python -m pytest -q` — 873 passed, 9 skipped
- [ ] After merge/deploy, confirm `curl -s https://darkhours.app/dark-sky/sitemap.xml` returns a minimal HTML 404 body instead of S3's XML error

🤖 Generated with [Claude Code](https://claude.com/claude-code)