### PR TITLE
Raise the worker concurrency cap once the account quota lands

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -313,12 +313,15 @@ class LambdaApiStack(Stack):
         # max_concurrency caps how many worker invocations SQS drives in parallel. Without
         # it, a backlog of jobs can hold every slot in the account-wide Lambda concurrency
         # pool for up to the worker's 900s timeout, throttling the API into user-facing
-        # 5xx — the API and the worker draw from the same pool. This is sized against that
-        # pool (currently 10), not against job throughput, so it is deliberately low:
-        # raise it once the account's concurrent-executions quota is raised, or jobs will
-        # queue rather than fan out. See docs/OBSERVABILITY.md § Capacity limits.
+        # 5xx — the API and the worker draw from the same pool. So this is sized against
+        # that pool: it leaves the API ample room at the account quota of 1000, while
+        # still letting jobs fan out instead of queuing.
+        #
+        # DO NOT raise this above ~half the account's concurrent-executions quota, and
+        # lower it if that quota is ever reduced — the two move together.
+        # See docs/OBSERVABILITY.md § Capacity limits.
         worker.add_event_source(
-            lambda_events.SqsEventSource(jobs_queue, batch_size=1, max_concurrency=5)
+            lambda_events.SqsEventSource(jobs_queue, batch_size=1, max_concurrency=50)
         )
 
         # --- Provider health monitor read (circuit breaker's monitor-driven recovery) ---

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -158,7 +158,7 @@ Three ceilings govern how much traffic this stack absorbs. Two of them live outs
 so they are invisible in the templates and easy to rediscover the hard way.
 
 **Lambda concurrent executions (account-wide).** This account ran at **10** — AWS's default
-is 1000, and the account was never raised. The API and the worker draw from that same pool,
+is 1000 — until an increase back to 1000 was requested on 2026-08-08. The API and the worker draw from that same pool,
 so it is a shared ceiling, not a per-function one. Check and raise it with:
 
 ```
@@ -174,14 +174,17 @@ time it is non-zero, users have already seen 5xx.
 **Worker SQS concurrency.** `max_concurrency` on the worker's `SqsEventSource`
 (`cdk/lambda_api_stack.py`) is what stops a job backlog from consuming the whole pool and
 starving the API. It is sized against the account quota above, so the two must move
-together — raising the quota without raising this just leaves jobs queuing.
+together: raising the quota without raising this just leaves jobs queuing, and raising this
+without the quota re-opens the starvation path it exists to close. Keep it at roughly half
+the quota or below.
 
 **Cache table capacity.** The cache table is created outside CDK and imported by name
 (`dynamodb.Table.from_table_name`), so its billing mode is *not* under CloudFormation and a
 `cdk deploy` will not reassert it. It ran provisioned at 25 RCU / 25 WCU with no autoscaling
 — exactly the legacy always-free-tier allowance, which is why DynamoDB billed ~$0. Under
 load, short spikes above 25 survive only on burst credit (~300s of unused capacity); a
-sustained overrun throttles. Inspect and switch with:
+sustained overrun throttles. It was switched to on-demand on 2026-08-08 after a surge peaked
+at ~2x provisioned read capacity for a full minute; expect ~$2/mo at that traffic level. Inspect and switch with:
 
 ```
 aws dynamodb describe-table --table-name "$PYNIGHTSKY_CACHE_TABLE" \


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until the Lambda concurrent-executions quota increase is approved.**
> Merging to `main` deploys immediately. While the account pool is still at its old value,
> this change lets the worker occupy every slot and undoes the protection added in #185 —
> the exact failure mode that PR was written to close. Opened as a draft for that reason.

## Why

#185 capped the worker's SQS event source to stop a job backlog from starving the API of
Lambda concurrency. That cap was sized against an account concurrency pool of **10**, so it
was deliberately set very low.

A quota increase back to AWS's default of 1000 has been requested and is pending. Once it is
approved, the old cap stops being a safety valve and becomes the bottleneck: jobs would queue
instead of fanning out, for no reason.

## What this changes

- Worker `max_concurrency`: 5 → **50**, leaving the API ample headroom at a pool of 1000.
- Updates `docs/OBSERVABILITY.md` § Capacity limits to record the quota request, the
  on-demand switch, and the rule tying the two values together.

The cap and the account quota have to move together in both directions. The comment and the
doc now say so explicitly, and give the rule: keep the cap at roughly half the quota or below.

## Merge checklist

- [ ] Quota request approved (`aws service-quotas get-service-quota --service-code lambda --quota-code L-B99A9384` returns 1000)
- [ ] `aws lambda get-account-settings` reflects the new limit
- [ ] Then mark ready and merge — deploy is automatic

## Verification

`python -m pytest -q` → 880 passed, 9 skipped. `cdk synth` is not run locally (known bundling
failure on this machine, see CLAUDE.md); the deploy workflow is the real synth proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
