### PR TITLE
Set a descriptive og:title and twitter:title

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -15,7 +15,7 @@
     <title>DarkHours — Dark Sky & Astrophotography Planner</title>
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="DarkHours" />
-    <meta property="og:title" content="DarkHours" />
+    <meta property="og:title" content="DarkHours — Dark Sky &amp; Astrophotography Planner" />
     <meta property="og:description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <meta property="og:url" content="https://darkhours.app" />
     <meta property="og:image" content="https://darkhours.app/og.jpg" />
@@ -24,7 +24,7 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="DarkHours — Precision Landscape Astrophotography Planning" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="DarkHours" />
+    <meta name="twitter:title" content="DarkHours — Dark Sky &amp; Astrophotography Planner" />
     <meta name="twitter:description" content="DarkHours is a free, open-source astrophotography planning app for moon phase, weather, and light pollution forecasting." />
     <meta name="twitter:image" content="https://darkhours.app/og.jpg" />
     <meta name="twitter:image:alt" content="DarkHours — Precision Landscape Astrophotography Planning" />


### PR DESCRIPTION
## Summary
- `og:title` and `twitter:title` were both just "DarkHours", duplicating `og:site_name` and giving link-share previews (Slack, iMessage, Twitter/X, etc.) no more context than the bare site name.
- Reuses the existing `<title>` tag's fuller text ("DarkHours — Dark Sky & Astrophotography Planner") for both, matching the pattern already used for `og:description`/`twitter:description`.

Low-priority fix identified during a broader SEO audit of darkhours.app (action item, not a defect) — no functional/behavioral change, metadata only.

## Test plan
- [x] Verified live via `social_meta.py`: `og:title`/`twitter:title` now render the full descriptive string (previously just "DarkHours")

🤖 Generated with [Claude Code](https://claude.com/claude-code)