### PR TITLE
Stop humidity alone from condemning clear, calm nights

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -667,9 +667,12 @@ export default function App() {
                 The scoring underneath is tuned for photographers, not general weather: wind is scored on a
                 quadratic curve that reaches zero around 38 mph (17 m/s), counting gusts as well as sustained
                 speed, since a gust is what shakes a tripod mid-exposure even when the sustained reading looks
-                calm. Humidity above 50% is penalized on a sliding scale for dew and fog risk. Any active
-                precipitation, or visibility under 1,000 meters, is a hard stop regardless of what the rest of the
-                numbers say.
+                calm. Dew risk is scored from the dew-point spread rather than raw humidity, and it is treated as
+                a heads-up rather than a dealbreaker: it can shade an hour's rating by up to 20% and no more,
+                because dew is something you can plan around with a heater strap or a dew shield. Watch for the
+                dew point turning red in the hourly table, which is the same 5°C spread the score reacts to. Any
+                active precipitation, or visibility under 1,000 meters, is a hard stop regardless of what the rest
+                of the numbers say.
               </p>
             </div>
             <div className="es-faq-item">

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -536,7 +536,7 @@ export default function ReportCard({
             k="Weather"
             v={`${r.weather_score.toFixed(1)}/10${r.wx_source ? `  ·  ${r.wx_source}` : ''}`}
             score={r.score_components.weather}
-            scoreTip={<>40% of the composite, and a veto below 4/10 — under that line the whole night is capped at this score. Hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, wind, and humidity. Low and mid cloud block outright; high cirrus counts for 0.8 of that, since it dims and bloats stars rather than hiding them.</>}
+            scoreTip={<>40% of the composite, and a veto below 4/10 — under that line the whole night is capped at this score. Hourly condition ratings averaged across the night, with dark-window hours weighted 3× over twilight. Clouds dominate; then seeing, transparency, and wind. Low and mid cloud block outright; high cirrus counts for 0.8 of that, since it dims and bloats stars rather than hiding them. Dew risk shades an hour by up to 20% and never more, since it is manageable in the field.</>}
           />
         )}
         {showWeather && r.wx_pending && <MetaRow k="Weather" v="Pending  (beyond the ~16-day forecast horizon)" />}

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -144,7 +144,11 @@ export function rateConditions(p: WeatherPoint): number {
     const low  = (p.cloud_cover_low_pct  ?? 0) / 100
     const mid  = (p.cloud_cover_mid_pct  ?? 0) / 100
     const high = (p.cloud_cover_high_pct ?? 0) / 100
-    const effective = Math.min(1, Math.max(low, mid) + 0.6 * high)
+    // Low and mid are treated as independent odds of an opaque sky, not as one layer
+    // subsuming the other; high cirrus adds at 0.8 weight. Kept in sync with
+    // rate_conditions in darkhours/weather.py.
+    const opaque = 1 - (1 - low) * (1 - mid)
+    const effective = Math.min(1, opaque + 0.8 * high)
     limiters.push(Math.max(0, 1 - Math.pow(effective, 1.5)))
   } else if (p.cloud_cover_pct != null) {
     limiters.push(Math.max(0, 1 - Math.pow(p.cloud_cover_pct / 100, 1.5)))
@@ -191,17 +195,28 @@ export function rateConditions(p: WeatherPoint): number {
     limiters.push(Math.max(0, Math.min(1, s)))
   }
 
-  // Quality base: average of seeing and humidity (additive)
+  // Quality base: seeing (additive)
   const base: number[] = []
   if (p.seeing_arcsec != null)
     base.push(Math.max(0, Math.min(1, (4.0 - p.seeing_arcsec) / 3.0)))
-  if (p.humidity_pct != null)
-    base.push(Math.max(0, 1 - Math.max(0, p.humidity_pct - 50) / 50))
 
-  if (!limiters.length && !base.length) return 10
+  // Dew risk — a bounded advisory, not a limiter. Floored at DEW_FLOOR so it can shade a
+  // rating but never condemn one: dew is manageable in the field with a heater strap, and
+  // the dew-point readout already flags it at the same 5°C spread used here. Keyed off
+  // dew-point spread, falling back to RH (onset 75%) when temp/dew point are missing.
+  // Kept in sync with _dew_risk_factor in darkhours/weather.py.
+  const DEW_FLOOR = 0.8
+  let dewFactor: number | null = null
+  if (p.temperature_c != null && p.dew_point_c != null)
+    dewFactor = DEW_FLOOR + (1 - DEW_FLOOR) * Math.max(0, Math.min(1, (p.temperature_c - p.dew_point_c) / 5.0))
+  else if (p.humidity_pct != null)
+    dewFactor = DEW_FLOOR + (1 - DEW_FLOOR) * Math.max(0, Math.min(1, 1 - (p.humidity_pct - 75) / 25))
+
+  if (!limiters.length && !base.length && dewFactor == null) return 10
 
   const baseScore = base.length ? base.reduce((s, v) => s + v, 0) / base.length : 1.0
-  const final = limiters.reduce((s, v) => s * v, baseScore)
+  let final = limiters.reduce((s, v) => s * v, baseScore)
+  if (dewFactor != null) final *= dewFactor
   return Math.max(1, Math.min(10, Math.round(final * 10)))
 }
 

--- a/darkhours/weather.py
+++ b/darkhours/weather.py
@@ -555,14 +555,66 @@ def night_aod(points: list, start: datetime, end: datetime) -> "float | None":
 # stratus. See the derivation at its use site in rate_conditions.
 _HIGH_CLOUD_WEIGHT = 0.8
 
+# --- Dew risk ---------------------------------------------------------------
+# Dew is the one adverse condition on this list a shooter can actually manage in
+# the field: a heater strap, a dew shield, or just wiping the corrector keeps the
+# night going. It's a heads-up, not a dealbreaker, and the UI already flags it
+# independently of the score (the dew-point readout turns red at the same spread
+# threshold used below). So it shades a rating rather than gating one, and is
+# floored at _DEW_FLOOR — worst case a 20% haircut.
+#
+# Being soft here is only safe because the genuinely unshootable end of the
+# moisture spectrum is already caught upstream: fog arrives as a non-"none"
+# precip_type (hard gate 1) or as sub-1000 m visibility (hard gate 2). What's
+# left for this term is the manageable middle.
+_DEW_FLOOR = 0.80
+
+# Dew-point spread (°C) at or above which there's no meaningful condensation
+# risk. 5.0 matches the threshold the SPA already uses to flag the dew-point
+# readout (see NightTimeline.tsx) so the warning and the penalty start together.
+_DEW_CLEAR_SPREAD_C = 5.0
+
+# Relative-humidity onset for the fallback path, used only when temperature or
+# dew point is missing. At typical night temperatures 75% RH ≈ a 4.4 °C spread,
+# so the two paths agree to within ~0.02 of each other across their whole range.
+_DEW_RH_ONSET_PCT = 75.0
+
+
+def _dew_risk_factor(p: 'WeatherPoint') -> float | None:
+    """
+    Bounded dew-risk multiplier in [_DEW_FLOOR, 1.0], or None when the point
+    carries neither dew point nor humidity.
+
+    Keyed off dew-point spread (air temperature minus dew point), which is the
+    direct physical measure of how close the air is to condensing — raw RH is
+    only a proxy for it. Falls back to RH when the spread can't be computed.
+
+    Note the interaction with clear skies: radiative cooling under a cloudless
+    sky drives temperature down toward the dew point, so high RH is partly a
+    *symptom* of the very conditions the cloud limiter is rewarding. That's the
+    other half of why this term is capped — left unbounded it quietly claws back
+    the credit a clear night just earned.
+    """
+    if p.temperature_c is not None and p.dew_point_c is not None:
+        spread = p.temperature_c - p.dew_point_c
+        clear_frac = spread / _DEW_CLEAR_SPREAD_C
+    elif p.humidity_pct is not None:
+        over = p.humidity_pct - _DEW_RH_ONSET_PCT
+        clear_frac = 1.0 - over / (100.0 - _DEW_RH_ONSET_PCT)
+    else:
+        return None
+
+    clear_frac = max(0.0, min(1.0, clear_frac))
+    return _DEW_FLOOR + (1.0 - _DEW_FLOOR) * clear_frac
+
 
 def rate_conditions(p: 'WeatherPoint') -> int:
     """
     Rate sky conditions for astrophotography from 1 (unusable) to 10 (perfect).
 
     Uses a multiplicative limiting-factor model for dealbreakers (clouds, wind, transparency,
-    aerosols, visibility) and an additive quality model for atmospheric steadiness (seeing,
-    humidity).
+    aerosols, visibility), an additive quality model for atmospheric steadiness (seeing), and
+    a bounded advisory factor for dew risk that can shade a rating but never gate one.
     """
     # Hard gate 1: any non-"none" precip_type. Covers rain/snow/frzr/icep/fog/tstorm
     # uniformly, since fog/tstorm are just additional non-"none" string values.
@@ -684,19 +736,28 @@ def rate_conditions(p: 'WeatherPoint') -> int:
         seeing_score = max(0.0, min(1.0, (4.0 - p.seeing_arcsec) / 3.0))
         base_factors.append(seeing_score)
 
-    if p.humidity_pct is not None:
-        # Penalizes high humidity due to dew/fog risk. Starts dropping linearly after 50%.
-        humid_score = max(0.0, 1.0 - max(0.0, p.humidity_pct - 50.0) / 50.0)
-        base_factors.append(humid_score)
+    # Humidity used to live here, averaged with seeing. That made its weight depend on
+    # whether seeing happened to be available: with 7Timer covering the date the two were
+    # averaged, but past 7Timer's 72-hour ASTRO horizon humidity became the *sole* base
+    # factor and multiplied the whole rating on its own. The same clear, calm, Bortle-1
+    # night rated 5.6 at D+2 and 3.1 at D+3 purely on which providers answered. Dew risk
+    # is now its own bounded factor below, so it carries the same weight either way.
 
-    # Calculate base quality (average of seeing and humidity)
-    # If neither is provided, assume perfect base conditions (1.0) before applying limiters.
+    # Calculate base quality (currently seeing alone).
+    # If not provided, assume perfect base conditions (1.0) before applying limiters.
     base_score = sum(base_factors) / len(base_factors) if base_factors else 1.0
 
     # Apply limiters multiplicatively
     final_score = base_score
     for limiter in limiters:
         final_score *= limiter
+
+    # --- 3. DEW RISK (bounded advisory) ---
+    # Applied outside `limiters` on purpose: everything in that list is allowed to reach
+    # zero and end the night, and this one deliberately cannot. See _dew_risk_factor.
+    dew_factor = _dew_risk_factor(p)
+    if dew_factor is not None:
+        final_score *= dew_factor
 
     # Scale to 1-10 range and round safely
     return max(1, min(10, round(final_score * 10)))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -230,7 +230,7 @@ The Night Quality Score (1 to 10) is a composite of four factors:
 
 | Factor | Weight | Scoring |
 |--------|--------|---------|
-| **Weather** | 40% | Cloud cover, seeing, transparency, humidity, and precipitation |
+| **Weather** | 40% | Cloud cover, seeing, transparency, dew risk, and precipitation |
 | **Lunar Interference** | 25% | K&S sky-brightening credit at 90° separation, 30° altitude. 10 = new moon, ≈0 = gibbous or full |
 | **Dark Sky Hours** | 25% | Based on your location's typical lunar cycle, scored against its best conditions |
 | **Light Pollution** | 10% | 10 = Bortle 1 (no pollution), dropping toward zero at Bortle 9 (inner city) |
@@ -394,7 +394,11 @@ rating = 10 × base_quality × (limiter₁ × limiter₂ × … )
 | Aerosols | The worse of aerosol optical depth and PM2.5, so a shallow trapped smoke layer can't hide behind a moderate satellite column reading |
 | Visibility | 1.0 above 20 km, tapering linearly to 0.7 at 10 km, then log-scaled below that |
 
-**Quality base**, the averaged ceiling: seeing (1.0 arcsec or better is excellent, 4.0 is poor) and humidity (no penalty below 50%, zero at 100%). With neither available the base is 1.0 and the limiters act alone.
+**Quality base**, the ceiling the limiters multiply against: seeing (1.0 arcsec or better is excellent, 4.0 is poor). Unavailable past 7Timer's 72-hour horizon, in which case the base is 1.0 and the limiters act alone.
+
+**Dew risk**, a bounded advisory applied last. Keyed off dew-point spread (air temperature minus dew point), which is the direct measure of how close the air is to condensing; relative humidity is a fallback when the spread can't be computed, with its onset at 75%. No penalty at a spread of 5°C or more, tapering to a floor of 0.80 at saturation, so it can shade a rating by at most 20% and can never gate one. That floor is deliberate: dew is the one adverse condition here a shooter can manage in the field with a heater strap or a dew shield, and the hourly table already turns the dew-point readout red at the same 5°C threshold. Being soft is safe because the unshootable end of the moisture range is caught upstream by the fog and visibility hard gates.
+
+Dew risk sits outside the quality base rather than inside it. Averaging it with seeing made its weight depend on whether seeing happened to be available: past 7Timer's horizon it became the sole base factor and multiplied the rating on its own, so the same clear, calm, Bortle 1 night could rate 5.6 at D+2 and 3.1 at D+3 purely on which providers answered.
 
 Cloud cover falls back to plain total cover on the same 1.5 power curve when a provider gives no low/mid/high split. The rating floors at 1, never 0, so a single unusable hour doesn't zero a whole night's average on its own. That floor is why the night-level weather veto exists: see [Night Quality Score](#night-quality-score).
 

--- a/tests/test_weather_conditions.py
+++ b/tests/test_weather_conditions.py
@@ -139,19 +139,83 @@ class TestRateConditions:
         """Severe sustained wind isn't masked by a merely-mild gust value."""
         assert rate_conditions(_wp(wind_speed_ms=20.0, wind_gust_ms=2.0)) == 1
 
-    # --- Humidity (Base Quality): max(0.0, 1.0 - max(0.0, RH-50)/50) ---
+    # --- Dew risk (bounded advisory): floored at 0.80, keyed off dew-point spread,
+    #     falling back to RH with a 75% onset. Never a gate. ---
 
-    def test_humidity_below_50_has_no_penalty(self):
-        """≤ 50% RH → no dew risk, full humidity base quality."""
-        s30 = rate_conditions(_wp(humidity_pct=30))
-        s50 = rate_conditions(_wp(humidity_pct=50))
-        assert s30 == s50
+    def test_humidity_below_onset_has_no_penalty(self):
+        """≤ 75% RH → no meaningful condensation risk, no penalty."""
+        s30 = rate_conditions(_wp(humidity_pct=30, cloud_cover_pct=0))
+        s75 = rate_conditions(_wp(humidity_pct=75, cloud_cover_pct=0))
+        assert s30 == s75 == 10
 
     def test_humidity_90_reduces_score(self):
-        """90% RH drops the base quality significantly (1.0 - 40/50 = 0.2)."""
-        low_rh = rate_conditions(_wp(humidity_pct=50, cloud_cover_pct=0))
+        low_rh = rate_conditions(_wp(humidity_pct=75, cloud_cover_pct=0))
         high_rh = rate_conditions(_wp(humidity_pct=90, cloud_cover_pct=0))
         assert low_rh > high_rh
+
+    def test_saturated_air_costs_at_most_twenty_percent(self):
+        """100% RH on an otherwise perfect hour must not drop below 8/10. Dew is
+        manageable in the field; genuine fog is caught by the precip/visibility gates."""
+        assert rate_conditions(_wp(humidity_pct=100, cloud_cover_pct=0)) == 8
+
+    def test_zero_dew_point_spread_costs_at_most_twenty_percent(self):
+        """Same ceiling via the dew-point-spread path (temp == dew point)."""
+        assert rate_conditions(
+            _wp(cloud_cover_pct=0, temperature_c=10.0, dew_point_c=10.0)
+        ) == 8
+
+    def test_dew_spread_above_threshold_has_no_penalty(self):
+        """≥ 5 °C spread → no penalty, matching the UI's dew-warning threshold."""
+        assert rate_conditions(
+            _wp(cloud_cover_pct=0, temperature_c=15.0, dew_point_c=10.0)
+        ) == 10
+
+    def test_dew_spread_tapers_monotonically(self):
+        scores = [
+            rate_conditions(_wp(cloud_cover_pct=0, temperature_c=15.0, dew_point_c=15.0 - s))
+            for s in (0.0, 1.0, 2.0, 3.0, 4.0, 5.0)
+        ]
+        assert scores == sorted(scores)
+        assert scores[0] == 8 and scores[-1] == 10
+
+    def test_dew_point_spread_preferred_over_humidity(self):
+        """When both are present the spread wins — it's the direct physical measure."""
+        # RH says saturated, spread says bone dry. Spread should carry the hour.
+        assert rate_conditions(
+            _wp(cloud_cover_pct=0, humidity_pct=100, temperature_c=15.0, dew_point_c=5.0)
+        ) == 10
+
+    def test_dew_and_rh_paths_agree(self):
+        """The two paths are calibrated against each other, so a point carrying dew point
+        and the RH it implies must not rate differently depending on which path runs."""
+        # 95% RH at 15 °C ⇒ dew point ≈ 14.2 °C (Magnus).
+        via_spread = rate_conditions(
+            _wp(cloud_cover_pct=0, temperature_c=15.0, dew_point_c=14.2)
+        )
+        via_rh = rate_conditions(_wp(cloud_cover_pct=0, humidity_pct=95))
+        assert via_spread == via_rh
+
+    def test_dew_risk_weight_does_not_depend_on_seeing_availability(self):
+        """Regression: dew used to be averaged with seeing, so its weight doubled when
+        seeing was missing (past 7Timer's 72h horizon). The gap between a humid and a dry
+        hour must now be the same whether or not seeing came through."""
+        def gap(**extra):
+            dry   = rate_conditions(_wp(cloud_cover_pct=0, humidity_pct=50, **extra))
+            humid = rate_conditions(_wp(cloud_cover_pct=0, humidity_pct=95, **extra))
+            return dry - humid
+
+        assert gap() == gap(seeing_arcsec=1.0)
+
+    def test_clear_calm_humid_night_is_not_condemned(self):
+        """The Olympic Peninsula case: zero cloud, calm, pristine air, 20 km visibility,
+        but marine-layer humidity. Must not read as an unusable night."""
+        p = _wp(
+            cloud_cover_low_pct=0, cloud_cover_mid_pct=0, cloud_cover_high_pct=0,
+            wind_speed_ms=1.5, wind_gust_ms=1.3, visibility_m=24140.0,
+            aerosol_optical_depth=0.09, pm2_5=5.0,
+            humidity_pct=91, temperature_c=15.3, dew_point_c=13.9,
+        )
+        assert rate_conditions(p) >= 8
 
     # --- Transparency (Limiter) ---
 


### PR DESCRIPTION
## The bug

`https://darkhours.app/?lat=47.88427734375&lon=-124.08976745605469&date=2026-08-12` (Olympic Peninsula, new moon, Bortle 1) scored **3.1/10** despite 0% cloud at every hour of the night. Since 3.1 is under `WEATHER_VETO_THRESHOLD`, that capped the whole night at 3.1, discarding a perfect moon score, a perfect Bortle score and 5.35 dark hours.

Every limiter was ~1.0: zero cloud across all three tiers, 1.5 m/s wind, 24 km visibility, AOD 0.09, PM2.5 ~5. Strip the humidity term and the identical night scores 9.9. The entire penalty was humidity.

## Two things were wrong

**The weight was accidental.** Humidity lived in the additive quality base, averaged with seeing. Past 7Timer's 72-hour ASTRO horizon there is no seeing value, so `base_factors` had one member and `base_score == humid_score`: humidity stopped being one of two quality factors and started behaving like a limiter. The horizon cliff is visible on the same coordinates:

| date | source | seeing pts | median RH | weather |
|---|---|---|---|---|
| 08-10 | Open-Meteo + 7Timer | 12/12 | 82 | 5.4 |
| 08-11 | Open-Meteo + 7Timer | 11/12 | 98 | 1.6 |
| **08-12** | **Open-Meteo** | **0/12** | **81** | **3.1** |
| 08-13 | Open-Meteo | 0/12 | 58 | 7.5 |

Injecting a plausible seeing value into the unchanged 08-12 data gives 6.4 / 5.6 / 4.6 at 1.0" / 1.5" / 2.0" against an actual 3.1. Identical weather, different rating, decided by which provider happened to cover the date.

**The magnitude was wrong.** Radiative cooling under a cloudless sky drives temperature toward the dew point, so high RH is partly a *symptom* of the conditions the cloud limiter is rewarding. Unbounded, the humidity term quietly clawed back the credit a clear night had just earned. 78% RH on a calm coastal August night was scoring 4/10 under a Bortle 1 new moon.

## The change

Dew risk becomes its own factor, applied outside the limiter chain:

- **Keyed off dew-point spread** (air temp minus dew point), the direct measure of how close the air is to condensing. RH is a fallback when the spread can't be computed, with its onset moved from 50% to **75%**. The two paths are calibrated to agree within ~0.02 across their whole range, so a point doesn't rate differently depending on which one runs.
- **No penalty at a spread of 5°C or more**, matching the threshold `NightTimeline.tsx` already uses to flag the dew-point readout red. Warning and penalty now start together.
- **Floored at 0.80**: at most a 20% haircut, never a gate. Dew is the one adverse condition on this list a shooter can manage in the field with a heater strap or a dew shield, and the UI already tells them it's coming. Being soft is safe because the genuinely unshootable end of the moisture range is caught upstream by the fog (`precip_type`) and sub-1000m visibility hard gates.
- **Deliberately outside `limiters`**: everything in that list is allowed to reach zero and end the night. This one must not, so it doesn't live there.

## Drive-by fix: the client-side mirror had drifted

`format.ts` mirrors `rate_conditions` for the inline weather chips on Targets, Milky Way and Satellites. It was still on the **old** cloud model (`max(low, mid) + 0.6 * high`) while the engine had moved to independent overlap + 0.8 weight. Those chips disagreed with the headline weather score on **60 of 344** real forecast points before this branch. Now synced, with the dew logic mirrored too.

## Verification

- **888 tests pass.** 8 new ones pin the floor, the spread taper, agreement between the two paths, and a regression test that the dew penalty no longer changes weight with seeing availability.
- **Engine/mirror parity**: a harness comparing `format.ts` against `rate_conditions` point-for-point over 344 real forecast points went from **60 mismatches to 0**.
- **Gates intact**: fog, sub-1km visibility, 100% cloud, 20 m/s wind and wildfire AOD all still return 1. Cloud × dew matrix is monotonic in both axes.
- **Real-data sweep, 8 sites × 3 dates**: dry sites (Death Valley, Joshua Tree, Zion) essentially unchanged, since humidity was never the binding constraint there. Cloudy nights still bad: Zion 08-15 stays 1.0 at 100% cloud. The movers are exactly the clear-but-humid cases: Olympic +5.6, Yellowstone +4.2, Everglades +3.8. Two small −0.3 moves on 7Timer dates, correct direction, since seeing is no longer diluted by an unrelated signal.
- Reported night: **weather 3.1 → 8.7, overall 3.1 → 9.3.** Worst hour (95% RH, 0.8°C spread) went 1 → 8.
- `tsc` clean; eslint findings identical to baseline.

## Reviewer note: what this does *not* fix

Seeing still has the same absent-provider-scores-as-perfect defect. `base_score` is `seeing_score` when 7Timer covers the date and `1.0` when it doesn't, so a D+2 night with mediocre seeing can rate below the identical night at D+3. Same class of bug, but changing seeing's absent-default shifts scores broadly and deserves its own decision rather than riding along here.

Docs, the weather FAQ and the weather-score tooltip are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
