### PR TITLE
Set a descriptive og:title and twitter:title

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -15,7 +15,7 @@
     <title>DarkHours — Dark Sky & Astrophotography Planner</title>
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="DarkHours" />
-    <meta property="og:title" content="DarkHours" />
+    <meta property="og:title" content="DarkHours — Dark Sky &amp; Astrophotography Planner" />
     <meta property="og:description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <meta property="og:url" content="https://darkhours.app" />
     <meta property="og:image" content="https://darkhours.app/og.jpg" />
@@ -24,7 +24,7 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="DarkHours — Precision Landscape Astrophotography Planning" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="DarkHours" />
+    <meta name="twitter:title" content="DarkHours — Dark Sky &amp; Astrophotography Planner" />
     <meta name="twitter:description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <meta name="twitter:image" content="https://darkhours.app/og.jpg" />
     <meta name="twitter:image:alt" content="DarkHours — Precision Landscape Astrophotography Planning" />


### PR DESCRIPTION
## Summary
`og:title` and `twitter:title` were both just "DarkHours", duplicating `og:site_name` and giving link-share previews no more context than the bare site name. Reuses the existing `<title>` tag's fuller text ("DarkHours — Dark Sky & Astrophotography Planner"), per the audit's suggestion (action item #10, marked low priority, not a defect).

## Test plan
- [x] `tsc -b && vite build` — clean
- [x] `scripts/validate_schema.py` (agentic-seo skill) — still clean (unrelated to this change, re-ran as a sanity check since it's the same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)