### PR TITLE
Stop a job backlog from starving the API of Lambda concurrency

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -310,7 +310,16 @@ class LambdaApiStack(Stack):
         worker.add_to_role_policy(geo_policy)
         worker.add_environment("PYNIGHTSKY_PLACE_INDEX", place_index.index_name)
         worker.add_to_role_policy(route_policy)
-        worker.add_event_source(lambda_events.SqsEventSource(jobs_queue, batch_size=1))
+        # max_concurrency caps how many worker invocations SQS drives in parallel. Without
+        # it, a backlog of jobs can hold every slot in the account-wide Lambda concurrency
+        # pool for up to the worker's 900s timeout, throttling the API into user-facing
+        # 5xx — the API and the worker draw from the same pool. This is sized against that
+        # pool (currently 10), not against job throughput, so it is deliberately low:
+        # raise it once the account's concurrent-executions quota is raised, or jobs will
+        # queue rather than fan out. See docs/OBSERVABILITY.md § Capacity limits.
+        worker.add_event_source(
+            lambda_events.SqsEventSource(jobs_queue, batch_size=1, max_concurrency=5)
+        )
 
         # --- Provider health monitor read (circuit breaker's monitor-driven recovery) ---
         # Least-privilege on purpose: dynamodb:GetItem only (the breaker does single-key

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -151,3 +151,44 @@ aws budgets create-notification \
   --notification Type=ACTUAL,ComparisonOperator=GREATER_THAN,Threshold=80,ThresholdType=PERCENTAGE \
   --subscribers SubscriptionType=EMAIL,Address=<you>
 ```
+
+## Capacity limits
+
+Three ceilings govern how much traffic this stack absorbs. Two of them live outside CDK,
+so they are invisible in the templates and easy to rediscover the hard way.
+
+**Lambda concurrent executions (account-wide).** This account ran at **10** — AWS's default
+is 1000, and the account was never raised. The API and the worker draw from that same pool,
+so it is a shared ceiling, not a per-function one. Check and raise it with:
+
+```
+aws service-quotas get-service-quota --service-code lambda --quota-code L-B99A9384
+aws service-quotas request-service-quota-increase \
+  --service-code lambda --quota-code L-B99A9384 --desired-value 1000
+```
+
+Watch `AWS/Lambda ConcurrentExecutions` with no dimensions (account-wide, `Maximum`) against
+whatever that value currently is. Per-function `Throttles` is the lagging indicator: by the
+time it is non-zero, users have already seen 5xx.
+
+**Worker SQS concurrency.** `max_concurrency` on the worker's `SqsEventSource`
+(`cdk/lambda_api_stack.py`) is what stops a job backlog from consuming the whole pool and
+starving the API. It is sized against the account quota above, so the two must move
+together — raising the quota without raising this just leaves jobs queuing.
+
+**Cache table capacity.** The cache table is created outside CDK and imported by name
+(`dynamodb.Table.from_table_name`), so its billing mode is *not* under CloudFormation and a
+`cdk deploy` will not reassert it. It ran provisioned at 25 RCU / 25 WCU with no autoscaling
+— exactly the legacy always-free-tier allowance, which is why DynamoDB billed ~$0. Under
+load, short spikes above 25 survive only on burst credit (~300s of unused capacity); a
+sustained overrun throttles. Inspect and switch with:
+
+```
+aws dynamodb describe-table --table-name "$PYNIGHTSKY_CACHE_TABLE" \
+  --query 'Table.{Billing:BillingModeSummary.BillingMode,RCU:ProvisionedThroughput.ReadCapacityUnits}'
+aws dynamodb update-table --table-name "$PYNIGHTSKY_CACHE_TABLE" --billing-mode PAY_PER_REQUEST
+```
+
+Billing mode can only be switched once per 24 hours. Note that the cache does nearly as many
+writes as reads, so table load scales close to linearly with traffic rather than flattening
+as the cache warms.


### PR DESCRIPTION
## Why

Traffic stepped up sharply today (roughly 30x the usual hourly rate, sustained rather than a
spike). Nothing broke: zero Lambda throttles, zero function errors, zero CloudFront 5xx across
the whole surge. But checking the metrics turned up two ceilings that are far lower than they
look, and one of them fails in a way that takes the site down rather than just slowing it.

The API Lambda and the async worker draw from the **same account-wide concurrency pool**, and
that pool is small. The worker has a 900s timeout and its SQS event source had no
`max_concurrency`, so a backlog of queued jobs could occupy every slot for up to fifteen
minutes each. The API would then be throttled and users would get 5xx — with no warning from
job volume itself, since the queue looks healthy right up until it isn't. Peak concurrency
during the surge was already half the ceiling, so this is close, not theoretical.

## What this changes

- Caps the worker's SQS event source at `max_concurrency=5`, reserving room for the API.
- Documents the capacity ceilings in `docs/OBSERVABILITY.md` § Capacity limits.

The cap is sized against the concurrency pool, not against job throughput, so it is
deliberately low. **It should be raised when the account quota is raised** — otherwise jobs
queue instead of fanning out. The comment and the doc both say so; the two values have to move
together.

## Two things this does *not* fix

Both live outside CDK, so neither can be fixed in a PR:

1. **The account concurrent-executions quota.** It sits at the un-raised value while AWS's
   default is 1000. A quota-increase request is the actual fix; this PR only stops the worker
   from monopolizing what little there is.
2. **The cache table's capacity mode.** It is created outside CDK and imported by name, so
   CloudFormation never asserts its billing mode. It runs provisioned with no autoscaling, and
   during the surge peaked at roughly **2x its provisioned read capacity** for a full minute.
   That did not throttle only because DynamoDB burst credit covered it — burst is ~300s of
   unused capacity, so a sustained overrun at that level exhausts it in about five minutes and
   then throttles hard. Switching it to on-demand is the fix.

Doc section covers the commands for both.

## Verification

`python -m pytest -q` → 880 passed, 9 skipped. `cdk synth` is not run locally (the asset
bundling step fails on this machine for unrelated reasons, see CLAUDE.md); the deploy workflow
is the real synth proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
