### PR TITLE
Make Find Sky Nearby radius selector more granular

### DIFF
--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import type { NightReport, NearbyResult, CalendarResult } from './types'
-import { formatTime, formatHm, tzAbbr, tzTitle, fmtDist, lpString, scoreBand, scoreLabel, tonightIso, availabilityFor, nightVerdict } from './format'
+import { formatTime, formatHm, tzAbbr, tzTitle, fmtDist, fmtRadiusDist, lpString, scoreBand, scoreLabel, tonightIso, availabilityFor, nightVerdict } from './format'
 import { MoonPhaseSvg, InfoTip } from './shared'
 import { fetchNearby, fetchCalendar, fetchNightDateOnly, ApiRequestError } from './api'
 import OutlookTelemetryRibbon from './OutlookTelemetryRibbon'
@@ -97,7 +97,7 @@ export default function ReportCard({
     return radius != null ? { phase: 'loading', radius } : { phase: 'idle' }
   })
 
-  const [draftRadius, setDraftRadius] = useState<60 | 120>(60)
+  const [draftRadius, setDraftRadius] = useState<number>(20)
 
   async function handleFindNearby(radius: number) {
     setNearbyState({ phase: 'loading', radius })
@@ -564,19 +564,21 @@ export default function ReportCard({
               {nearbyState.phase === 'idle' && (
                 <div className="nearby-radius-control">
                   <span className="nearby-radius-label">Radius</span>
-                  <div className="units-toggle" role="group" aria-label="Search radius">
-                    <button type="button" className={draftRadius === 60 ? 'active' : ''} onClick={() => setDraftRadius(60)}>
-                      {fmtDist(60 * 1.60934, imperial)}
-                    </button>
-                    <button type="button" className={draftRadius === 120 ? 'active' : ''} onClick={() => setDraftRadius(120)}>
-                      {fmtDist(120 * 1.60934, imperial)}
-                    </button>
+                  <div className="nearby-radius-slider">
+                    <input
+                      type="range"
+                      min={20} max={100} step={10}
+                      value={draftRadius}
+                      onChange={e => setDraftRadius(Number(e.target.value))}
+                      aria-label="Search radius"
+                    />
+                    <span className="nearby-radius-value">{fmtRadiusDist(draftRadius, imperial)}</span>
                   </div>
                   <button className="submit nearby-search-btn" onClick={() => handleFindNearby(draftRadius)}>Search Nearby</button>
                 </div>
               )}
               {nearbyState.phase === 'loading' && (
-                <p className="sat-notice">Scanning within {fmtDist(nearbyState.radius * 1.60934, imperial)}…</p>
+                <p className="sat-notice">Scanning within {fmtRadiusDist(nearbyState.radius, imperial)}…</p>
               )}
               {nearbyState.phase === 'error' && (
                 <p className="sat-notice">{nearbyState.message}</p>

--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -248,6 +248,14 @@ export function fmtDist(km: number, imp: boolean): string {
   return `${Math.round(km).toLocaleString()} km`
 }
 
+// Radius-selector distance: same mi→km conversion as fmtDist, but km rounds to
+// the nearest 10 for a clean approximate label, since the mile value is always
+// a fixed slider step (20/30/.../100), not a precise measurement.
+export function fmtRadiusDist(mi: number, imp: boolean): string {
+  if (imp) return `${mi} mi`
+  return `${Math.round(mi * 1.60934 / 10) * 10} km`
+}
+
 // ── Moon wash (Krisciunas & Schaefer 1991) — mirrors moonlight.py ────────────
 
 // Sky surface brightness increase from scattered moonlight (Δ mag/arcsec²)

--- a/apps/web/src/report/Nearby.tsx
+++ b/apps/web/src/report/Nearby.tsx
@@ -1,5 +1,5 @@
 import type { NearbyPlace, NearbyResult } from '../types'
-import { fmtDist } from '../format'
+import { fmtDist, fmtRadiusDist } from '../format'
 import { Navigation } from 'lucide-react'
 
 // ── Nearby dark-sky results ──────────────────────────────────────────────────
@@ -100,13 +100,13 @@ export function NearbyResults(
     <>
       <div className="meta-row">
         <span className="meta-k">Origin:</span>
-        <span className="meta-v"><span className={nearbyBortleClass(origin_bortle)}>Bortle {origin_bortle}</span>{sqmStr}  ·  {fmtMi(radius_miles)} radius</span>
+        <span className="meta-v"><span className={nearbyBortleClass(origin_bortle)}>Bortle {origin_bortle}</span>{sqmStr}  ·  {fmtRadiusDist(radius_miles, imperial)} radius</span>
       </div>
 
       {/* 1. Note when already at Bortle 1 — results still shown below */}
       {origin_bortle <= 1 && results.length > 0 && (
         <p className="sat-notice">
-          Already at Bortle {origin_bortle}{sqmStr} — showing other Bortle 1 sites within {fmtMi(radius_miles)}.
+          Already at Bortle {origin_bortle}{sqmStr} — showing other Bortle 1 sites within {fmtRadiusDist(radius_miles, imperial)}.
         </p>
       )}
 
@@ -114,8 +114,8 @@ export function NearbyResults(
       {results.length === 0 && (
         <p className="sat-notice">
           {origin_bortle <= 1
-            ? `No other Bortle 1 sites found within ${fmtMi(radius_miles)}.`
-            : `No significantly darker sky found within ${fmtMi(radius_miles)}.`
+            ? `No other Bortle 1 sites found within ${fmtRadiusDist(radius_miles, imperial)}.`
+            : `No significantly darker sky found within ${fmtRadiusDist(radius_miles, imperial)}.`
           }
           {best_available && origin_bortle > 1 && (
             <> Closest darker spot: <span className={nearbyBortleClass(best_available.bortle_class)}>Bortle {best_available.bortle_class}</span>, {distOf(best_available)} {best_available.direction}{formatDriveTime(best_available.drive_minutes) ? ` · ${formatDriveTime(best_available.drive_minutes)} drive` : ''}  ({placeNode(best_available)})</>

--- a/apps/web/src/styles/06-planning.css
+++ b/apps/web/src/styles/06-planning.css
@@ -30,7 +30,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 6px;
-  max-width: 160px;
+  max-width: 220px;
 }
 .nearby-radius-label {
   align-self: center;
@@ -38,12 +38,57 @@
   font-weight: 600;
   color: var(--text-dim);
 }
-.nearby-radius-control .units-toggle {
+.nearby-radius-slider {
   width: 100%;
-  margin-left: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
-.nearby-radius-control .units-toggle button {
+.nearby-radius-slider input[type=range] {
   flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+/* accent-color alone only tints the thumb/filled portion in some browsers —
+   the untraveled track keeps the OS-default light track color, which reads as
+   a white streak against red mode's dark background. Explicitly styling the
+   track/thumb (same technique as .sky-scrub's range input) keeps both in
+   theme colors that flip automatically with --card-border/--accent. */
+.nearby-radius-slider input[type=range]::-webkit-slider-runnable-track {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--card-border);
+}
+.nearby-radius-slider input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-top: -6px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 1px solid var(--text-h);
+  cursor: pointer;
+}
+.nearby-radius-slider input[type=range]::-moz-range-track {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--card-border);
+}
+.nearby-radius-slider input[type=range]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 1px solid var(--text-h);
+  cursor: pointer;
+}
+.nearby-radius-value {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  white-space: nowrap;
 }
 .nearby-search-btn {
   width: 100%;
@@ -167,7 +212,7 @@
 }
 .crp-trigger {
   /* Colors/border/hover/active/disabled/red-mode come from .submit (shared
-     with "Score the night"/"View Details"/60 MI/120 MI) — this class only
+     with "Score the night"/"View Details"/"Search Nearby") — this class only
      adds the icon + label + chevron flex layout .submit doesn't need. */
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Replace the 60/120 mi two-button toggle on the "Find Sky Nearby" panel with a slider offering 20-100 mi in 10 mi steps
- Km readout rounds to the nearest 10 for a clean approximate label (real place distances elsewhere in the panel are unaffected and stay precise)
- Fix the slider track showing the browser's default light track color in red/night-vision mode

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified in-browser: slider steps through all 9 values with correct mi/km labels in both unit modes
- [x] Verified the "Scanning within…" and results-panel radius text match the slider, while the actual search request still uses the precise mile value
- [x] Verified track/thumb styling in both light and red/night-vision mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)