### PR TITLE
Lazy-load ReportCard to cut mobile LCP-blocking JS

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,13 +1,22 @@
-import { useState, useRef, useEffect, type FormEvent } from 'react'
+import { useState, useRef, useEffect, lazy, Suspense, type FormEvent } from 'react'
 import './App.css'
 import { LocateFixed, ChevronLeft, ChevronRight, Clock, MapPin, X } from 'lucide-react'
 import { ApiRequestError, fetchNight, fetchSuggestions, type NightQuery } from './api'
 import { tonightIso, toIsoDate, defaultImperial, availabilityFor } from './format'
-import ReportCard from './ReportCard'
 import DatePicker from './DatePicker'
 import type { NightReport } from './types'
 import { readLocalStorage } from './env'
 import { FEATURES } from './content/features'
+
+// ReportCard (and everything it pulls in — report/*, CalendarRangePicker,
+// OutlookTelemetryRibbon) only ever renders after a successful /night fetch,
+// so it's split into its own chunk to keep it out of the initial bundle that
+// gates first paint. `warmReportCard` shares the same module-cache entry as
+// the lazy() import below (same specifier), so calling it while the /night
+// request is in flight (see runQuery) makes the chunk fetch overlap with the
+// API round trip instead of adding visible latency once the report is ready.
+const warmReportCard = () => import('./ReportCard')
+const ReportCard = lazy(warmReportCard)
 
 type Mode = 'place' | 'coords'
 
@@ -104,6 +113,7 @@ export default function App() {
     setScopeOpen(false)
     setLoading(true)
     setError(null)
+    warmReportCard() // overlap the ReportCard chunk fetch with the /night request below
     try {
       const r = await fetchNight(q)
       setReport(r)
@@ -646,17 +656,19 @@ export default function App() {
         </div>
       )}
       {report && !loading && (
-        <ReportCard
-          report={report}
-          showWeather={reportWeather}
-          showTargets={reportTargets}
-          showSatellites={reportSatellites}
-          imperial={imperial}
-          onToggleUnits={toggleUnits}
-          onDateDetail={handleDateDetail}
-          onSelectLocation={selectNearbyLocation}
-          redMode={redMode}
-        />
+        <Suspense fallback={<div className="card">Loading report…</div>}>
+          <ReportCard
+            report={report}
+            showWeather={reportWeather}
+            showTargets={reportTargets}
+            showSatellites={reportSatellites}
+            imperial={imperial}
+            onToggleUnits={toggleUnits}
+            onDateDetail={handleDateDetail}
+            onSelectLocation={selectNearbyLocation}
+            redMode={redMode}
+          />
+        </Suspense>
       )}
 
       <footer className="colophon">


### PR DESCRIPTION
## Summary
- `ReportCard` (report/*, CalendarRangePicker, OutlookTelemetryRibbon — ~2.9K LOC) only renders after a successful `/night` fetch, but was bundled eagerly into the initial JS payload that gates first paint.
- Split it into its own chunk via `React.lazy()` + `Suspense`; the chunk fetch is warmed at the start of `runQuery` so it overlaps with the `/night` API call instead of adding perceived latency once the report is ready.
- Targets the SEO audit's mobile LCP finding: 3,365ms ("needs improvement") vs 709ms desktop on the same pipeline, with PageSpeed flagging 640ms of potential "unused JavaScript" savings as the top opportunity.

## Measured (local production build)
| | Before | After |
|---|---|---|
| Initial JS bundle | 401 KB (129 KB gzip) | 229 KB (73 KB gzip) |
| Deferred chunk | — | 173 KB (57 KB gzip), loads on search |

43% reduction in the JS blocking first paint.

## Test plan
- [x] `tsc -b && vite build` — clean
- [x] `npm run lint` — same 39 pre-existing issues as `main`, none introduced in this diff
- [x] Local preview: empty-state (LCP-critical view) renders correctly on mobile viewport, no console errors
- [x] Local preview: triggering a search fetches `ReportCard-*.js` (200 OK) in parallel with `/night`, no console errors
- [ ] Re-run PageSpeed Insights mobile against production after merge/deploy to confirm the LCP number actually drops

## Deliberately out of scope
The audit also flagged 130ms of "unused CSS." `App.css`'s own header warns the `@import` order is cascade-load-bearing (`11-responsive.css` intentionally loads last to override earlier files). Splitting the report-only stylesheets into the lazy chunk would load them *after* `11-responsive.css`'s overrides instead of before, risking a specificity/cascade regression across breakpoints. Not worth the risk for 130ms against the 640ms already captured here — flagging as a follow-up that would need its own careful pass (and visual QA) rather than bundling it into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)