### PR TITLE
Stop a stalled Celestrak fetch from holding a user request for 30s

### DIFF
--- a/apps/warmer/handler.py
+++ b/apps/warmer/handler.py
@@ -39,12 +39,19 @@ def handler(event=None, context=None):
     results: dict[str, str] = {}
     ok = True
 
+    # The warmer deliberately uses a longer per-socket timeout than the request
+    # path: nobody is waiting on it, and every fetch it lands here is one the
+    # request path never has to make. Failing fast is the right trade for a user
+    # staring at a spinner, and the wrong one for the job whose whole purpose is
+    # to have the answer ready before they ask.
     for norad, label in _TRACKED:
-        r = _tle.get_tle(norad)          # fetch + cache under "tle|<norad>"
+        r = _tle.get_tle(norad, timeout=_tle._WARM_FETCH_TIMEOUT)
         results[label] = _status(r.stale, r.error)
         ok = ok and (r.error is None and not r.stale)
 
-    trains, stale, err = _tle.get_starlink_train_tles()   # caches "tle|group|starlink"
+    trains, stale, err = _tle.get_starlink_train_tles(
+        timeout=_tle._WARM_FETCH_TIMEOUT,
+    )   # caches "tle|group|starlink"
     results["starlink"] = (f"ok ({len(trains)} trains)"
                            if (err is None and not stale) else _status(stale, err))
     ok = ok and (err is None and not stale)

--- a/darkhours/tle_provider.py
+++ b/darkhours/tle_provider.py
@@ -6,14 +6,14 @@ Separates fetch/cache concerns from orbit computation so the CLI and a
 future webapp can each manage TLE lifecycle independently.  The webapp
 would skip get_tle() entirely and supply its own TLE (fetched by a
 background scheduler and stored in Redis/DB); the CLI calls get_tle()
-which handles fetch, 6-hour cache, and stale-data fallback.
+which handles fetch, caching, and stale-data fallback.
 
 Public API:
-    get_tle(norad_id)              → TLEResult
-    get_starlink_train_tles()      → (list[tuple], stale, error)
-    ISS_NORAD_ID                   → 25544
-    TLE_TTL                        → 21600   (seconds — 6 hours)
-    TRACKED_SATELLITES             → [(norad_id, display_name), ...]
+    get_tle(norad_id, timeout=…)         → TLEResult
+    get_starlink_train_tles(timeout=…)   → (list[tuple], stale, error)
+    ISS_NORAD_ID                         → 25544
+    TLE_TTL                              → 86400   (seconds — 24 hours)
+    TRACKED_SATELLITES                   → [(norad_id, display_name), ...]
 """
 
 import logging
@@ -44,6 +44,19 @@ TIANGONG_NORAD_ID = 48274
 # still predicts passes usefully, and is infinitely better than none.
 TLE_TTL     = 24 * 3600  # 24 h retention; revalidated every 6 h
 _USER_AGENT = "DarkHours/1.0 (open-source astronomical observation planner)"
+
+# urllib's timeout bounds a single socket operation, not the whole transfer, so
+# these cap how long one stalled read may block — not how long a legitimate
+# download may take. The Starlink group file is a couple of MB and streams fine
+# under either value; Celestrak normally answers in well under a second.
+#
+# The split is deliberate. On the request path a hung fetch is time a user spends
+# waiting on an *optional* feature (satellite passes) while the rest of their
+# forecast sits ready, so it fails fast and lets the breaker take over. The warmer
+# has nobody waiting, and its success is precisely what stops the request path
+# from ever needing to fetch, so it gets room to finish on a slow day.
+_FETCH_TIMEOUT      = 5    # request path — fail fast, degrade to no satellites
+_WARM_FETCH_TIMEOUT = 30   # background warmer — patience is free here
 
 # Per-resource locks (mirrors weather.py's/aqicn.py's lock_for). Satellites are a
 # single-night feature (fetch_satellites is never True on the trip/calendar fan-out
@@ -102,7 +115,7 @@ class _NotModified(Exception):
     """
 
 
-def _fetch_tle_raw(norad_id: int) -> str:
+def _fetch_tle_raw(norad_id: int, timeout: float = _FETCH_TIMEOUT) -> str:
     """
     Fetch the raw 3-line TLE text from Celestrak for *norad_id*.
 
@@ -114,7 +127,7 @@ def _fetch_tle_raw(norad_id: int) -> str:
     if not _cb.allow("celestrak"):
         raise _cb.unavailable("celestrak")
     try:
-        with _rl.acquire("celestrak"), _http.urlopen(req, timeout=15) as resp:
+        with _rl.acquire("celestrak"), _http.urlopen(req, timeout=timeout) as resp:
             text = resp.read().decode("utf-8").strip()
         lines = [l for l in text.splitlines() if l.strip()]
         if len(lines) < 3:
@@ -154,7 +167,7 @@ def _parse_tle(raw: str) -> tuple[str, str, str] | None:
 # Public API
 # ---------------------------------------------------------------------------
 
-def get_tle(norad_id: int) -> TLEResult:
+def get_tle(norad_id: int, timeout: float = _FETCH_TIMEOUT) -> TLEResult:
     """
     Return a TLEResult for *norad_id*.
 
@@ -188,7 +201,7 @@ def get_tle(norad_id: int) -> TLEResult:
                 log.debug("TLE cache hit for NORAD %d (after single-flight wait)", norad_id)
                 return TLEResult(lines=parsed, stale=False, error=None)
         try:
-            raw    = _fetch_tle_raw(norad_id)
+            raw    = _fetch_tle_raw(norad_id, timeout)
             _cache.set(key, raw, ttl_seconds=TLE_TTL)
             parsed = _parse_tle(raw)
             if parsed is None:
@@ -300,7 +313,9 @@ def _filter_train_tles(raw: str) -> list[tuple[str, str, str]]:
     return result
 
 
-def get_starlink_train_tles() -> tuple[list[tuple[str, str, str]], bool, str | None]:
+def get_starlink_train_tles(
+    timeout: float = _FETCH_TIMEOUT,
+) -> tuple[list[tuple[str, str, str]], bool, str | None]:
     """
     Return (tles, stale, error) for Starlink satellites currently in raising phase.
 
@@ -330,7 +345,7 @@ def get_starlink_train_tles() -> tuple[list[tuple[str, str, str]], bool, str | N
                 else:
                     req = urllib.request.Request(_STARLINK_GROUP_URL, headers={"User-Agent": _USER_AGENT})
                     try:
-                        with _rl.acquire("celestrak"), _http.urlopen(req, timeout=30) as resp:
+                        with _rl.acquire("celestrak"), _http.urlopen(req, timeout=timeout) as resp:
                             raw = resp.read().decode("utf-8").strip()
                         _cache.set(key, raw, ttl_seconds=TLE_TTL)
                         log.debug("Fetched Starlink group TLE (%d bytes)", len(raw))

--- a/docs/CIRCUIT_BREAKER.md
+++ b/docs/CIRCUIT_BREAKER.md
@@ -198,3 +198,18 @@ Two invariants keep it fixed, both covered by tests:
   missed run destroys the only copy.
 - **403 with an empty cache must count as a failure.** Retrying cannot help, so it has
   to trip the breaker. Only 403 *with* something to revalidate is a success.
+
+### Fetch timeouts are split by caller
+
+`_FETCH_TIMEOUT` (5s) applies on the request path; `_WARM_FETCH_TIMEOUT` (30s) is what
+the warmer passes. Both are per-socket-operation, not total-transfer, deadlines — the
+Starlink group file is a couple of MB and streams fine under either.
+
+The asymmetry is the point. Satellite passes are optional and the rest of the forecast
+is already computed by the time the TLE future is awaited, so a stalled fetch on the
+request path is pure user-visible latency: a single 30s default was producing ~30s p99
+spikes whenever Celestrak hung. The warmer has nobody waiting, and every fetch it lands
+is one the request path never makes, so it is the wrong place to give up early.
+
+If you find yourself raising the request-path value to "fix" missing satellite data, the
+problem is almost certainly that the warmer is failing — look there instead.

--- a/tests/test_tle_provider.py
+++ b/tests/test_tle_provider.py
@@ -264,6 +264,33 @@ class TestGetTle:
         fail.assert_called_once_with("celestrak")
         mc.set.assert_not_called()
 
+    def test_request_path_timeout_is_short(self):
+        """A hung Celestrak fetch must not hold a user request for 30s.
+
+        Satellites are optional; the rest of the forecast is already computed by
+        the time this is awaited. The 30s default previously produced ~30s p99
+        spikes whenever a fetch stalled.
+        """
+        assert tle_mod._FETCH_TIMEOUT <= 10
+
+    def test_warmer_gets_a_longer_timeout_than_the_request_path(self):
+        """The background warmer should be the patient one.
+
+        Its success is what stops the request path from ever needing to fetch, so
+        it is the wrong place to fail fast.
+        """
+        assert tle_mod._WARM_FETCH_TIMEOUT > tle_mod._FETCH_TIMEOUT
+
+    def test_fetch_uses_the_supplied_timeout(self):
+        """The timeout argument must actually reach urlopen, not just exist."""
+        mc = self._mock_cache(get_val=None, stale_val=None)
+        with mock.patch.object(tle_mod, '_cache', mc), \
+             mock.patch.object(tle_mod._http, 'urlopen') as urlopen:
+            urlopen.return_value.__enter__.return_value.read.return_value = \
+                _ISS_RAW.encode()
+            get_tle(25544, timeout=7)
+        assert urlopen.call_args.kwargs["timeout"] == 7
+
     def test_ttl_is_wider_than_the_warmer_interval(self):
         """TLE_TTL must stay several refresh cycles wide.
 

--- a/tests/test_warmer.py
+++ b/tests/test_warmer.py
@@ -5,9 +5,9 @@ from darkhours import tle_provider as tle
 
 def test_warm_all_ok(monkeypatch):
     monkeypatch.setattr(tle, "get_tle",
-                        lambda n: tle.TLEResult(lines=("a", "b", "c"), stale=False, error=None))
+                        lambda n, timeout=None: tle.TLEResult(lines=("a", "b", "c"), stale=False, error=None))
     monkeypatch.setattr(tle, "get_starlink_train_tles",
-                        lambda: ([("a", "b", "c")], False, None))
+                        lambda timeout=None: ([("a", "b", "c")], False, None))
     out = h.handler({}, None)
     assert out["ok"] is True
     assert out["results"]["ISS"] == "ok"
@@ -17,9 +17,9 @@ def test_warm_all_ok(monkeypatch):
 
 def test_warm_reports_failures(monkeypatch):
     monkeypatch.setattr(tle, "get_tle",
-                        lambda n: tle.TLEResult(lines=None, stale=False, error="HTTP 503"))
+                        lambda n, timeout=None: tle.TLEResult(lines=None, stale=False, error="HTTP 503"))
     monkeypatch.setattr(tle, "get_starlink_train_tles",
-                        lambda: ([], True, "timed out"))
+                        lambda timeout=None: ([], True, "timed out"))
     out = h.handler({}, None)
     assert out["ok"] is False
     assert "FAIL" in out["results"]["ISS"]
@@ -29,9 +29,37 @@ def test_warm_reports_failures(monkeypatch):
 def test_warm_stale_is_not_ok(monkeypatch):
     # stale data served (fetch failed but cache had an old entry) → ok=False
     monkeypatch.setattr(tle, "get_tle",
-                        lambda n: tle.TLEResult(lines=("a", "b", "c"), stale=True, error="HTTP 500"))
+                        lambda n, timeout=None: tle.TLEResult(lines=("a", "b", "c"), stale=True, error="HTTP 500"))
     monkeypatch.setattr(tle, "get_starlink_train_tles",
-                        lambda: ([("a", "b", "c")], False, None))
+                        lambda timeout=None: ([("a", "b", "c")], False, None))
     out = h.handler({}, None)
     assert out["ok"] is False
     assert "stale" in out["results"]["ISS"]
+
+
+def test_warmer_uses_the_long_timeout_not_the_request_path_one(monkeypatch):
+    """The warmer must opt into the patient timeout.
+
+    The request path fails fast (5s) so a hung Celestrak fetch never holds a user
+    request. The warmer has nobody waiting and its success is what stops the
+    request path from needing to fetch at all, so it gets the longer budget. If
+    it silently inherited the short default, the job most likely to succeed would
+    be the one most likely to give up.
+    """
+    seen: dict[str, float] = {}
+
+    def fake_get_tle(norad, timeout=None):
+        seen["tle"] = timeout
+        return tle.TLEResult(lines=("a", "b", "c"), stale=False, error=None)
+
+    def fake_group(timeout=None):
+        seen["group"] = timeout
+        return [("a", "b", "c")], False, None
+
+    monkeypatch.setattr(tle, "get_tle", fake_get_tle)
+    monkeypatch.setattr(tle, "get_starlink_train_tles", fake_group)
+    h.handler({}, None)
+
+    assert seen["tle"] == tle._WARM_FETCH_TIMEOUT
+    assert seen["group"] == tle._WARM_FETCH_TIMEOUT
+    assert seen["tle"] > tle._FETCH_TIMEOUT


### PR DESCRIPTION
## Why

The Starlink group fetch used `timeout=30` on the **synchronous request path**. Satellite
passes are optional and the rest of the forecast is already computed by the time that
future is awaited, so a stalled fetch was pure user-visible latency.

#191 stopped the spin loop, but this remained — the breaker's periodic probe still pays
the full timeout when Celestrak hangs. Measured after #191 deployed:

```
08-11 01:00   p99 15,230ms
08-11 01:55   p99 30,724ms   ← 3 requests over 20s, worst 31,182ms
08-11 03:00   p99  9,988ms
```

So the frequency dropped but the ceiling didn't. I had reported these as fixed off twenty
minutes of post-deploy data — they weren't.

## What this changes

The timeout is now split by caller:

| caller | timeout | rationale |
|---|---|---|
| request path | **5s** | fail fast, degrade to no satellites |
| warmer | **30s** | nobody waiting; its success is what prevents request-path fetches |

Both are **per-socket-operation**, not total-transfer, deadlines — the Starlink group file
is a couple of MB and streams fine under either. Celestrak normally answers in well under a
second.

The asymmetry is deliberate and it's the part worth keeping: failing fast is right for a
user staring at a spinner, and wrong for the background job whose entire purpose is to have
the answer ready before they ask. Applied to both the group fetch and the per-satellite
path, which shared the same problem at 15s.

## Tests

`python -m pytest -q` → **903 passed**, 9 skipped (was 899; +4).

- request-path timeout stays ≤10s
- warmer's timeout is strictly greater than the request path's
- the `timeout` argument actually reaches `urlopen` rather than merely existing
- the warmer passes the long value, so it can't silently inherit the fast-fail default

That last one matters: if the warmer ever inherits the short timeout, the job most likely
to succeed becomes the one most likely to give up, and the symptom would look like missing
satellite data rather than a timeout regression.

## Note

Satellites are still unavailable — Celestrak hasn't published new Starlink elements since
the 403 lock began, so the cache is empty and `/healthz` still reports 503 on that one
provider. This change doesn't address that (nothing on our side can), it just stops the
periodic probe from costing a user 30 seconds.

`/healthz` returning 503 for one optional provider remains open and is the next thing I'd
fix — it can page you for something no user experiences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
