### PR TITLE
Fix SkyDome cold-mount crash: gradient call before canvas is sized

### DIFF
--- a/apps/web/src/report/skydome/SkyDome.tsx
+++ b/apps/web/src/report/skydome/SkyDome.tsx
@@ -166,6 +166,9 @@ export function SkyDome({ summary, report }: {
   // The 12k-star recompute is coalesced to one run per animation frame: a fast
   // scrub emits many input events per frame, and running the tick synchronously
   // in each commit saturates a phone's main thread and makes the slider stick.
+  // The draw itself always goes through requestDraw — the one scheduling path
+  // that ends in renderer.render() — so a frame can never be drawn before
+  // SkyRenderer has a measured size.
   const tickParamsRef = useRef<{ utcMs: number; cloudFrac: number; aod: number | null } | null>(null)
   const tickRafRef = useRef(0)
   useEffect(() => {
@@ -188,13 +191,13 @@ export function SkyDome({ summary, report }: {
       const ren = rendererRef.current
       if (!params || !ren) return
       setTickResult(ren.tick(params))
-      ren.render()
+      requestDraw()
     })
-  }, [report, timeMs, cloudFrac, aod, catState, mwReady])
-  useEffect(() => () => {
-    if (tickRafRef.current) cancelAnimationFrame(tickRafRef.current)
-    tickRafRef.current = 0
-  }, [])
+    return () => {
+      if (tickRafRef.current) cancelAnimationFrame(tickRafRef.current)
+      tickRafRef.current = 0
+    }
+  }, [report, timeMs, cloudFrac, aod, catState, mwReady, requestDraw])
 
   // ── View changes redraw only (no recompute) ─────────────────────────────────
   useEffect(() => {

--- a/apps/web/src/report/skydome/render.ts
+++ b/apps/web/src/report/skydome/render.ts
@@ -323,7 +323,10 @@ export class SkyRenderer {
   }
 
   render() {
-    if (!this.statics) return
+    // Guards the pre-measurement window: W/H start at 0 until the first
+    // ResizeObserver delivery calls setSize, and a draw before that turns
+    // the diffuse-canvas scale factor into Infinity (NaN gradient stops).
+    if (!this.statics || this.W < 1 || this.H < 1) return
     const cam = this.camera()
     this.drawDiffuse(cam)
     const ctx = this.ctx


### PR DESCRIPTION
## Summary
- On first mount, `SkyDome`'s statics effect scheduled its own `requestAnimationFrame` that called `SkyRenderer.render()` directly, ahead of the first `ResizeObserver` delivery that sets `W`/`H` via `setSize`.
- With `W = H = 0`, the diffuse-canvas scale factor divides by zero, producing a `NaN` `horizonY`, which throws `TypeError: The provided double value is non-finite` from `createLinearGradient` in `drawDiffuse`. No visible defect (the dome self-heals on the next frame once `setSize` runs), but it throws on every cold report load.
- `render()` now guards on `W < 1 || H < 1` in addition to the existing `!statics` check — the single choke point all draw calls funnel through, so it closes the hole regardless of how many call sites/gradients are involved.
- Consolidated the tick effect's direct `ren.render()` call to go through `requestDraw` instead (one scheduling path into `renderer.render()`), and gave that effect its own cleanup for the pending `rAF` instead of relying on a separate empty-deps effect.

Verified directly against the built module in a live browser (not just static reading): confirmed the pre-fix code throws the exact reported error when called with `W=H=0`, confirmed the new guard suppresses it, and confirmed rendering still succeeds normally once `setSize` runs (no regression to the steady-state draw path).

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean on both touched files
- [x] Live-verified against the actual `render.ts` module in-browser: throws pre-fix with `W=H=0`, silent post-fix, renders correctly after `setSize`
- [ ] Reviewer: cold-load a report locally with DevTools open and confirm no console errors on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)