### PR TITLE
Revert #165: custom 404 page for /dark-sky/*

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -765,48 +765,10 @@ function handler(event) {
             code=cloudfront.FunctionCode.from_inline(_dark_sky_rewrite_js),
             runtime=cloudfront.FunctionRuntime.JS_2_0,
         )
-
-        # Swaps S3's raw NoSuchKey/AccessDenied XML body (which echoes the S3 key plus
-        # AWS's own RequestId/HostId — see the ListBucket grant below for why 404 is now
-        # reachable at all) for a static, empty-of-request-data page. Only touches 404s:
-        # a distribution-level error_responses remap was deliberately avoided elsewhere in
-        # this file for touching every behavior on `dist`, and the same reasoning applies
-        # here — leave WAF-block 403s and every other behavior's error body untouched.
-        # Only content-type is overwritten (not the whole headers object), so the security
-        # headers already added by base_headers_policy below survive unchanged.
-        _dark_sky_error_page_js = """
-function handler(event) {
-  var response = event.response;
-
-  if (response.statusCode === 404) {
-    response.statusDescription = 'Not Found';
-    response.headers['content-type'] = { value: 'text/html; charset=UTF-8' };
-    response.body = {
-      encoding: 'text',
-      data: '<!doctype html><html lang="en"><head><meta charset="utf-8">'
-        + '<title>404 Not Found</title></head><body><h1>404 Not Found</h1>'
-        + '<p>The page you requested does not exist.</p></body></html>'
-    };
-  }
-
-  return response;
-}
-"""
-        dark_sky_error_page_fn = cloudfront.Function(
-            self, "DarkSkyErrorPage",
-            code=cloudfront.FunctionCode.from_inline(_dark_sky_error_page_js),
-            runtime=cloudfront.FunctionRuntime.JS_2_0,
-        )
-        dark_sky_fn_assoc = [
-            cloudfront.FunctionAssociation(
-                event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
-                function=dark_sky_rewrite_fn,
-            ),
-            cloudfront.FunctionAssociation(
-                event_type=cloudfront.FunctionEventType.VIEWER_RESPONSE,
-                function=dark_sky_error_page_fn,
-            ),
-        ]
+        dark_sky_fn_assoc = [cloudfront.FunctionAssociation(
+            event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
+            function=dark_sky_rewrite_fn,
+        )]
 
         # --- Access logs (standard logs) to S3 ---
         # Free from CloudFront itself; only S3 storage/request costs apply, which at this


### PR DESCRIPTION
## Summary
- Reverts #165 only. #164 (the ListBucket grant that makes missing `/dark-sky/*` keys return 404 instead of 403) stays in place.
- The custom 404 page in #165 doesn't work: CloudFront Functions have a hard platform restriction and never run on the `viewer-response` event when the origin returns a 4xx/5xx status — confirmed against AWS's own docs after testing live. Confirmed via `aws cloudfront test-function` that the function itself was correct in isolation, but it's simply never invoked for real error responses at the edge.
- The only AWS-native way to fix this properly would be a distribution-level custom error page, which isn't safe here: `/jobs/{job_id}` ([apps/api/main.py:377](https://github.com/mbeher2200/DarkHours/blob/main/apps/api/main.py#L377)) legitimately returns real HTTP 404s with a JSON body as part of normal job-polling — a distribution-wide remap would break that contract. The remaining option (Lambda@Edge scoped to just `/dark-sky*`) is real infra weight for what's a cosmetic fix, not a security one — the raw S3 XML body doesn't expose anything sensitive (no bucket name, no account ID, just AWS's own opaque support-correlation IDs and the URL path already known to the requester).
- Clean revert via `git revert`, no conflicts with #164's changes.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` on the changed file
- [x] `python -m pytest -q` — 873 passed, 9 skipped
- [ ] After merge/deploy, confirm `/dark-sky/*` 404s still return plain status 404 (from #164) with S3's raw XML body (expected, no longer custom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)