### PR TITLE
Add map-rendering primitives: road/trail line geometry + composite Bortle grid

### DIFF
--- a/darkhours/darksky.py
+++ b/darkhours/darksky.py
@@ -906,6 +906,63 @@ def _sqm_to_bortle_array(sqm_arr: "np.ndarray") -> "np.ndarray":
     return out
 
 
+def _composite_bortle_grid(
+    viirs_array: "np.ndarray",
+    falchi_array: "np.ndarray | None" = None,
+    viirs_sqm_arr: "np.ndarray | None" = None,
+) -> "tuple[np.ndarray, np.ndarray]":
+    """
+    Build a composite Bortle-class array from a VIIRS radiance window, with
+    Falchi 2016 filling in VIIRS-zero pixels (dark sites below VIIRS's
+    detection floor) — same source-selection as lookup()'s single-point path,
+    vectorized. Factored out of _extract_dark_sky_candidates so other
+    raster-window consumers (e.g. offline map rendering) don't duplicate the
+    formula.
+
+    viirs_sqm_arr: pass a pre-computed VIIRS SQM array to skip one log10 pass
+    if the caller already has it (as _extract_dark_sky_candidates does).
+
+    Returns (bortle_arr, sqm_arr) — bortle_arr is int8 (0 = no data). Pixels
+    where both sources read zero are Bortle 1 by convention in bortle_arr,
+    but stay NaN in sqm_arr (no measured value, just "at least this dark").
+    """
+    import numpy as np
+
+    if viirs_sqm_arr is not None:
+        sqm_viirs = viirs_sqm_arr
+    else:
+        sqm_viirs = np.where(
+            viirs_array > 0,
+            21.7 - 2.5 * np.log10(viirs_array + 0.6),
+            np.nan,
+        )
+    bortle_arr = _sqm_to_bortle_array(sqm_viirs)
+
+    if falchi_array is not None:
+        viirs_zero    = viirs_array == 0
+        falchi_scaled = falchi_array * _FALCHI_SCALE
+        sqm_falchi = np.where(
+            falchi_scaled > 0,
+            _SQM_NATURAL - 2.5 * np.log10(
+                (falchi_scaled + _L_NATURAL) / _L_NATURAL
+            ),
+            np.nan,
+        )
+        falchi_bortle = _sqm_to_bortle_array(sqm_falchi)
+        # VIIRS-zero AND Falchi-zero → pristine sky (Bortle 1)
+        falchi_bortle = np.where(
+            np.isnan(sqm_falchi) & viirs_zero, 1, falchi_bortle
+        )
+        bortle_arr = np.where(
+            viirs_zero & (bortle_arr == 0), falchi_bortle, bortle_arr
+        )
+        sqm_arr = np.where(viirs_array > 0, sqm_viirs, sqm_falchi)
+    else:
+        sqm_arr = sqm_viirs
+
+    return bortle_arr, sqm_arr
+
+
 def _load_raster_window(
     source_key: str,
     min_lat: float,
@@ -1200,45 +1257,9 @@ def _extract_dark_sky_candidates(
         land_mask = _glm.is_land(lat_grid, lon_grid)
 
     # ── Composite Bortle array ────────────────────────────────────────────────
-    # VIIRS primary: any pixel with measurable radiance.
-    # Reuse pre-computed SQM when the caller provides it (saves one log10 pass).
-    if viirs_sqm_arr is not None:
-        sqm_viirs = viirs_sqm_arr
-    else:
-        sqm_viirs = np.where(
-            viirs_array > 0,
-            21.7 - 2.5 * np.log10(viirs_array + 0.6),
-            np.nan,
-        )
-    bortle_arr = _sqm_to_bortle_array(sqm_viirs)
-
-    # Falchi fills VIIRS-zero pixels (dark sites below VIIRS detection floor)
-    if falchi_array is not None:
-        viirs_zero  = viirs_array == 0
-        falchi_scaled = falchi_array * _FALCHI_SCALE
-        sqm_falchi = np.where(
-            falchi_scaled > 0,
-            _SQM_NATURAL - 2.5 * np.log10(
-                (falchi_scaled + _L_NATURAL) / _L_NATURAL
-            ),
-            np.nan,
-        )
-        falchi_bortle = _sqm_to_bortle_array(sqm_falchi)
-        # VIIRS-zero AND Falchi-zero → pristine sky (Bortle 1)
-        falchi_bortle = np.where(
-            np.isnan(sqm_falchi) & viirs_zero, 1, falchi_bortle
-        )
-        bortle_arr = np.where(
-            viirs_zero & (bortle_arr == 0), falchi_bortle, bortle_arr
-        )
-
-    # Combined SQM array: mirrors bortle_arr source selection.
-    # VIIRS-measured pixels use sqm_viirs; Falchi-filled pixels use sqm_falchi;
-    # pristine sky pixels (both sources zero) have NaN → stored as None.
-    if falchi_array is not None:
-        sqm_arr = np.where(viirs_array > 0, sqm_viirs, sqm_falchi)
-    else:
-        sqm_arr = sqm_viirs
+    # VIIRS primary (any pixel with measurable radiance), Falchi fills VIIRS-zero
+    # pixels (dark sites below VIIRS's detection floor) — see _composite_bortle_grid.
+    bortle_arr, sqm_arr = _composite_bortle_grid(viirs_array, falchi_array, viirs_sqm_arr)
 
     # ── Vectorised haversine distance ─────────────────────────────────────────
     dlat = np.radians(lat_grid - origin_lat)

--- a/darkhours/darksky.py
+++ b/darkhours/darksky.py
@@ -1459,6 +1459,85 @@ def _overpass_natural_areas_in_radius(
     return areas
 
 
+def _overpass_ways_in_bbox(
+    min_lat: float, max_lat: float, min_lon: float, max_lon: float,
+    highway_types: tuple[str, ...],
+) -> list[dict]:
+    """
+    Fetch road/trail line geometry (OSM ways tagged `highway`) within a
+    bounding box. One HTTP call covers the whole box.
+
+    highway_types: OSM `highway` tag values to include, e.g.
+      ("motorway", "trunk", "primary", "secondary", "tertiary",
+       "unclassified", "residential", "service") for roads, or
+      ("path", "footway", "track") for trails — callers combine results
+      from two calls (one per style) rather than mixing tags in one query,
+      so roads/trails can be drawn with different line styles.
+
+    Returns list of dicts: {name, highway, coords} where coords is an
+    ordered [(lat, lon), ...] polyline for that way (`out geom;` inlines
+    node coordinates, no separate `>;out skel qt;` recursion needed).
+
+    Not used by the live API/worker — this is a primitive for offline
+    map-rendering tooling (see darkhours-destinations' scripts/). No
+    caller-side AWS-backend gating like _overpass_natural_areas_in_radius
+    has, since nothing in the request-serving path calls this.
+
+    Cached per bbox (rounded to ~350 ft) + highway-type set for 90 days.
+    No result-size cap: fine for the low-road-density NPS-backcountry
+    boxes this is built for, but a dense urban bbox could return a large
+    payload — not a concern this primitive tries to solve.
+    """
+    cache_key = (
+        f"overpass_ways|{min_lat:.3f}|{min_lon:.3f}|{max_lat:.3f}|{max_lon:.3f}"
+        f"|{','.join(sorted(highway_types))}"
+    )
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    highway_pattern = "|".join(highway_types)
+    query = (
+        f"[out:json][timeout:60];\n"
+        f'way["highway"~"^({highway_pattern})$"]'
+        f"({min_lat:.5f},{min_lon:.5f},{max_lat:.5f},{max_lon:.5f});\n"
+        f"out geom;"
+    )
+
+    params = urllib.parse.urlencode({"data": query})
+    url    = f"{_OVERPASS_URL}?{params}"
+    with _rl.acquire("overpass"):
+        try:
+            req = urllib.request.Request(
+                url,
+                headers={"User-Agent": "DarkHours/1.0 (light-pollution-research)"},
+            )
+            with _http.urlopen(req, timeout=65) as resp:
+                data = json.loads(resp.read())
+        except Exception as e:
+            log.debug("Overpass ways-in-bbox failed for (%.4f,%.4f)-(%.4f,%.4f): %s",
+                       min_lat, min_lon, max_lat, max_lon, e)
+            cache.set(cache_key, [], ttl_seconds=300)
+            return []
+
+    ways = []
+    for el in data.get("elements", []):
+        geometry = el.get("geometry")
+        if not geometry:
+            continue
+        tags = el.get("tags", {})
+        ways.append({
+            "name":    tags.get("name"),
+            "highway": tags.get("highway", ""),
+            "coords":  [(pt["lat"], pt["lon"]) for pt in geometry],
+        })
+
+    log.debug("Overpass ways-in-bbox: %d ways found for (%.4f,%.4f)-(%.4f,%.4f)",
+               len(ways), min_lat, min_lon, max_lat, max_lon)
+    cache.set(cache_key, ways, ttl_seconds=_GEO_CACHE_TTL)
+    return ways
+
+
 # National forests have bboxes 60–135 miles wide — far too coarse for
 # containment matching (the rectangle includes towns, private land, gaps).
 # Wilderness areas and monuments are 5–20 miles wide and are reliable.


### PR DESCRIPTION
## Summary
Two small, additive primitives an upcoming `darkhours-destinations` map-generation script needs (static Bortle-overlay maps for the dark-sky destination guides). Neither is called from any live API/worker path.

**1. `_overpass_ways_in_bbox()`** — no road/trail *line* geometry is fetchable anywhere in the codebase today, only point POIs and area bounding boxes. Modeled directly on the existing `_overpass_natural_areas_in_radius` (same rate-limit gate, http/cache/error-handling pattern, 90-day cache TTL) but queries `way["highway"~"..."]` with `out geom;` for polylines.

**2. `_composite_bortle_grid()`** — factored out of `_extract_dark_sky_candidates`'s inline VIIRS-primary/Falchi-fallback composite-array logic (pure refactor, no behavior change) so the map script can build the same Bortle-class raster `find_nearby`'s dark-pixel search already builds, without re-deriving the SQM formula (and risking a transcription bug on `_FALCHI_SCALE`/`_SQM_NATURAL`/`_L_NATURAL`).

## Test plan
- [x] `python -m pytest -q` — 873 passed, 9 skipped (both before and after the refactor commit)
- [x] `_overpass_ways_in_bbox` verified against a real Zion-area bbox: 1230 road ways, 1057 trail ways, cache round-trips correctly
- [x] `_composite_bortle_grid` verified behavior-preserving: `_extract_dark_sky_candidates` now calls it with identical inputs it used to compute inline, full suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)