### PR TITLE
Stop clouded-out nights from scoring "Good"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pick a place and a date. DarkHours presents a score, an hour by hour plan of wha
 
 ## What you get
 
-**The night's score.** The Night Quality Score runs 1 to 10. It folds together weather, moonlight, clear dark hours, and light pollution data. We use a geometric mean, not a plain average. This means that one dealbreaker can't hide behind three good numbers. A clouded out night scores like a clouded out night should.
+**The night's score.** The Night Quality Score runs 1 to 10. It folds together weather, moonlight, dark hours, and light pollution data. We use a geometric mean, not a plain average, so one dealbreaker can't hide behind three good numbers. Clouds get the last word on top of that: below 4 out of 10 on weather, the night is capped at its weather score. A clouded out night scores like a clouded out night should, however new the moon is.
 
 **Moonlight math.** Most apps say the moon is up, so you're done. That's lazy. DarkHours figures out how much the moon actually brightens the sky at each target. A thin crescent barely counts. A bright gibbous moon next to your subject gets flagged, and the imaging window gets cut off exactly when the contrast dies.
 
@@ -83,8 +83,10 @@ The Night Quality Score (1 to 10) is a weighted geometric mean of four things:
 |--------|-------:|------------------|
 | Seeing and cloud cover | 40% | Cn2 profile integration via 7Timer ASTRO/GFS, adjusted for clouds |
 | Lunar interference | 25% | K&S sky brightening credit, not raw illumination percent |
-| Clear dark sky hours | 25% | Effective dark time, corrected for the moon |
+| Dark hours | 25% | Effective dark time, corrected for the moon |
 | Bortle scale | 10% | VIIRS 2025 satellite radiance, with a Falchi 2016 fallback for truly dark sites |
+
+Clouds also get a veto. Below a weather score of 4 out of 10, the night is capped at its weather score, because no amount of dark, moonless sky makes an overcast night shootable. Above that line the geometric mean stands on its own, so a night with real usable time keeps its full range.
 
 If a factor is not available, like a date that's past the forecast window, the weights shift on their own. A night two months out still lines up fairly against tonight.
 

--- a/apps/web/src/OutlookTelemetryRibbon.tsx
+++ b/apps/web/src/OutlookTelemetryRibbon.tsx
@@ -205,7 +205,7 @@ export default function OutlookTelemetryRibbon({
                 {sc && (
                   <div className="telemetry-mini-bars">
                     {sc.bortle != null && <ScoreBar label="Light Pollution" value={sc.bortle} />}
-                    {sc.dark   != null && <ScoreBar label="Clear Dark Sky"  value={sc.dark} />}
+                    {sc.dark   != null && <ScoreBar label="Dark Hours"  value={sc.dark} />}
                     {selected.weather_informed && sc.weather != null && <ScoreBar label="Weather" value={sc.weather} />}
                     {sc.moon   != null && <ScoreBar label="Lunar Conditions" value={sc.moon} />}
                   </div>

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -490,7 +490,7 @@ export default function ReportCard({
             <div className="overall-label">{scoreLabel(r.score)}</div>
           </div>
           <div className="overall-sub">
-            <InfoTip tip={<>Weighted geometric mean of Weather 40% · Lunar 25% · Dark Hours 25% · Dark Sky 10% (weights redistribute when a factor is unavailable). Geometric means one hard zero — full overcast, full moon — zeroes the whole night, just like it does in the field.</>}>
+            <InfoTip tip={<>Weighted geometric mean of Weather 40% · Lunar 25% · Dark Hours 25% · Dark Sky 10% (weights redistribute when a factor is unavailable). Geometric means one hard zero — a full moon, a total washout — zeroes the whole night, just like it does in the field. Clouds also get a veto: below 4/10 on weather the night is capped at its weather score, because no amount of moonless dark sky makes an overcast night shootable.</>}>
               0–10 composite score
             </InfoTip>
           </div>
@@ -525,18 +525,18 @@ export default function ReportCard({
         )}
 
         <MetaRow
-          k="Clear Dark Sky"
+          k="Dark Hours"
           v={darkStrCard}
-          tip={<>Hours you can actually shoot: astronomical darkness (sun ≥18° below the horizon), minus moon interference, minus hours clouded over (&gt;50% cover).</>}
+          tip={<>Hours you can actually shoot: astronomical darkness (sun ≥18° below the horizon), minus moon interference, minus hours clouded over (&gt;50% cover). The bar beside it rates the astronomy alone, so a clouded-out night reads "None" here next to a high bar.</>}
           score={r.score_components.dark}
-          scoreTip={<>25% of the composite — tonight's moon-free dark hours measured against this lunar cycle's average, so the score reflects what this month can actually offer.</>}
+          scoreTip={<>25% of the composite — tonight's moon-free dark hours measured against this lunar cycle's best, so the score reflects what this month can actually offer. Astronomy only: it answers "how good is the sky geometry tonight", not "will you get to use it". Clouds are scored under Weather, and veto the overall score when the night is unshootable.</>}
         />
         {showWeather && r.weather_score != null && (
           <MetaRow
             k="Weather"
             v={`${r.weather_score.toFixed(1)}/10${r.wx_source ? `  ·  ${r.wx_source}` : ''}`}
             score={r.score_components.weather}
-            scoreTip={<>40% of the composite — hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, wind, and humidity.</>}
+            scoreTip={<>40% of the composite, and a veto below 4/10 — under that line the whole night is capped at this score. Hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, wind, and humidity. Low and mid cloud block outright; high cirrus counts for 0.8 of that, since it dims and bloats stars rather than hiding them.</>}
           />
         )}
         {showWeather && r.wx_pending && <MetaRow k="Weather" v="Pending  (beyond the ~16-day forecast horizon)" />}

--- a/apps/web/src/report/common.tsx
+++ b/apps/web/src/report/common.tsx
@@ -24,7 +24,7 @@ export function cell(isFetching: boolean, value: React.ReactNode): React.ReactNo
 
 // ── Metadata row ─────────────────────────────────────────────────────────────
 // `score` ties the row to its composite-score factor (Bortle → Light Pollution,
-// dark hours → Clear Dark Sky, etc.) via an inline bar; `scoreTip` carries the
+// dark → Dark Hours, etc.) via an inline bar; `scoreTip` carries the
 // weighting/methodology explainer that used to live on the standalone score
 // bars, now surfaced through a small "?" badge so it isn't lost.
 

--- a/darkhours/render_calendar.py
+++ b/darkhours/render_calendar.py
@@ -30,7 +30,9 @@ def print_calendar(summaries: list, display_name: str,
     print(f"{period_str}\n")
 
     # Column headers — exact names as in the nightly report
-    headers = ("Date", "Night Quality Score", "Clear Dark Hours", "Weather", "Moon")
+    # "Dark Hours", not "Clear Dark Hours": _dark_str reports summary.dark_hours,
+    # which is moon-free astronomical darkness with no cloud correction applied.
+    headers = ("Date", "Night Quality Score", "Dark Hours", "Weather", "Moon")
     aligns  = ("l",    "r",                   "r",                "r",       "l")
 
     # Per-row value formatters

--- a/darkhours/scoring.py
+++ b/darkhours/scoring.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Night sky scoring — converts raw sky/weather metrics into 0–10 scores."""
 
+# Below this weather score, clouds stop being one factor among four and become a
+# hard gate: the night is unshootable regardless of how dark or moon-free it is.
+# See WEATHER_VETO_THRESHOLD's use in rate_night for why a ceiling is needed at
+# all, and why it only applies below the threshold rather than always.
+WEATHER_VETO_THRESHOLD = 4.0
+
 
 def rate_night(
     moon_score: float,
@@ -25,6 +31,26 @@ def rate_night(
     The geometric mean naturally punishes low factors — a single zero
     (complete cloud cover, full moon) zeros the whole score, and a factor
     of 1/10 with 40% weight contributes (0.1)^0.4 ≈ 0.25× to the product.
+
+    Weather veto
+    ------------
+    The geometric mean is proportional, and that under-punishes bad weather: a
+    true zero zeros the night, but a 3/10 at 40% weight only removes ~40% of the
+    total, so three near-perfect factors carry the rest.  A new-moon night under
+    100% cirrus scored 6.0 ("Good") with *zero* clear dark hours — clouds are a
+    hard gate, not a proportional penalty.
+
+    So when weather < WEATHER_VETO_THRESHOLD, the overall score is capped at the
+    weather score. Above the threshold the geometric mean stands unmodified, so
+    nights with genuinely usable time keep their full range (a night that's 4.8
+    on weather but otherwise excellent still scores 7.2, not 4.8). The cap is
+    deliberately one-sided rather than an always-on ceiling: weather is usually
+    the weakest of the four factors, so an unconditional cap would collapse the
+    model into "the weather score" on nearly every night.
+
+    When weather is unavailable (beyond the forecast horizon, provider outage)
+    there is nothing to veto with, and the geometric mean over the remaining
+    factors stands — the same graceful degradation as the weight redistribution.
     """
     named = {
         "weather": (weather_score, 0.40),
@@ -45,6 +71,9 @@ def rate_night(
         wgm *= (s / 10) ** norm[k]
 
     score = round(10 * wgm, 1)
+
+    if weather_score is not None and weather_score < WEATHER_VETO_THRESHOLD:
+        score = round(min(score, weather_score), 1)
 
     components = {k: round(s, 1) for k, (s, _) in available.items()}
     return {"score": score, "components": components}

--- a/darkhours/weather.py
+++ b/darkhours/weather.py
@@ -551,6 +551,11 @@ def night_aod(points: list, start: datetime, end: datetime) -> "float | None":
 # Conditions rating
 # ---------------------------------------------------------------------------
 
+# How much high/cirrus cloud counts toward an opaque sky, relative to low/mid
+# stratus. See the derivation at its use site in rate_conditions.
+_HIGH_CLOUD_WEIGHT = 0.8
+
+
 def rate_conditions(p: 'WeatherPoint') -> int:
     """
     Rate sky conditions for astrophotography from 1 (unusable) to 10 (perfect).
@@ -585,8 +590,13 @@ def rate_conditions(p: 'WeatherPoint') -> int:
         # assumption: opaque = 1 - P(clear from low) * P(clear from mid).
         opaque_cloud = 1.0 - (1.0 - low) * (1.0 - mid)
         # High/cirrus still scatters light and blurs stars (star bloat, transparency loss)
-        # but rarely fully blocks the sky — lighter 0.6 weight into the same curve.
-        effective_cloud = min(1.0, opaque_cloud + 0.6 * high)
+        # but rarely fully blocks the sky — lighter weight into the same curve.
+        # Was 0.6, which capped total cirrus overcast at a 46% penalty: a solid
+        # 100%-cirrus hour still rated 5/10, and a whole night of it averaged 3.0.
+        # That's optimistic for deep-sky work, where continuous cirrus kills faint
+        # detail outright; 0.8 puts such an hour at 3/10 while still ranking cirrus
+        # ahead of the equivalent low/mid stratus.
+        effective_cloud = min(1.0, opaque_cloud + _HIGH_CLOUD_WEIGHT * high)
         limiters.append(max(0.0, 1.0 - effective_cloud ** 1.5))
     elif p.cloud_cover_pct is not None:
         # Fallback for sources without cloud-tier data (7Timer-only points, pre-upgrade

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,7 @@ report = assemble_night(
     display_name="Death Valley",
 )
 print(report.score)           # 0–10
-print(report.dark_hours)      # clear dark sky hours tonight
+print(report.dark_hours)      # moon-free hours of astronomical night (not cloud-adjusted)
 print(report.active_showers)  # active meteor showers
 ```
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -209,8 +209,8 @@ Calendar — Sedona, Coconino County, Arizona, United States
 Light Pollution:    SQM 18.7  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]  ·  Score 3.3/10
 June 2026
 
-  Date        Night Quality Score  Clear Dark Hours  Weather  Moon
-  ----------  -------------------  ----------------  -------  ----
+  Date        Night Quality Score  Dark Hours  Weather  Moon
+  ----------  -------------------  ----------  -------  ----
   2026-06-01               0.0/10            0h 00m        —  0.0
   2026-06-11               7.8/10            6h 00m        —  9.9
   2026-06-12               8.3/10            5h 58m        —  10.0
@@ -244,6 +244,16 @@ score = (weather^0.40) × (lunar^0.25) × (dark_hours^0.25) × (light_pollution^
 ```
 
 A geometric mean lets every factor pull its own weight. One zero factor, full cloud or full moon, zeros the whole score. A factor of 1/10 at 40% weight multiplies the product by roughly 0.25, so a bad factor drags the score down hard with no separate penalty term bolted on.
+
+**The weather veto.** Proportional weighting alone still under-punishes clouds. A weather score of 3/10 at 40% weight removes only about 40% of the total, so three near-perfect factors carry the rest: a new moon under 100% cirrus, with zero clear dark hours, used to score 6.0 and read as "Good". So when the weather score falls below `WEATHER_VETO_THRESHOLD` (4.0), the composite is capped at the weather score:
+
+```
+if weather < 4.0:  score = min(score, weather)
+```
+
+The cap is deliberately one-sided. Weather is usually the weakest of the four factors, so an unconditional ceiling would flatten the model into "the weather score" on nearly every night, dragging down nights that have genuinely usable time. Above the threshold nothing changes. With no weather data at all there is nothing to veto with, and the geometric mean over the remaining factors stands.
+
+Note that **Dark Sky Hours is astronomical only**: moon-free hours within astronomical night, measured against the lunar cycle. It does not subtract clouds. Clouds are scored once under Weather and then applied again as the veto above. The "Clear Dark Sky Hours" line in the report *is* cloud-corrected, so that line can read `None (overcast)` next to a high Dark Sky Hours score. That is the two of them measuring different things, by design.
 
 **Score interpretation:**
 
@@ -366,17 +376,27 @@ Weather  [NOAA/NWS + 7Timer]:
 
 ### Wx Rating formula
 
-A weighted combination of every hourly parameter available:
+Not a weighted average. Dealbreakers multiply, and quality factors set the ceiling they multiply against:
 
-| Factor | Weight | Notes |
-|--------|--------|-------|
-| Cloud cover | 50% | Non-linear. Heavy cloud is penalised harder above 50% |
-| Seeing | 20% | Atmospheric steadiness |
-| Transparency | 15% | Sky clarity and extinction |
-| Wind speed | 10% | Vibration, tracking error, turbulence |
-| Humidity | 5% | Dew risk. No penalty below 50%, zero score above 90% |
+```
+rating = 10 × base_quality × (limiter₁ × limiter₂ × … )
+```
 
-Any precipitation caps the Wx Rating at 1. Weights redistribute on their own when a field is missing.
+**Hard gates**, either of which forces a 1: any precipitation type other than `none` (this covers rain, snow, freezing rain, ice pellets, fog, and thunderstorms uniformly), or horizontal visibility under 1000 m.
+
+**Limiters**, each a 0-to-1 multiplier. Any one of them near zero ruins the hour on its own, which is the point:
+
+| Limiter | Behaviour |
+|---------|-----------|
+| Cloud cover | Low and mid layers are treated as independent odds of an opaque sky: `1 − (1 − low)(1 − mid)`. High cirrus adds at 0.8 weight, since it dims and bloats stars rather than hiding them outright. The total runs through a 1.5 power curve |
+| Wind | Scales with velocity squared (dynamic pressure), capped at 17 m/s. Uses the worse of sustained speed and gust |
+| Transparency | Excellent 1.0, Good 0.8, Fair 0.4, Poor 0.1 |
+| Aerosols | The worse of aerosol optical depth and PM2.5, so a shallow trapped smoke layer can't hide behind a moderate satellite column reading |
+| Visibility | 1.0 above 20 km, tapering linearly to 0.7 at 10 km, then log-scaled below that |
+
+**Quality base**, the averaged ceiling: seeing (1.0 arcsec or better is excellent, 4.0 is poor) and humidity (no penalty below 50%, zero at 100%). With neither available the base is 1.0 and the limiters act alone.
+
+Cloud cover falls back to plain total cover on the same 1.5 power curve when a provider gives no low/mid/high split. The rating floors at 1, never 0, so a single unusable hour doesn't zero a whole night's average on its own. That floor is why the night-level weather veto exists: see [Night Quality Score](#night-quality-score).
 
 ### Providers
 
@@ -507,8 +527,8 @@ Calendar — Grand Canyon Village, Coconino County, Arizona, United States
 Light Pollution:    SQM 21.9  ·  Zone 2a  ·  Bortle 2  (Truly dark sky)  [Falchi 2016]  ·  Score 8.9/10
 March 2026
 
-  Date        Night Quality Score  Clear Dark Hours  Weather  Moon
-  ----------  -------------------  ----------------  -------  ----
+  Date        Night Quality Score  Dark Hours  Weather  Moon
+  ----------  -------------------  ----------  -------  ----
   2026-03-01               0.0/10            0h 00m        —  0.0
   2026-03-02               0.0/10            0h 00m        —  0.0  ·  *** Total lunar eclipse at  4:33 AM  (mag umbral 1.149) ***
   ...

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -8,9 +8,10 @@ usable from the command line — CLI-only extras are labeled.
 <!-- source: scoring.py, predictor.py -->
 ## Night Quality Score
 One 0–10 score that answers "is tonight worth it?" — a weighted blend of weather
-(40%), lunar interference (25%), clear dark hours (25%), and light pollution
-(10%). A geometric mean, so one ruined factor can't be averaged away: a
-clouded-out night scores like a clouded-out night.
+(40%), lunar interference (25%), dark hours (25%), and light pollution
+(10%). A geometric mean, so one ruined factor can't be averaged away, plus a
+weather veto: below 4/10 on weather the whole night is capped at that score, so a
+clouded-out night scores like a clouded-out night no matter how new the moon is.
 
 <!-- source: moonlight.py -->
 ## Moonlight modeled, not feared

--- a/docs/TRIPBUILDER.md
+++ b/docs/TRIPBUILDER.md
@@ -76,6 +76,8 @@ Trip Builder uses the same Night Quality Score formula as the single-night repor
 
 Near dates and far dates run through the same redistribution logic. So scores from one run line up against each other, no matter the date.
 
+One asymmetry to keep in mind when reading a mixed range: the weather veto (below 4/10 on weather, the night is capped at its weather score) can only fire on dates that have weather. A clouded-out night inside the forecast window will rank below an unknown night past it, because the far night is being scored on its astronomy alone. Use `--no-weather` when you want every date judged on the same footing.
+
 ---
 
 ## Caching

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -111,6 +111,45 @@ class TestRateNight:
         assert result["score"] == pytest.approx(expected_score, abs=0.05)
 
 
+class TestWeatherVeto:
+    """Below WEATHER_VETO_THRESHOLD, clouds gate the night instead of scaling it."""
+
+    def test_clouded_out_new_moon_cannot_score_good(self):
+        """
+        The regression this veto exists for: 2026-08-12 at 40.52,-109.54 — a new
+        moon under 100% cirrus, zero clear dark hours, scored 6.0 ("Good") on the
+        strength of its moon and dark-hours components alone.
+        """
+        result = rate_night(moon_score=10.0, dark_score=9.8, weather_score=1.8, bortle_score=7.8)
+        assert result["score"] == pytest.approx(1.8, abs=0.05)
+
+    def test_veto_caps_at_weather_score(self):
+        for wx in (0.5, 1.0, 2.0, 3.9):
+            score = rate_night(10, 10, wx, 10)["score"]
+            assert score == pytest.approx(wx, abs=0.05), f"weather {wx} should cap the night"
+
+    def test_above_threshold_leaves_geometric_mean_intact(self):
+        """A merely-mediocre night keeps its full range — the cap is one-sided."""
+        result = rate_night(moon_score=10.0, dark_score=9.6, weather_score=4.8, bortle_score=7.8)
+        assert result["score"] == pytest.approx(7.2, abs=0.05)
+        assert result["score"] > 4.8
+
+    def test_veto_never_raises_a_score(self):
+        """min(), not assignment: a weak night below the threshold stays weak."""
+        result = rate_night(moon_score=1.0, dark_score=1.0, weather_score=3.9, bortle_score=1.0)
+        assert result["score"] < 3.9
+
+    def test_missing_weather_is_not_vetoed(self):
+        """Beyond the forecast horizon there is nothing to veto with."""
+        result = rate_night(10, 10, None, 10)
+        assert result["score"] == pytest.approx(10.0, abs=0.05)
+
+    def test_components_unchanged_by_veto(self):
+        """The veto adjusts the composite only — the bars still report raw components."""
+        result = rate_night(10.0, 9.8, 1.8, 7.8)
+        assert result["components"] == {"weather": 1.8, "moon": 10.0, "dark": 9.8, "bortle": 7.8}
+
+
 # ---------------------------------------------------------------------------
 # weighted_weather_score
 # ---------------------------------------------------------------------------

--- a/tests/test_weather_conditions.py
+++ b/tests/test_weather_conditions.py
@@ -201,10 +201,20 @@ class TestRateConditions:
 
     def test_cloud_tiers_high_cirrus_penalized_less_than_low_mid(self):
         """Same magnitude split between high-only vs low-only cloud cover — high/cirrus
-        gets the lighter 0.6 weight, so it should score strictly higher."""
+        gets the lighter _HIGH_CLOUD_WEIGHT, so it should score strictly higher."""
         high_only = rate_conditions(_wp(cloud_cover_low_pct=0, cloud_cover_mid_pct=0, cloud_cover_high_pct=80))
         low_only  = rate_conditions(_wp(cloud_cover_low_pct=80, cloud_cover_mid_pct=0, cloud_cover_high_pct=0))
         assert high_only > low_only
+
+    def test_solid_cirrus_overcast_is_a_poor_hour(self):
+        """
+        100% high cloud and nothing else. At the old 0.6 weight this rated 5/10 —
+        a "usable" hour under an unbroken cirrus deck, which lifted whole overcast
+        nights into the middle of the scale. It should land in the poor band.
+        """
+        assert rate_conditions(
+            _wp(cloud_cover_pct=100, cloud_cover_low_pct=0, cloud_cover_mid_pct=0, cloud_cover_high_pct=100)
+        ) == 3
 
     def test_cloud_tiers_fall_back_to_total_when_tiers_absent(self):
         """No tier fields set — reproduces the pre-upgrade cloud_cover_pct-only score."""


### PR DESCRIPTION
## The bug

[This night](https://darkhours.app/?lat=40.5188125&lon=-109.5424375&date=2026-08-12) — a new moon under 100% cirrus, with **zero** clear dark hours — scored **6.0 "Good"**, with the "Clear Dark Sky" row reading `9.8` directly beside the value `None (clouded out during dark window)`.

Two independent causes.

**1. The composite under-punishes clouds.** `rate_night` is a pure weighted geometric mean. A true zero does zero the night, but a weather score of 3/10 at 40% weight only removes ~40% of the total, so the other three near-perfect factors carried the rest:

```
0.30^0.40 × 1.00^0.25 × 0.98^0.25 × 0.78^0.10 = 0.60 → 6.0
```

**2. High cloud was weighted too lightly.** At `0.6`, total cirrus overcast capped out at a 46% penalty, so a solid 100%-cirrus hour still rated 5/10 and a whole night of it averaged 3.0 rather than ~1.

## The fix

**A weather veto.** Below `WEATHER_VETO_THRESHOLD` (4.0), the composite is capped at the weather score.

It is deliberately **one-sided**. Weather is normally the weakest of the four factors, so an unconditional ceiling would flatten the model into "the weather score" on nearly every night and punish nights with genuinely usable time. Above the threshold the geometric mean is untouched. With no weather data (past the 16-day horizon, provider outage) there is nothing to veto with, and the existing weight redistribution stands unchanged.

**Cirrus weight 0.6 → 0.8**, now the named `_HIGH_CLOUD_WEIGHT`. A solid-cirrus hour drops from 5/10 to 3/10, still ranked ahead of equivalent low/mid stratus.

## Effect on real nights

Verified against the live forecast at the reported location. `clear dark hrs` is the ground truth — hours both moon-free-dark and under 50% cloud:

| Night | Clear dark hrs | Before | After |
|---|---|---|---|
| Aug 11 | **0.00** | 6.4 | **3.1** |
| Aug 12 | **0.00** | 6.0 | **1.8** |
| Aug 17 | **0.00** | 5.3 | **2.0** |
| Aug 13 / 16 / 19 / 20 / 21 | 0.00 | 3.3–3.9 | 1.0–1.1 |
| Aug 10 | 4.55 | 7.7 | 7.2 |
| Aug 15 | 3.79 | 8.8 | 8.4 |
| Aug 14 | 6.77 | 8.5 | **8.5** (unchanged) |
| Aug 18 | 5.95 | 9.1 | **9.1** (unchanged) |

All eight zero-usable-hour nights now read Poor. Every night with real usable time keeps its band. Aug 11 was worse than the reported night and is fixed by the same change.

Three other rules were evaluated against the same 15 nights and rejected: a hard cap at the weather score (dropped Aug 10 to 4.8 and Aug 14 to 7.1), a `weather + 2` soft cap (left Aug 11 at 5.1 with zero usable hours), and folding clouds into the dark-hours component (produced literal `0.0`s and would score nights past the forecast horizon by a different definition).

## Labelling

The reason this was hard to spot: the row was titled **"Clear Dark Sky"**, but its score is astronomical only — moon-free hours measured against the lunar cycle's best, with no cloud correction — while the *value* beside it is cloud-corrected. Hence `9.8` next to `None (clouded out)`.

- Report card and outlook ribbon rows renamed to **"Dark Hours"**.
- The CLI calendar had the identical defect, printing `Clear Dark Hours` over `summary.dark_hours`. Renamed.
- Tooltips now state which is which, and the composite tooltip documents the veto. It also previously claimed "one hard zero — full overcast, full moon — zeroes the whole night"; full overcast never produced a zero, because the hourly rating floors at 1.

`App.tsx`'s "Clear Dark Hours" scope item is intentionally left alone — it is gated on weather availability, so it genuinely names the cloud-corrected figure, which is exactly what goes out of range past 14 days.

## Docs

Veto documented in `README`, `FEATURES`, `CLI`, `TRIPBUILDER`. Two pre-existing inaccuracies corrected while in there:

- `ARCHITECTURE.md` described `report.dark_hours` as "clear dark sky hours". It has never been cloud-adjusted.
- The CLI **"Wx Rating formula"** table described an additive weighted average (Cloud 50%, Seeing 20%, Transparency 15%, Wind 10%, Humidity 5%) that `rate_conditions` does not implement. It is multiplicative limiters against an additive quality base, with two hard gates. Rewritten to match the code.

`TRIPBUILDER` gains a caveat worth a reviewer's attention: the veto can only fire on dates that *have* weather, so in a mixed range a clouded-out near night now ranks below an unknown far night. `--no-weather` levels the comparison.

## Testing

`880 passed, 9 skipped`. Six new veto tests (including a regression pinned to the reported night) and one asserting solid cirrus lands in the poor band. Verified end-to-end through the CLI parity oracle and through the SPA against a local API.

## Note

`.gitignore` is left uncommitted on purpose — it was already modified before this work began and is unrelated (node_modules / map-proto ignore rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
