### PR TITLE
Stop real sessions from spending their rate limit on favicons

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -552,13 +552,18 @@ class LambdaApiStack(Stack):
         #                                sized for someone actively comparing several spots in
         #                                one session rather than a single opt-in click.
         #   5  RateLimitPerIp          — block any single IP exceeding 150 requests / 5 min
-        #                                across all endpoints. Raised alongside the calendar
-        #                                auto-fire above: each location view now costs ~1
-        #                                /night + 1 /calendar submit + a few /jobs/{id} polls
-        #                                (polls aren't covered by the per-endpoint rules, only
-        #                                this global one), plus typeahead /suggest calls. Still
-        #                                well below anything a scripted scraper needs seconds,
-        #                                not minutes, to exceed.
+        #                                across the API surface (scoped: /night, /suggest,
+        #                                /nearby, /calendar, /jobs, /healthz). Raised alongside
+        #                                the calendar auto-fire above: each location view now
+        #                                costs ~1 /night + 1 /calendar submit + a few
+        #                                /jobs/{id} polls (polls aren't covered by the
+        #                                per-endpoint rules, only this one), plus typeahead
+        #                                /suggest calls. Still well below anything a scripted
+        #                                scraper needs seconds, not minutes, to exceed.
+        #                                The scope-down matters: while this rule counted
+        #                                static assets too, real sessions were tripping it on
+        #                                favicons and bundle fetches and getting 403s on the
+        #                                API calls that followed.
         # Total ~931 WCU, still under the 1500-WCU default WebACL capacity (rate-based rule cost
         # doesn't scale with the numeric limit). Managed groups use override_action=none so each
         # group's own block/count actions apply unchanged — except CommonRuleSet, see above.
@@ -649,8 +654,35 @@ class LambdaApiStack(Stack):
                     action=wafv2.CfnWebACL.RuleActionProperty(block={}),
                     statement=wafv2.CfnWebACL.StatementProperty(
                         rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
-                            limit=150,                 # requests per IP per 5-min window
+                            limit=150,                 # API requests per IP per 5-min window
                             aggregate_key_type="IP",
+                            # Scoped to the API surface. Unscoped, this counted every asset
+                            # CloudFront served — favicons, images, the JS bundle — so a
+                            # single engaged session could exhaust 150 on static files alone
+                            # and get 403s on the API calls that matter. Static assets are
+                            # served from S3 and cost nothing to serve; only the Lambda-backed
+                            # paths are worth rate limiting. Mirrors the STARTS_WITH style of
+                            # the two per-endpoint rules above.
+                            scope_down_statement=wafv2.CfnWebACL.StatementProperty(
+                                or_statement=wafv2.CfnWebACL.OrStatementProperty(
+                                    statements=[
+                                        wafv2.CfnWebACL.StatementProperty(
+                                            byte_match_statement=wafv2.CfnWebACL.ByteMatchStatementProperty(
+                                                field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(uri_path={}),
+                                                positional_constraint="STARTS_WITH",
+                                                search_string=path,
+                                                text_transformations=[wafv2.CfnWebACL.TextTransformationProperty(
+                                                    priority=0, type="NONE",
+                                                )],
+                                            ),
+                                        )
+                                        for path in (
+                                            "/night", "/suggest", "/nearby",
+                                            "/calendar", "/jobs", "/healthz",
+                                        )
+                                    ],
+                                ),
+                            ),
                         ),
                     ),
                     visibility_config=vis("RateLimitPerIp"),
@@ -885,12 +917,44 @@ function handler(event) {
         # the /dark-sky/* pipeline (darkhours-destinations repo). The non-html pass keeps
         # `prune` (its default) so stale assets still get removed; the html-only pass
         # must NOT prune, or it would delete every non-html key it doesn't know about.
+        #
+        # Each pass also sets Cache-Control, which nothing here did before: objects landed
+        # with no cache header at all, so browsers fell back to heuristic freshness off
+        # Last-Modified — and Last-Modified is the deploy timestamp, so the heuristic window
+        # was ~nothing and every navigation revalidated every asset. In the WAF logs a single
+        # session showed 146 favicon round-trips in one hour for this reason. Three tiers:
+        #
+        #   assets/*   content-hashed by Vite (index-<hash>.js), so the URL changes whenever
+        #              the bytes do -> immutable, cache for a year, never revalidate.
+        #   other      favicons, images, *.bin, robots/sitemap: stable names, so a fixed TTL.
+        #              One day is the trade: a returning browser can be up to a day stale on
+        #              these after a deploy, which is fine for content that rarely changes.
+        #   *.html     the entry point that names the current asset hashes. no-cache means
+        #              "store it, but revalidate every time" -> cheap 304s, and a deploy is
+        #              picked up on the next navigation instead of a day later.
+        #
+        # Pruning stays scoped per pass: assets/* prunes within itself (so superseded
+        # bundles don't accumulate), the non-html pass prunes everything it owns, and the
+        # html pass must NOT prune or it would delete every non-html key it doesn't know.
         spa_dist_path = os.path.join(os.path.dirname(__file__), "..", "apps", "web", "dist")
+        s3deploy.BucketDeployment(
+            self, "SpaDeployAssets",
+            sources=[s3deploy.Source.asset(spa_dist_path)],
+            destination_bucket=spa_bucket,
+            exclude=["*"],
+            include=["assets/*"],
+            cache_control=[s3deploy.CacheControl.from_string(
+                "public, max-age=31536000, immutable",
+            )],
+            distribution=dist,
+            distribution_paths=["/*"],
+        )
         s3deploy.BucketDeployment(
             self, "SpaDeploy",
             sources=[s3deploy.Source.asset(spa_dist_path)],
             destination_bucket=spa_bucket,
-            exclude=["*.html"],
+            exclude=["*.html", "assets/*"],
+            cache_control=[s3deploy.CacheControl.from_string("public, max-age=86400")],
             distribution=dist,
             distribution_paths=["/*"],
         )
@@ -901,6 +965,7 @@ function handler(event) {
             exclude=["*"],
             include=["*.html"],
             content_type="text/html; charset=utf-8",
+            cache_control=[s3deploy.CacheControl.from_string("no-cache")],
             prune=False,
             distribution=dist,
             distribution_paths=["/*"],

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -192,3 +192,27 @@ aws dynamodb update-table --table-name "$PYNIGHTSKY_CACHE_TABLE" --billing-mode 
 Billing mode can only be switched once per 24 hours. Note that the cache does nearly as many
 writes as reads, so table load scales close to linearly with traffic rather than flattening
 as the cache warms.
+
+## Edge caching and the per-IP rate limit
+
+These two interact, and getting one wrong shows up as the other misbehaving.
+
+**Cache-Control is set at upload**, per `BucketDeployment` pass in `cdk/lambda_api_stack.py`,
+not by a CloudFront response-headers policy. Three tiers: `assets/*` is content-hashed so it
+is `immutable` for a year; other static files get a one-day TTL; `*.html` is `no-cache` so a
+deploy is picked up on the next navigation rather than a day later. Before this was set,
+objects landed with no cache header at all and browsers revalidated everything on every
+navigation — one session in the WAF logs made 146 favicon round-trips in an hour.
+
+**`RateLimitPerIp` is scoped to the API surface** (`/night`, `/suggest`, `/nearby`,
+`/calendar`, `/jobs`, `/healthz`). It must stay scoped. Unscoped it counted every asset
+CloudFront served, so an engaged session could spend its 150-request budget on favicons and
+bundle fetches and then get 403s on the API calls that actually mattered. If you add a new
+Lambda-backed path, add it to the scope-down list too — a path that isn't listed is not rate
+limited at all.
+
+To see what the limiter is actually catching, query the WAF log group
+(`aws-waf-logs-pynightsky`, 30-day retention) grouped by `terminatingRuleId` and
+`httpRequest.uri`. Check whether blocked clients are also making real API calls before
+treating them as abusive: a client that fetches `/suggest`, `/night` and then polls
+`/jobs/{id}` is a user, not a scraper.


### PR DESCRIPTION
## Why

Investigating 403s in the RUM data turned up a pair of problems that combine badly.

**Nothing we serve sets `Cache-Control`.** Neither `BucketDeployment` set it, so every object
landed with no cache policy. Browsers fall back to heuristic freshness derived from
`Last-Modified` — which is the deploy timestamp — so the freshness window is effectively zero
and every navigation revalidates every asset. That includes the content-hashed JS bundle,
whose whole point is that it never needs revalidating.

**`RateLimitPerIp` counted those revalidations.** It was unscoped, so all 150 requests per
5-minute window were shared with favicons, images and bundle fetches. In the WAF logs one
ordinary session made 146 favicon round-trips in a single hour, then hit the limit. Another
session shows the user-visible version: typeahead requests, then a 403 on the `/night` call
that followed.

So the app was generating pointless traffic, and then rate-limiting real users for generating
it. Both halves are ours.

## What this changes

**Cache-Control, per deployment tier:**

| tier | policy | why |
|---|---|---|
| `assets/*` | `public, max-age=31536000, immutable` | content-hashed by Vite, URL changes when bytes do |
| other static | `public, max-age=86400` | stable names, rarely change |
| `*.html` | `no-cache` | entry point naming current hashes; revalidate for cheap 304s |

`no-cache` means "store but revalidate", not "don't store" — a deploy is picked up on the next
navigation rather than a day later.

**Rate limit scoped** to the API surface: `/night`, `/suggest`, `/nearby`, `/calendar`,
`/jobs`, `/healthz`. Static assets come from S3 and cost nothing to serve, so they have no
business consuming an API budget.

Pruning is preserved per pass: the new `assets/*` pass prunes within itself so superseded
bundles don't accumulate, the non-html pass prunes what it owns, and the html pass still must
not prune.

## Note for whoever adds an endpoint next

A Lambda-backed path that isn't in the scope-down list is **not rate limited at all**. The
comment and `docs/OBSERVABILITY.md` both say so, but it's the kind of thing worth knowing
before adding a route.

## Verification

- WAF capacity checked against the live ACL via `check-capacity`: the rule goes 2 → 14 WCU,
  taking the ACL from 935 to 947 of its 1500 limit. 553 WCU headroom remains.
- `python -m pytest -q` → 880 passed, 9 skipped.
- `cdk synth` is not run locally (known bundling failure on this machine, see CLAUDE.md); the
  deploy workflow is the real synth proof.

Worth confirming after deploy that `curl -I` on a favicon and on `/assets/index-*.js` returns
the expected `Cache-Control`, since this is upload-time object metadata rather than a
CloudFront policy — existing objects only pick it up when re-uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
