### PR TITLE
Add root-level WebSite JSON-LD with SearchAction

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -55,6 +55,22 @@
       }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "DarkHours",
+      "url": "https://darkhours.app",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "https://darkhours.app/?q={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Today the only entity markup at the page root is `WebApplication` with a `Person` nested under `.author` — no `WebSite`/`Organization` block, which weakens brand entity consolidation for Knowledge Graph / AI citation (audit finding, Schema category).
- Adds a `WebSite` JSON-LD block with a `SearchAction`. Verified `/?q=<value>` is a real, working query interface (App.tsx reads `q` from `URLSearchParams` on load and auto-runs the search) — not a stub SearchAction pointing nowhere.

## Test plan
- [x] Both JSON-LD blocks on the page parse as valid JSON (checked via `json.loads`)
- [x] `scripts/validate_schema.py` (agentic-seo skill) — clean, no findings
- [x] `tsc -b && vite build` — clean
- [ ] After merge: spot-check with [Google's Rich Results Test](https://search.google.com/test/rich-results) against the live URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)