### PR TITLE
Fix inconsistent/oversized app description copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DarkHours
 
-**DarkHours is a precision landscape astrophotography planning tool to help you determine if a given location and night is worth the trip. If it isn't, it helps you find another place and time.**
+**DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting.**
 
 [![Try it live](https://img.shields.io/badge/darkhours.app-live-brightgreen)](https://darkhours.app)
 [![Deploy](https://github.com/mbeher2200/DarkHours/actions/workflows/deploy.yml/badge.svg)](https://github.com/mbeher2200/DarkHours/actions/workflows/deploy.yml)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,12 +11,12 @@
     <link rel="alternate" type="application/rss+xml" title="DarkHours Blog" href="https://darkhours.app/blog/rss.xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="robots" content="max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
-    <meta name="description" content="Precision Landscape Astrophotography Planning. Bortle class, ephemeris data, clear dark hours, weather conditions, and deep sky object viability in a single view. Plans fall through? Find a better location nearby, in seconds." />
+    <meta name="description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <title>DarkHours — Dark Sky & Astrophotography Planner</title>
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="DarkHours" />
     <meta property="og:title" content="DarkHours" />
-    <meta property="og:description" content="Precision Landscape Astrophotography Planning. Bortle class, ephemeris data, clear dark hours, weather conditions, and deep sky object viability in a single view. Plans fall through? Find a better location nearby, in seconds." />
+    <meta property="og:description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <meta property="og:url" content="https://darkhours.app" />
     <meta property="og:image" content="https://darkhours.app/og.jpg" />
     <meta property="og:image:type" content="image/jpeg" />
@@ -25,7 +25,7 @@
     <meta property="og:image:alt" content="DarkHours — Precision Landscape Astrophotography Planning" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="DarkHours" />
-    <meta name="twitter:description" content="Precision Landscape Astrophotography Planning. Bortle class, ephemeris data, clear dark hours, weather conditions, and deep sky object viability in a single view. Plans fall through? Find a better location nearby, in seconds." />
+    <meta name="twitter:description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <meta name="twitter:image" content="https://darkhours.app/og.jpg" />
     <meta name="twitter:image:alt" content="DarkHours — Precision Landscape Astrophotography Planning" />
     <script type="application/ld+json">
@@ -34,7 +34,7 @@
       "@type": "WebApplication",
       "name": "DarkHours",
       "url": "https://darkhours.app",
-      "description": "Precision Landscape Astrophotography Planning. Bortle class, ephemeris data, clear dark hours, weather conditions, and deep sky object viability in a single view.",
+      "description": "DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting.",
       "applicationCategory": "UtilitiesApplication",
       "operatingSystem": "Web",
       "offers": {

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,6 +1,6 @@
 # DarkHours
 
-> DarkHours is a free astrophotography planning app for finding dark skies — moon phase, weather, and light-pollution forecasting for any location and date, so you know when and where the sky will actually be clear and dark.
+> DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting.
 
 ## Site
 


### PR DESCRIPTION
## Summary
- The homepage meta description (`name="description"`, `og:description`, `twitter:description`, and JSON-LD `description` — all identical) was 225 characters, well past Google's ~155-160 char SERP truncation point, flagged by a live SEO audit of darkhours.app.
- `README.md` and `apps/web/public/llms.txt` each had their own, differently-worded description of what DarkHours is, on top of that — three inconsistent pitches for the same product across the repo.
- Standardized all three on one 120-char line: "DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." This already matches (near-verbatim) the phrasing used in the `darkhours-destinations` repo's `llms.txt`, so that repo needs no change.

## Notes for reviewer
- `og:image:alt` / `twitter:image:alt` were deliberately left as "DarkHours — Precision Landscape Astrophotography Planning" — that phrase is baked into `og.jpg` as rendered text (verified by opening the image), so the alt text is still an accurate description of the image, not stale copy. Updating it would mean regenerating the actual social-card graphic, a separate design task.
- Pure copy/metadata change — no code paths touched, nothing to test beyond visually confirming the new description reads correctly once deployed.

## Test plan
- [ ] Confirm the new meta description renders correctly in a social-share preview (e.g. Twitter Card Validator or Facebook Sharing Debugger) after deploy
- [ ] Confirm `darkhours.app/llms.txt` reflects the updated line after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)