### PR TITLE
Stop serving every blog post at two URLs that both return 200

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -50,7 +50,7 @@
       "author": {
         "@type": "Person",
         "name": "Miguel Beher",
-        "url": "https://darkhours.app/blog/about",
+        "url": "https://darkhours.app/blog/about/",
         "sameAs": [
           "https://github.com/mbeher2200",
           "https://www.linkedin.com/in/mbeher/",
@@ -69,7 +69,7 @@
       "publisher": {
         "@type": "Person",
         "name": "Miguel Beher",
-        "url": "https://darkhours.app/blog/about"
+        "url": "https://darkhours.app/blog/about/"
       }
     }
     </script>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -598,7 +598,7 @@ export default function App() {
             <p className="es-headline">Built for landscape astrophotography. Not for subscriptions.</p>
             <p className="es-body">
               Most of us only get a handful of clear, dark hours each month to do what we love.{' '}
-              <a href="/blog/my-astrophotography-origin-story-and-a-new-app" target="_blank" rel="noreferrer">
+              <a href="/blog/my-astrophotography-origin-story-and-a-new-app/" target="_blank" rel="noreferrer">
                 I built DarkHours because I needed a highly precise predictive tool for my own landscape astrophotography
               </a>
               . It's open-source, free, and designed to help make the most of every dark hour.
@@ -770,7 +770,7 @@ export default function App() {
 
         <p className="colophon-tagline">
           DarkHours is built by{' '}
-          <a href="/blog/about" target="_blank" rel="noreferrer">Miguel Beher</a>
+          <a href="/blog/about/" target="_blank" rel="noreferrer">Miguel Beher</a>
           , free and{' '}
           <a href="https://github.com/mbeher2200/DarkHours" target="_blank" rel="noreferrer">open source</a>
           , and will never require your email address. Follow our{' '}

--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -674,17 +674,17 @@ class LambdaApiStack(Stack):
         )
         blog_origin = origins.S3BucketOrigin.with_origin_access_control(blog_bucket)
 
-        # Existing CloudFront Function (created outside CDK) that rewrites directory
-        # requests to index.html so Astro's static output is served correctly from S3.
-        blog_rewrite_fn = cloudfront.Function.from_function_attributes(
-            self, "BlogIndexRewriteFn",
-            function_arn=f"arn:aws:cloudfront::{self.account}:function/AstroBlogIndexRewrite",
-            function_name="AstroBlogIndexRewrite",
-        )
-        blog_fn_assoc = [cloudfront.FunctionAssociation(
-            event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
-            function=blog_rewrite_fn,
-        )]
+        # The blog's directory-index rewrite is the shared static_index_rewrite_fn defined
+        # further down (it is path-agnostic), NOT the out-of-band AstroBlogIndexRewrite
+        # function this stack used to import. That one silently rewrote /blog/foo to
+        # /blog/foo/index.html, so the slashed and unslashed forms of every post both
+        # returned 200 with identical bytes. Google crawled the unslashed form (which is
+        # what the internal links pointed at), found rel=canonical naming the slashed one,
+        # and filed the post under "Alternate page with proper canonical tag" — i.e. not
+        # indexed. Sharing the 301 function fixes that the same way /dark-sky* already did.
+        #
+        # AstroBlogIndexRewrite is now unreferenced. It was created by hand rather than by
+        # CDK, so nothing here deletes it; remove it manually once this is deployed.
 
         # --- Dark-sky destination pages: S3 origin for the darkhours-destinations repo ---
         # Static per-destination guides (SEO landing pages) served at /dark-sky/*. Like the
@@ -713,8 +713,8 @@ class LambdaApiStack(Stack):
         dest_origin = origins.S3BucketOrigin.with_origin_access_control(dest_bucket)
 
         # Directory-index rewrite for the statically generated pages. Written inline (not
-        # created out-of-band like AstroBlogIndexRewrite) because it has to stay in lockstep
-        # with the generator's output, so it belongs versioned with this stack.
+        # created out-of-band like AstroBlogIndexRewrite was) because it has to stay in
+        # lockstep with the generator's output, so it belongs versioned with this stack.
         #
         #   /dark-sky/          -> /dark-sky/index.html
         #   /dark-sky/foo/      -> /dark-sky/foo/index.html
@@ -724,8 +724,18 @@ class LambdaApiStack(Stack):
         # The 301 rather than a silent rewrite is an SEO choice: serving 200 on both the
         # slashed and unslashed form creates two URLs for one page and makes Google dedupe
         # them via rel=canonical. Redirecting removes the ambiguity at the edge instead.
-        # This function is only associated with /dark-sky*, so it never sees SPA or API paths.
-        _dark_sky_rewrite_js = """
+        #
+        # Nothing in the body is /dark-sky-specific, so /blog* shares it (see the blog
+        # origin above) — both origins are Astro sites emitting the same directory layout,
+        # and the blog had exactly the duplicate-URL problem this 301 exists to prevent.
+        # The construct id stays "DarkSkyIndexRewrite" despite now serving both: renaming
+        # it would replace the deployed function for cosmetic reasons only. Associated with
+        # /blog* and /dark-sky* only, so it never sees SPA or API paths.
+        #
+        # The dot test looks at the last path segment, not the whole URI, so a directory
+        # with a dot in an ancestor segment still redirects correctly. (AstroBlogIndexRewrite
+        # tested the whole URI — one of several reasons not to keep it.)
+        _static_index_rewrite_js = """
 function handler(event) {
   var req = event.request;
   var uri = req.uri;
@@ -760,14 +770,14 @@ function handler(event) {
   };
 }
 """
-        dark_sky_rewrite_fn = cloudfront.Function(
+        static_index_rewrite_fn = cloudfront.Function(
             self, "DarkSkyIndexRewrite",
-            code=cloudfront.FunctionCode.from_inline(_dark_sky_rewrite_js),
+            code=cloudfront.FunctionCode.from_inline(_static_index_rewrite_js),
             runtime=cloudfront.FunctionRuntime.JS_2_0,
         )
-        dark_sky_fn_assoc = [cloudfront.FunctionAssociation(
+        static_index_fn_assoc = [cloudfront.FunctionAssociation(
             event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
-            function=dark_sky_rewrite_fn,
+            function=static_index_rewrite_fn,
         )]
 
         # --- Access logs (standard logs) to S3 ---
@@ -816,7 +826,7 @@ function handler(event) {
                     viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                     allowed_methods=cloudfront.AllowedMethods.ALLOW_GET_HEAD,
                     cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
-                    function_associations=blog_fn_assoc,
+                    function_associations=static_index_fn_assoc,
                     response_headers_policy=base_headers_policy,
                 ),
                 # base_headers_policy (no CSP) for now, matching /blog*. The destination
@@ -830,7 +840,7 @@ function handler(event) {
                     viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                     allowed_methods=cloudfront.AllowedMethods.ALLOW_GET_HEAD,
                     cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
-                    function_associations=dark_sky_fn_assoc,
+                    function_associations=static_index_fn_assoc,
                     response_headers_policy=base_headers_policy,
                 ),
             },


### PR DESCRIPTION
## Why

Search Console reported the Zion post as **"Alternate page with proper canonical tag"** — Google crawled a URL, read its `rel=canonical`, and indexed a different one instead.

`/blog*` was still wired to `AstroBlogIndexRewrite`, a CloudFront function created by hand outside CDK. It silently rewrote `/blog/foo` → `/blog/foo/index.html`, so both forms returned 200 with byte-identical content:

| URL | Status | Pointed at by |
|---|---|---|
| `/blog/summer-night-sky-in-zion-national-park` | 200 | every internal link |
| `/blog/summer-night-sky-in-zion-national-park/` | 200 | `rel=canonical` + blog sitemap |

Googlebot only ever *discovered* the unslashed form, then got told the slashed one was canonical.

## What changed

`/dark-sky*` already solved this with a 301 to the slashed form, chosen [precisely so the two forms never both resolve](https://github.com/mbeher2200/DarkHours/blob/main/cdk/lambda_api_stack.py). Nothing in that function's body is dark-sky-specific, so `/blog*` now shares it.

The construct id stays `DarkSkyIndexRewrite` — renaming would replace the deployed function for cosmetic reasons only. The shared function is also strictly more correct than the one it replaces: it tests for a dot in the **last path segment** rather than anywhere in the URI.

Plus the four internal references now point at the slashed form: two links in `App.tsx`, and the author/publisher `url` in both JSON-LD blocks.

## Verification

- Shared function's logic run against the blog's real URL set: redirects all 8 page paths (including bare `/blog`, tag dirs, and query-string preservation), passes through every asset untouched.
- All **105 objects** in the blog bucket have a dot in their last path segment, so the 301 cannot redirect a real object into a 404.
- `pytest -q`: 880 passed, 9 skipped.
- `npm run build`: clean, prerender injected 14914 chars, JSON-LD still parses and featureList synced.

## Follow-up (not in this PR)

- `AstroBlogIndexRewrite` is now unreferenced. CDK never managed its lifecycle, so it needs deleting by hand once this deploys.
- The blog index's own post links (`darkhours-blog` repo) still emit the unslashed form. They'll 301 correctly after this, but fixing them there saves a redirect hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)