### PR TITLE
Stop the geocode store from wedging at DynamoDB's item-size limit

### DIFF
--- a/darkhours/location.py
+++ b/darkhours/location.py
@@ -33,30 +33,60 @@ USER_AGENT = "darkhours/1.0"
 
 
 class LocalGeocodeStore:
-    """Saved/cached named locations persisted as one JSON file on local disk."""
+    """Saved/cached named locations persisted as one JSON file on local disk.
+
+    The file keeps the whole-dict format it has always had — one process, one
+    file, no size ceiling worth worrying about — but the store now exposes the
+    same per-key contract as the DynamoDB one so callers never hold the whole
+    dict in order to add a single entry.
+    """
 
     def __init__(self, path: Path = CACHE_FILE):
         self.path = path
 
-    def load(self) -> dict:
+    def _read(self) -> dict:
         if self.path.exists():
             return json.loads(self.path.read_text())
         return {}
 
-    def save(self, data: dict) -> None:
+    def _write(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(json.dumps(data, indent=2))
 
+    def get(self, key: str) -> dict | None:
+        return self._read().get(key)
+
+    def put(self, key: str, entry: dict) -> None:
+        data = self._read()
+        data[key] = entry
+        self._write(data)
+
+    def all(self) -> dict:
+        return self._read()
+
 
 class DynamoGeocodeStore:
-    """Saved locations persisted as a single JSON blob in the shared DynamoDB table.
+    """Saved locations in the shared DynamoDB table, one item per location.
 
-    Stored under the reserved system key ``__geocode__`` (no TTL → permanent),
-    so a cache flush never touches it. Mirrors the whole-dict load/save contract
-    of LocalGeocodeStore.
+    Each entry is its own item under ``geocode|<key>``, written with no TTL so a
+    cache flush never touches it.
+
+    This deliberately does *not* mirror LocalGeocodeStore's file layout. It used
+    to: every location lived in a single ``__geocode__`` blob that was read and
+    rewritten in full on every save. That is the natural shape for a JSON file
+    and a pathological one for DynamoDB — the item reached the hard 400 KB item
+    limit at ~2,600 locations, after which every write failed and nothing new was
+    ever cached (so every lookup re-hit the geocoding provider, at real cost).
+    Before that it was merely expensive: ~50 RCU per read and ~400 WCU per write,
+    for one location. It was also lossy — read-modify-write on a shared blob from
+    concurrent Lambda containers silently dropped whichever write landed first.
+
+    Per-key items cost ~1 RCU / ~1 WCU, have no collective size ceiling, and
+    cannot clobber each other. Keep it that way: do not reintroduce an API that
+    writes every location at once.
     """
 
-    _KEY = "__geocode__"
+    _PREFIX = "geocode|"
 
     def __init__(self, table_name: str | None = None):
         self._table_name = table_name
@@ -69,31 +99,60 @@ class DynamoGeocodeStore:
             self._table = _dynamo_table(self._table_name)
         return self._table
 
-    def load(self) -> dict:
+    def get(self, key: str) -> dict | None:
         try:
-            item = self.table.get_item(Key={"cache_key": self._KEY}).get("Item")
-            return json.loads(item["value"]) if item else {}
+            item = self.table.get_item(Key={"cache_key": self._PREFIX + key}).get("Item")
+            return json.loads(item["value"]) if item else None
         except Exception as e:
-            log.debug("Geocode store load error: %s", e)
-            return {}
+            log.debug("Geocode store get error for %r: %s", key, e)
+            return None
 
-    def save(self, data: dict) -> None:
+    def put(self, key: str, entry: dict) -> None:
         try:
-            self.table.put_item(Item={"cache_key": self._KEY, "value": json.dumps(data)})
+            self.table.put_item(
+                Item={"cache_key": self._PREFIX + key, "value": json.dumps(entry)}
+            )
         except Exception as e:
             # A geocode-cache write failure must not fail the request — the lookup
             # still succeeds, it just won't be cached for next time.
             log.warning("Geocode store save failed (continuing uncached): %s", e)
 
+    def all(self) -> dict:
+        """Every saved location. Scans the table — CLI convenience, not a request path.
+
+        The table is hash-key-only, so there is no prefix Query to use here. This
+        is why nothing on the request path calls it.
+        """
+        out: dict = {}
+        try:
+            from boto3.dynamodb.conditions import Attr
+            kwargs = {"FilterExpression": Attr("cache_key").begins_with(self._PREFIX)}
+            while True:
+                resp = self.table.scan(**kwargs)
+                for item in resp.get("Items", []):
+                    out[item["cache_key"][len(self._PREFIX):]] = json.loads(item["value"])
+                if "LastEvaluatedKey" not in resp:
+                    return out
+                kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+        except Exception as e:
+            log.debug("Geocode store scan error: %s", e)
+            return out
+
 
 # Module-level helpers delegate to the active backend's geocode store so the
-# Nominatim resolution logic below is unchanged when storage moves to the cloud.
-def _load() -> dict:
-    return ports.get_backend().geocode_store.load()
+# resolution logic below is unchanged when storage moves to the cloud. These are
+# per-key on purpose: reading or writing every location to touch one of them is
+# what wedged the DynamoDB store at its item-size limit (see DynamoGeocodeStore).
+def _get(key: str) -> dict | None:
+    return ports.get_backend().geocode_store.get(key)
 
 
-def _save(cache: dict):
-    ports.get_backend().geocode_store.save(cache)
+def _put(key: str, entry: dict) -> None:
+    ports.get_backend().geocode_store.put(key, entry)
+
+
+def _all() -> dict:
+    return ports.get_backend().geocode_store.all()
 
 
 _US_ZIP_RE = re.compile(r"^\d{5}(-\d{4})?$")
@@ -280,16 +339,14 @@ def resolve(name: str) -> tuple:
         e = _mem_geocode[key]
         return e["lat"], e["lon"], e["display_name"], e["tz_name"]
 
-    cache = _load()
+    entry = _get(key)
 
-    if key in cache:
-        entry = cache[key]
+    if entry is not None:
         # Migrate older entries that predate tz_name caching
         if "tz_name" not in entry:
             log.debug("Migrating '%s': adding tz_name", key)
             entry["tz_name"] = _tz_name_for(entry["lat"], entry["lon"])
-            cache[key] = entry
-            _save(cache)
+            _put(key, entry)
         log.debug("Cache hit for '%s': lat=%s, lon=%s, tz=%s",
                   key, entry["lat"], entry["lon"], entry["tz_name"])
         _mem_geocode[key] = entry
@@ -304,8 +361,7 @@ def resolve(name: str) -> tuple:
     if entry is None:
         raise ValueError(f"Location not found: {name!r}")
 
-    cache[key] = entry
-    _save(cache)
+    _put(key, entry)
     _mem_geocode[key] = entry
     log.debug("Geocoded '%s': lat=%s, lon=%s, tz=%s",
               key, entry["lat"], entry["lon"], entry["tz_name"])
@@ -315,14 +371,12 @@ def resolve(name: str) -> tuple:
 
 def save(name: str, lat: float, lon: float, display_name: str = None):
     """Explicitly save a named location (e.g. 'home', 'dark site')."""
-    cache = _load()
-    cache[name.strip().lower()] = {
+    _put(name.strip().lower(), {
         "lat": lat,
         "lon": lon,
         "display_name": display_name or name,
         "tz_name": _tz_name_for(lat, lon),
-    }
-    _save(cache)
+    })
     log.info("Saved location '%s' → lat=%.4f, lon=%.4f", name, lat, lon)
 
 
@@ -350,5 +404,9 @@ def reverse_geocode(lat: float, lon: float) -> str | None:
 
 
 def list_all() -> dict:
-    """Return all saved/cached locations keyed by name."""
-    return _load()
+    """Return all saved/cached locations keyed by name.
+
+    CLI-only (``darkhours.py locations``). On the aws backend this scans the
+    cache table, so keep it off any request path.
+    """
+    return _all()

--- a/darkhours/ports.py
+++ b/darkhours/ports.py
@@ -34,10 +34,17 @@ class Cache(Protocol):
 
 @runtime_checkable
 class GeocodeStore(Protocol):
-    """Persistence for saved/cached named locations (the whole dict at once)."""
+    """Persistence for saved/cached named locations, one location at a time.
 
-    def load(self) -> dict: ...
-    def save(self, data: dict) -> None: ...
+    Per-key on purpose. A whole-dict contract works on a JSON file and fails on
+    DynamoDB, where it put every location in one item until that item hit the
+    400 KB ceiling — see ``DynamoGeocodeStore``. ``all()`` exists for the CLI
+    listing only; nothing on a request path should call it.
+    """
+
+    def get(self, key: str) -> dict | None: ...
+    def put(self, key: str, entry: dict) -> None: ...
+    def all(self) -> dict: ...
 
 
 @runtime_checkable

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -219,3 +219,22 @@ To see what the limiter is actually catching, query the WAF log group
 `httpRequest.uri`. Check whether blocked clients are also making real API calls before
 treating them as abusive: a client that fetches `/suggest`, `/night` and then polls
 `/jobs/{id}` is a user, not a scraper.
+
+### Geocode store: one item per location
+
+The aws-backend geocode store keeps one DynamoDB item per location under
+`geocode|<key>`. It previously kept *all* of them in a single `__geocode__` item,
+mirroring `LocalGeocodeStore`'s JSON-file contract. On DynamoDB that meant ~50 RCU
+per read and ~400 WCU per write for a single location, silent write loss whenever two
+containers did read-modify-write concurrently, and eventually a hard stop: the item
+reached the 400 KB item limit at ~2,600 locations, every `PutItem` began failing with
+`ValidationException`, and nothing new was cached — so every lookup re-hit Amazon
+Location Service at real cost. That failure is quiet by design (the store logs a
+warning and continues uncached), so watch `DynamoDB UserErrors` on the cache table,
+not the request error rate, to catch a recurrence.
+
+Migration for the existing blob: `scripts/migrate_geocode_store.py` (dry run by
+default, `--apply` to write). Run it *before* deploying a change to the store layout —
+old code reads only the blob and new code reads only per-key items, so migrating first
+leaves no window where a lookup misses. The blob is left in place for rollback and can
+be deleted once the per-key store has run cleanly.

--- a/scripts/migrate_geocode_store.py
+++ b/scripts/migrate_geocode_store.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""One-shot migration: the ``__geocode__`` blob → one DynamoDB item per location.
+
+The aws-backend geocode store used to keep every saved location in a single item
+under ``__geocode__``. That item reached DynamoDB's hard 400 KB limit, after which
+every write failed and no new location was ever cached. ``DynamoGeocodeStore`` now
+writes one item per location under ``geocode|<key>``; this copies the existing
+entries across so nothing (in particular, explicitly saved named locations) is lost.
+
+Run this BEFORE deploying the per-key store. The old code only reads the blob and
+the new code only reads per-key items, so running it first means there is no window
+where a lookup misses. The blob is left in place — delete it once the new store has
+run cleanly for a while:
+
+    aws dynamodb delete-item --table-name "$PYNIGHTSKY_CACHE_TABLE" \
+        --key '{"cache_key":{"S":"__geocode__"}}'
+
+Usage:
+    PYNIGHTSKY_CACHE_TABLE=<table> python scripts/migrate_geocode_store.py [--apply]
+
+Defaults to a dry run; pass --apply to write. Idempotent — safe to re-run.
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+BLOB_KEY = "__geocode__"
+PREFIX = "geocode|"
+
+
+def _existing_keys(table, table_name: str, keys: list) -> set:
+    """Which of these location keys already exist as per-key items.
+
+    BatchGetItem, 100 at a time. One GetItem per key is thousands of sequential
+    round-trips — minutes of wall time for a check that should take seconds.
+    """
+    import boto3
+    ddb = boto3.resource("dynamodb")
+    found = set()
+    for i in range(0, len(keys), 100):
+        chunk = keys[i:i + 100]
+        request = {table_name: {
+            "Keys": [{"cache_key": PREFIX + k} for k in chunk],
+            "ProjectionExpression": "cache_key",
+        }}
+        while request:
+            resp = ddb.batch_get_item(RequestItems=request)
+            for item in resp.get("Responses", {}).get(table_name, []):
+                found.add(item["cache_key"][len(PREFIX):])
+            request = resp.get("UnprocessedKeys") or None
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="write items (default: dry run)")
+    ap.add_argument("--table", default=os.environ.get("PYNIGHTSKY_CACHE_TABLE"))
+    args = ap.parse_args()
+
+    if not args.table:
+        print("error: set PYNIGHTSKY_CACHE_TABLE or pass --table", file=sys.stderr)
+        return 2
+
+    import boto3
+    table = boto3.resource("dynamodb").Table(args.table)
+
+    item = table.get_item(Key={"cache_key": BLOB_KEY}).get("Item")
+    if not item:
+        print(f"no {BLOB_KEY!r} item found — nothing to migrate")
+        return 0
+
+    raw = item["value"]
+    entries = json.loads(raw)
+    print(f"blob: {len(raw.encode()):,} bytes, {len(entries):,} entries")
+
+    # Skip keys already migrated so a re-run is cheap and non-destructive.
+    # BatchGetItem in chunks of 100 — one GetItem per key is thousands of
+    # sequential round-trips and takes minutes.
+    todo = dict(entries)
+    for present in _existing_keys(table, args.table, list(entries)):
+        todo.pop(present, None)
+
+    print(f"already migrated: {len(entries) - len(todo):,}")
+    print(f"to write        : {len(todo):,}")
+
+    if not args.apply:
+        for key in list(todo)[:5]:
+            print(f"  would write {PREFIX + key!r}")
+        if len(todo) > 5:
+            print(f"  ... and {len(todo) - 5:,} more")
+        print("\ndry run — re-run with --apply to write")
+        return 0
+
+    written = 0
+    with table.batch_writer() as batch:
+        for key, entry in todo.items():
+            batch.put_item(Item={"cache_key": PREFIX + key, "value": json.dumps(entry)})
+            written += 1
+            if written % 250 == 0:
+                print(f"  {written:,}/{len(todo):,}")
+    print(f"wrote {written:,} items")
+
+    missing = [k for k in entries if table.get_item(
+        Key={"cache_key": PREFIX + k}).get("Item") is None]
+    if missing:
+        print(f"WARNING: {len(missing)} entries still missing, e.g. {missing[:3]}",
+              file=sys.stderr)
+        return 1
+    print(f"verified all {len(entries):,} entries present as per-key items")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -108,15 +108,46 @@ def geocode_impl(request, tmp_path, monkeypatch):
         yield DynamoGeocodeStore(table_name="test-cache")
 
 
-def test_geocode_empty_load_is_dict(geocode_impl):
-    assert geocode_impl.load() == {}
+def test_geocode_empty_all_is_dict(geocode_impl):
+    assert geocode_impl.all() == {}
 
 
-def test_geocode_save_load_roundtrip(geocode_impl):
-    data = {"home": {"lat": 1.5, "lon": -2.5, "display_name": "Home", "tz_name": "UTC"},
-            "dark site": {"lat": 36.42, "lon": -116.91, "display_name": "DV", "tz_name": "America/Los_Angeles"}}
-    geocode_impl.save(data)
-    assert geocode_impl.load() == data
+def test_geocode_missing_key_is_none(geocode_impl):
+    assert geocode_impl.get("nowhere") is None
+
+
+def test_geocode_put_get_roundtrip(geocode_impl):
+    entry = {"lat": 1.5, "lon": -2.5, "display_name": "Home", "tz_name": "UTC"}
+    geocode_impl.put("home", entry)
+    assert geocode_impl.get("home") == entry
+
+
+def test_geocode_put_is_per_key_not_whole_dict(geocode_impl):
+    """Writing one location must not disturb another.
+
+    This is the regression that matters: the DynamoDB store used to read the
+    whole dict, mutate it and write it back, so concurrent writers silently
+    dropped each other's entries — and the single item eventually hit the 400 KB
+    item limit and stopped accepting writes at all.
+    """
+    a = {"lat": 1.5, "lon": -2.5, "display_name": "Home", "tz_name": "UTC"}
+    b = {"lat": 36.42, "lon": -116.91, "display_name": "DV",
+         "tz_name": "America/Los_Angeles"}
+    geocode_impl.put("home", a)
+    geocode_impl.put("dark site", b)
+
+    assert geocode_impl.get("home") == a
+    assert geocode_impl.get("dark site") == b
+    assert geocode_impl.all() == {"home": a, "dark site": b}
+
+
+def test_geocode_put_overwrites_same_key(geocode_impl):
+    first = {"lat": 1.0, "lon": 2.0, "display_name": "X", "tz_name": "UTC"}
+    second = {"lat": 3.0, "lon": 4.0, "display_name": "Y", "tz_name": "UTC"}
+    geocode_impl.put("spot", first)
+    geocode_impl.put("spot", second)
+    assert geocode_impl.get("spot") == second
+    assert geocode_impl.all() == {"spot": second}
 
 
 # ── S3RasterSource grid resolution (no AWS needed) ───────────────────────────

--- a/tests/test_aws_location.py
+++ b/tests/test_aws_location.py
@@ -136,8 +136,8 @@ class TestResolveDispatch:
 
         with patch("darkhours.location._geocode_via_aws", mock_aws_geo), \
              patch("darkhours.location._geocode_via_nominatim", mock_nom_geo), \
-             patch("darkhours.location._load", return_value={}), \
-             patch("darkhours.location._save"):
+             patch("darkhours.location._get", return_value=None), \
+             patch("darkhours.location._put"):
             from darkhours.location import resolve
             lat, lon, disp, tz = resolve("Denver, CO")
 
@@ -161,8 +161,8 @@ class TestResolveDispatch:
 
         with patch("darkhours.location._geocode_via_nominatim", mock_nom_geo), \
              patch("darkhours.location._geocode_via_aws", mock_aws_geo), \
-             patch("darkhours.location._load", return_value={}), \
-             patch("darkhours.location._save"):
+             patch("darkhours.location._get", return_value=None), \
+             patch("darkhours.location._put"):
             from darkhours.location import resolve
             resolve("Denver, CO")
 
@@ -187,8 +187,8 @@ class TestResolveDispatch:
 
         with patch("darkhours.location._geocode_via_nominatim", mock_nom_geo), \
              patch("darkhours.location._geocode_via_aws", mock_aws_geo), \
-             patch("darkhours.location._load", return_value=cached), \
-             patch("darkhours.location._save"):
+             patch("darkhours.location._get", return_value=cached["denver, co"]), \
+             patch("darkhours.location._put"):
             from darkhours.location import resolve
             lat, lon, disp, tz = resolve("Denver, CO")
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Run the migration before merging.** Old code reads only the `__geocode__` blob;
> new code reads only per-key items. Migrating first means there is no window where a
> lookup misses. Opened as a draft for that reason.
>
> ```
> PYNIGHTSKY_CACHE_TABLE=<table> python scripts/migrate_geocode_store.py --apply
> ```

## The bug

The aws-backend geocode store kept every saved location in a **single DynamoDB item**
under `__geocode__`, mirroring `LocalGeocodeStore`'s whole-dict JSON-file contract. Its
docstring said so explicitly. That is the right shape for a file and a pathological one
for DynamoDB.

Measured on the live table:

```
item size : 409,562 bytes   (400.0 KB)
DDB limit : 409,600 bytes
headroom  : 38 bytes
entries   : 2,630
```

Thirty-eight bytes from the ceiling. Every new location's `PutItem` fails with
`ValidationException: Item size has exceeded the maximum allowed size` — **1,713 times
in the last 24 hours**, currently 100–290/hour.

The failure is silent by design: the store logs a warning and continues uncached, so
nothing errors for users. It just means **every subsequent lookup for that location is a
fresh Amazon Location Service call**, which is a live contributor to the geocoding spend.

Two more problems, present long before the ceiling:

- **Cost per operation.** Every read pulls all 400 KB (~50 RCU); every write rewrites all
  of it (~400 WCU) — to store one location. On the previously provisioned 25 WCU table a
  single save consumed sixteen seconds of the table's entire write capacity.
- **Silent write loss.** `resolve()` did read-modify-write on a shared blob with no
  conditional write. Two containers each adding a location meant one overwrote the other.
  That has been happening invisibly, and it gets worse with concurrency — the worker now
  runs up to 50.

## What this changes

One item per location under `geocode|<key>`: ~1 RCU / ~1 WCU, no collective size ceiling,
and independent keys cannot clobber each other.

- `GeocodeStore` protocol moves from `load()`/`save()` (whole dict) to
  `get()`/`put()`/`all()` (per key).
- `LocalGeocodeStore` keeps its on-disk JSON format unchanged — the whole-dict contract is
  fine for a file — and implements the per-key interface over it.
- `list_all()` is CLI-only and documented as such; on the aws backend it scans, so it must
  stay off any request path.
- `scripts/migrate_geocode_store.py` copies the existing 2,630 entries. Dry run by
  default, idempotent, verifies every entry afterward, and leaves the blob in place for
  rollback.

## Why this went unnoticed

The failure mode is a warning log and a silently disabled cache. Nothing 5xx'd, no alarm
that anyone was watching fired. The signal that *did* fire was `DynamoDB UserErrors`,
which had been in ALARM and was dismissed as monitoring noise.

## Verification

- `python -m pytest -q` → 894 passed, 9 skipped (was 880; +4 new store tests, 3 updated
  for the new contract). New coverage includes the specific regression: writing one
  location must not disturb another.
- Migration dry run against the live table: reads the blob, reports 2,630 entries to
  write, 0 already migrated, completes in under 3 seconds.
- `cdk synth` not run locally (known bundling failure, see CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
