### PR TITLE
Unify dark-candidate naming behavior across backends

### DIFF
--- a/darkhours/darksky.py
+++ b/darkhours/darksky.py
@@ -578,17 +578,6 @@ _MAX_SEARCH_RADIUS  = 150   # beyond this the Overpass query grows unreliable an
 # than the clustering stage already treats as distinct.
 _NAME_DEDUP_MILES = 8.0
 
-# _parallel_prefetch_settlements input cap: candidates arrive priority-ordered
-# (same order the main loop in _jit_geocode_candidates consumes), so only a
-# prefix needs prefetching, not the full up-to-_MAX_DARK_CANDIDATES=60 band-
-# selected pool. Measured on 25 real search origins: the main loop stopped at
-# _MAX_RESULTS=10 having consumed a median well under this prefix, while the
-# eager full-pool prefetch made 50.9% more Tier-3 calls than were ever
-# used. Any candidate beyond the cap that the loop does reach still gets named
-# — _jit_geocode_candidates falls back to a direct _settlement() call for a
-# cache miss on the prefetch map, so this is a volume cut, not a behavior change.
-_PREFETCH_CANDIDATE_PREFIX = 25
-
 # Main public Overpass instance. The overpass.private.coffee mirror was tried but
 # is unreachable (connections hang to timeout); other community mirrors
 # (kumi.systems, openstreetmap.ru, mail.ru) also failed to respond, while
@@ -2167,39 +2156,76 @@ def _offline_tier_name(
     return ("tier3", None)
 
 
-def _parallel_prefetch_settlements(
+def _lazy_batch_settlements(
     candidates: list,
+    start_idx: int,
+    kept_coords: "list[tuple[float, float]]",
+    batch_size: int,
     padus_index: "dict | None",
     natural_areas: "list | None",
-) -> dict:
-    """Concurrently reverse-geocode the spatially-distinct Tier-3 candidates.
+) -> "tuple[dict, int]":
+    """Resolve names for the next up-to-batch_size Tier-3 candidates starting at
+    start_idx, scanning forward through `candidates`. Both backends run this same
+    scan/gate/resolve algorithm — only batch_size differs (see _jit_geocode_candidates),
+    so which candidates get named and in what order is backend-independent; only
+    whether a batch's calls happen in parallel or serially differs, matching each
+    provider's own policy (AWS Location has no per-second limit; the public Nominatim
+    instance forbids parallel/bulk access).
 
-    Used only on backends with no per-second policy (AWS Location). Candidates that
-    Tiers 1-2 already name or discard are excluded; the remainder are clustered at
-    _NAME_DEDUP_MILES so only one representative per ~8 mi area is fetched (mirroring
-    the serial path's spatial dedup), and those reps are geocoded in parallel.
+    A candidate is included in the batch only if it's Tier-3 (Tiers 1-2 produced no
+    name) and isn't within _NAME_DEDUP_MILES of a coordinate already in kept_coords
+    *as known right now* — the same spatial pre-dedup the main loop itself applies.
+    Because kept_coords keeps growing as the main loop consumes results, a candidate
+    resolved here can occasionally turn out to be spatially superseded by the time the
+    loop actually reaches it (an intervening candidate within this same batch got
+    kept, and is close enough to invalidate a later one) — the main loop's existing
+    prefetch-map-miss fallback (a direct _settlement() call) already covers that rare
+    case, so it costs nothing extra to allow for.
 
-    Returns {(round(lat,3), round(lon,3)): settlement_result}, where the value is
-    whatever _settlement returned (a name / "" / None / _OVER_WATER). The main loop
-    reads names from this map instead of issuing the calls serially.
+    Returns ({(round(lat,3), round(lon,3)): settlement_result}, next_idx) — next_idx
+    is how far the scan got, so the next call can resume from there instead of
+    re-scanning candidates already classified.
     """
-    need = [c for c in candidates
-            if _offline_tier_name(c, padus_index, natural_areas)[0] == "tier3"]
-    if not need:
-        return {}
-    reps = _cluster_points(need, merge_miles=_NAME_DEDUP_MILES)
+    reps_needed: list = []
+    idx = start_idx
+    n = len(candidates)
+    while idx < n and len(reps_needed) < batch_size:
+        c = candidates[idx]
+        lat, lon = c["lat"], c["lon"]
+        kind, _ = _offline_tier_name(c, padus_index, natural_areas)
+        if kind == "tier3" and not any(
+            _haversine_miles(lat, lon, klat, klon) <= _NAME_DEDUP_MILES
+            for klat, klon in kept_coords
+        ):
+            reps_needed.append(c)
+        idx += 1
+    if not reps_needed:
+        return {}, idx
+
+    # Cluster first (mirrors the serial path's own spatial dedup — adjacent dark
+    # pixels reverse-geocode to the same settlement) so a batch that scanned several
+    # nearby candidates still issues only one call per ~8 mi area. Skipped for a
+    # single-candidate batch (batch_size=1, i.e. local): clustering one point is a
+    # no-op, and _cluster_points requires a 'bortle_class' key this call site's
+    # caller doesn't always populate on minimal candidate dicts.
+    reps = reps_needed if len(reps_needed) <= 1 else \
+        _cluster_points(reps_needed, merge_miles=_NAME_DEDUP_MILES)
     out: dict = {}
-    workers = min(_GEOCODE_MAX_WORKERS, len(reps))
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futures = {ex.submit(_settlement, c["lat"], c["lon"]): c for c in reps}
-        for fut in futures:
-            c = futures[fut]
-            try:
-                out[(round(c["lat"], 3), round(c["lon"], 3))] = fut.result()
-            except Exception as exc:
-                log.debug("parallel settlement failed (%.4f, %.4f): %s",
-                          c["lat"], c["lon"], exc)
-    return out
+    if len(reps) > 1 and batch_size > 1:
+        workers = min(_GEOCODE_MAX_WORKERS, len(reps))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {ex.submit(_settlement, c["lat"], c["lon"]): c for c in reps}
+            for fut in futures:
+                c = futures[fut]
+                try:
+                    out[(round(c["lat"], 3), round(c["lon"], 3))] = fut.result()
+                except Exception as exc:
+                    log.debug("batch settlement failed (%.4f, %.4f): %s",
+                              c["lat"], c["lon"], exc)
+    else:
+        for c in reps:
+            out[(round(c["lat"], 3), round(c["lon"], 3))] = _settlement(c["lat"], c["lon"])
+    return out, idx
 
 
 def _jit_geocode_candidates(
@@ -2226,11 +2252,15 @@ def _jit_geocode_candidates(
       Reached when Tiers 1-2 produced no name. _OVER_WATER → candidate discarded;
       None → coordinate fallback used.
 
-    Concurrency: the public Nominatim instance (local backend) forbids parallel/bulk
-    access, so it keeps the lazy serial path. On the aws backend (AWS Location, no
-    per-second policy) the Tier-3 calls for a priority-ordered prefix of candidates
-    are prefetched in parallel up front and the loop reads names from memory — see
-    _parallel_prefetch_settlements and _PREFETCH_CANDIDATE_PREFIX.
+    Concurrency: both backends walk the exact same lazy, on-demand algorithm — a
+    small forward-looking batch of Tier-3 candidates is resolved just before the
+    loop needs the first one in it (see _lazy_batch_settlements), never further
+    ahead than that, so which candidates get named is identical either way. Only
+    batch_size differs: _GEOCODE_MAX_WORKERS (resolved in parallel) on the aws
+    backend (AWS Location has no per-second policy), 1 (serial) on local — the
+    public Nominatim instance forbids parallel/bulk access, and batch_size=1
+    degenerates to exactly one _settlement() call per candidate, in order, with
+    no look-ahead at all.
 
     Dedup: each unique name appears at most once. Tier-3 candidates also get a spatial
     pre-dedup (see _NAME_DEDUP_MILES) that skips a candidate adjacent to an
@@ -2240,18 +2270,11 @@ def _jit_geocode_candidates(
     dark_clusters: list = []
     kept_coords: list[tuple[float, float]] = []   # (lat, lon) of accepted results
 
-    # On backends with no per-second policy (AWS Location), fetch the Tier-3 names
-    # concurrently so the loop below resolves them from memory instead of one serial
-    # network round-trip per candidate. Only a priority-ordered prefix is prefetched
-    # (see _PREFETCH_CANDIDATE_PREFIX) — the loop below stops at max_results long
-    # before it would walk the full candidate list, so prefetching past that point
-    # was paying for representatives it was never going to reach. Empty on the
-    # local/Nominatim backend.
-    prefetch = (_parallel_prefetch_settlements(
-                    candidates[:_PREFETCH_CANDIDATE_PREFIX], padus_index, natural_areas)
-                if ports.get_backend()._name == "aws" else {})
+    batch_size = _GEOCODE_MAX_WORKERS if ports.get_backend()._name == "aws" else 1
+    resolved: dict = {}
+    scan_idx = 0   # how far _lazy_batch_settlements has scanned candidates so far
 
-    for c in candidates:
+    for i, c in enumerate(candidates):
         lat, lon = c["lat"], c["lon"]
         kind, name = _offline_tier_name(c, padus_index, natural_areas)
         if kind == "discard":
@@ -2267,9 +2290,15 @@ def _jit_geocode_candidates(
                    for klat, klon in kept_coords):
                 continue
             key = (round(lat, 3), round(lon, 3))
-            # Prefetched on aws; otherwise (local, or a non-representative pixel whose
-            # rep was dropped) fall back to a single direct call.
-            name = prefetch[key] if key in prefetch else _settlement(lat, lon)
+            if key not in resolved:
+                more, scan_idx = _lazy_batch_settlements(
+                    candidates, max(scan_idx, i), kept_coords, batch_size,
+                    padus_index, natural_areas)
+                resolved.update(more)
+            # A miss here means this candidate's spatial eligibility changed between
+            # being batch-scanned and the loop reaching it (see _lazy_batch_settlements'
+            # docstring) — falls back to a single direct call, same as before.
+            name = resolved[key] if key in resolved else _settlement(lat, lon)
             if name == _OVER_WATER:
                 continue
             if not name:
@@ -2675,7 +2704,7 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
         areas_thread.start()
 
     # Name light domes. AWS Location has no per-second policy, so geocode them
-    # concurrently (like _parallel_prefetch_settlements); public Nominatim (local
+    # concurrently (like _lazy_batch_settlements); public Nominatim (local
     # backend) stays serial per its usage policy. Names/order are unchanged.
     with prof.phase("dome naming (geocode)"):
         if dome_clusters:

--- a/docs/PERF_FINDNEARBY.md
+++ b/docs/PERF_FINDNEARBY.md
@@ -50,10 +50,12 @@ here, all shipped and still in effect:
 - **Reverse-geocode discipline.** 8-mile pre-dedup of candidate probes
   (`_NAME_DEDUP_MILES`), POI/PAD-US-index-first naming, a 16-point-compass
   directional pre-dedup of dome candidates before naming (`_dedup_domes_by_direction`,
-  2026-08-16 entry), a priority-ordered prefix cap on the dark-candidate Tier-3
-  prefetch (`_PREFETCH_CANDIDATE_PREFIX`, 2026-08-16 entry), and — on the aws
-  backend only — parallel AWS Location calls (~87 ms each in-region) with a
-  pooled client. The local backend stays serial per Nominatim's 1 req/s policy.
+  2026-08-16 entry), and a lazy, backend-unified batch resolver for dark-candidate
+  Tier-3 naming (`_lazy_batch_settlements`, 2026-08-16 entry, reworked same day):
+  both backends run the identical scan/gate/resolve loop, resolving only as far
+  ahead as the next batch, never the whole candidate pool — the only backend
+  difference is batch width (1 = serial on local, per Nominatim's no-parallel
+  policy; `_GEOCODE_MAX_WORKERS` = parallel on aws, which has no per-second limit).
 - **Absolute-grid-anchored pixel labels.** Dome and dark-candidate pixel lat/lon
   labels are built from the raster's fixed absolute grid origin (`_window_pixel_grid`)
   instead of each window's own bounds, so the reverse-geocode cache key for a given
@@ -382,18 +384,26 @@ all shipped here:
    volume on its own, ~38% combined with fix #2 above (dome-side only; #1's
    cache-hit-rate benefit is separate and additive). `_dome_search =
    origin_bortle <= 6` (was `<= 7`).
-4. **Dark-candidate Tier-3 prefetch capped to a priority-ordered prefix.**
-   `_parallel_prefetch_settlements` resolved every Tier-3 representative in the
-   entire up-to-60-candidate band-selected list before the main loop in
-   `_jit_geocode_candidates` even started walking toward `_MAX_RESULTS=10`.
-   Measured on 25 real origins: 50.9% of prefetched calls were never consumed
-   (234 prefetched, 115 actually needed), 100% of the waste on international
-   searches (0 of 13 US origins in that batch needed any Tier-3 call vs. 12 of
-   12 international, averaging 19.5 each). Capped to the first
-   `_PREFETCH_CANDIDATE_PREFIX=25` candidates; a candidate beyond the cap that
-   the loop still reaches falls back to the existing direct `_settlement()`
-   call on a prefetch-map miss, so this is a call-volume cut, not a behavior
-   change.
+4. **Dark-candidate Tier-3 naming unified across backends, on-demand.**
+   `_parallel_prefetch_settlements` used to resolve every Tier-3 representative
+   in the entire up-to-60-candidate band-selected list before the main loop in
+   `_jit_geocode_candidates` even started walking toward `_MAX_RESULTS=10` — and
+   only ran on the aws backend at all, so local dev never exercised the same
+   code path. Measured on 25 real origins: 50.9% of those eager calls were never
+   consumed (234 prefetched, 115 actually needed), 100% of the waste on
+   international searches (0 of 13 US origins in that batch needed any Tier-3
+   call vs. 12 of 12 international, averaging 19.5 each). First fix (shipped,
+   then reworked same day): capped the prefetch to a static 25-candidate prefix.
+   Reworked into `_lazy_batch_settlements`: both backends now run the identical
+   scan/gate/resolve loop, resolving a batch of up to `batch_size` upcoming
+   Tier-3 candidates only right before the loop needs the first one in it, never
+   further ahead — so which candidates get named is backend-independent, proven
+   directly by `test_local_and_aws_backends_name_identical_candidates`. Only
+   `batch_size` differs: 1 (serial, one `_settlement()` call per candidate, no
+   look-ahead — exactly local's original behavior) on local, `_GEOCODE_MAX_WORKERS`
+   (parallel) on aws. A candidate whose spatial eligibility drifts between being
+   batch-scanned and the loop reaching it still falls back to a direct
+   `_settlement()` call, same safety net as before.
 5. **Shared, short-TTL cache for `/suggest`.** `_suggest_cached` was an
    in-process `functools.lru_cache` only — no benefit across different warm
    containers or after a cold start. Added a second tier on the existing

--- a/tests/test_jit_geocoding.py
+++ b/tests/test_jit_geocoding.py
@@ -128,40 +128,104 @@ def test_jit_loop_keeps_rural_candidates():
 
 
 # ---------------------------------------------------------------------------
-# aws-backend prefetch cap (_PREFETCH_CANDIDATE_PREFIX)
+# Backend-unified lazy batch resolution (_lazy_batch_settlements)
 # ---------------------------------------------------------------------------
+# _jit_geocode_candidates runs the exact same scan/gate/resolve algorithm on
+# both backends; only the batch width passed to _lazy_batch_settlements
+# differs (1 = serial on local, per Nominatim's no-parallel policy;
+# _GEOCODE_MAX_WORKERS = parallel on aws, which has no per-second limit).
 
-def test_aws_backend_prefetch_capped_to_priority_prefix():
-    """On the aws backend, only a priority-ordered prefix of the (up to
-    60-candidate) band-selected pool is handed to the parallel prefetch —
-    not the full list. Candidates beyond the prefix still get named correctly
-    via the existing per-candidate _settlement() fallback (proven here by
-    forcing the prefetch mock to return no names at all)."""
+def test_batch_size_is_one_on_local_geocode_workers_on_aws():
+    """The only backend-specific knob in the naming loop is batch_size."""
+    from darkhours import darksky as ds
+
+    candidates = [
+        {"lat": 40.0 + i, "lon": -100.0, "bortle_class": 3, "sqm": 21.0,
+         "distance_miles": float(i)}
+        for i in range(5)
+    ]
+    seen_batch_sizes = []
+
+    def _spy(cands, start_idx, kept_coords, batch_size, padus_index, natural_areas):
+        seen_batch_sizes.append(batch_size)
+        return {}, len(cands)
+
+    with patch.object(ds, "_lazy_batch_settlements", side_effect=_spy), \
+         patch.object(ds, "_settlement", return_value="Somewhere"):
+        ds._jit_geocode_candidates(candidates, max_results=10)
+    assert seen_batch_sizes and all(bs == 1 for bs in seen_batch_sizes)
+
+    fake_backend = type("FakeBackend", (), {"_name": "aws"})()
+    seen_batch_sizes.clear()
+    with patch.object(ds.ports, "get_backend", return_value=fake_backend), \
+         patch.object(ds, "_lazy_batch_settlements", side_effect=_spy), \
+         patch.object(ds, "_settlement", return_value="Somewhere"):
+        ds._jit_geocode_candidates(candidates, max_results=10)
+    assert seen_batch_sizes and all(bs == ds._GEOCODE_MAX_WORKERS for bs in seen_batch_sizes)
+
+
+def test_local_and_aws_backends_name_identical_candidates():
+    """The core claim: which candidates get named, in what order, and what's
+    returned is backend-independent — batch_size only changes how many of a
+    batch's _settlement() calls happen in parallel vs serially, not which
+    candidates end up resolved or kept."""
+    from darkhours import darksky as ds
+
+    candidates = [
+        {
+            "lat": 34.0 + i * 0.3, "lon": -110.0 + i * 0.3,
+            "bortle_class": 3, "sqm": 21.0, "distance_miles": float(i),
+        }
+        for i in range(30)
+    ]
+
+    def _settle(lat, lon):
+        return f"Town {round(lat, 1)}"
+
+    with patch.object(ds, "_settlement", side_effect=_settle):
+        local_result = ds._jit_geocode_candidates(
+            [dict(c) for c in candidates], max_results=10)
+
+    fake_backend = type("FakeBackend", (), {"_name": "aws"})()
+    with patch.object(ds.ports, "get_backend", return_value=fake_backend), \
+         patch.object(ds, "_settlement", side_effect=_settle):
+        aws_result = ds._jit_geocode_candidates(
+            [dict(c) for c in candidates], max_results=10)
+
+    assert len(local_result) == 10
+    assert [c["name"] for c in local_result] == [c["name"] for c in aws_result]
+    assert ([(c["lat"], c["lon"]) for c in local_result]
+            == [(c["lat"], c["lon"]) for c in aws_result])
+
+
+def test_aws_backend_does_not_resolve_beyond_what_is_needed():
+    """On aws, batching still stops once the loop is satisfied — it doesn't
+    eagerly resolve the full candidate pool up front (the previous eager,
+    prefix-capped prefetch's failure mode)."""
     from darkhours import darksky as ds
 
     candidates = [
         {
             "lat": 40.0 + i * 0.5, "lon": -100.0 + i * 0.5,
             "bortle_class": 3, "sqm": 21.0, "distance_miles": float(i),
-            "direction": "N", "priority_score": float(i),
         }
         for i in range(60)
     ]
+    settle_calls = []
+
+    def _settle(lat, lon):
+        settle_calls.append((lat, lon))
+        return f"City {lat:.2f}"
 
     fake_backend = type("FakeBackend", (), {"_name": "aws"})()
     with patch.object(ds.ports, "get_backend", return_value=fake_backend), \
-         patch.object(ds, "_parallel_prefetch_settlements", return_value={}) as mock_prefetch, \
-         patch.object(ds, "_settlement", side_effect=lambda lat, lon: f"City {lat:.2f}"):
+         patch.object(ds, "_settlement", side_effect=_settle):
         result = ds._jit_geocode_candidates(candidates, max_results=10)
 
-    mock_prefetch.assert_called_once()
-    prefetch_input = mock_prefetch.call_args[0][0]
-    assert len(prefetch_input) == ds._PREFETCH_CANDIDATE_PREFIX
-    assert prefetch_input == candidates[:ds._PREFETCH_CANDIDATE_PREFIX]
-    # Loop output unaffected by the cap — every result still got a real name
-    # via the direct _settlement() fallback (prefetch returned nothing).
     assert len(result) == 10
-    assert all(c["name"].startswith("City ") for c in result)
+    # Some batching overshoot is expected (a batch resolves _GEOCODE_MAX_WORKERS
+    # candidates at a time), but nowhere near the full 60-candidate pool.
+    assert len(settle_calls) < 30
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The dark-candidate Tier-3 naming path used to run genuinely different code
  on the two backends: an eager, capped-prefix parallel prefetch on `aws`
  only, vs. fully lazy one-at-a-time resolution on `local` (which never
  exercised the prefetch path at all).
- Replaces both with `_lazy_batch_settlements`: a single scan/gate/resolve
  algorithm both backends run identically, resolving a small forward-looking
  batch of Tier-3 candidates only right before the main loop needs the first
  one in it — never further ahead. The only thing that still differs between
  backends is batch width: 1 (serial, no look-ahead) on local — matching
  Nominatim's no-parallel policy and exactly reproducing local's original
  behavior — vs `_GEOCODE_MAX_WORKERS` (parallel) on aws, which has no
  per-second limit.
- Net effect: which candidates get named, in what order, is now provably
  identical on both backends. The only remaining difference is which
  provider actually answers the call (Nominatim vs. AWS Location) and
  whether that happens serially or in parallel — not the algorithm around it.

## Test plan

- [x] Full test suite passes (917 tests, offline/deterministic)
- [x] New test asserts local and aws backends name an identical candidate
      list in an identical order (`test_local_and_aws_backends_name_identical_candidates`)
- [x] New test confirms batch width is the only backend-specific parameter
      passed into the shared resolver
- [x] New test confirms aws still stops well short of resolving the full
      candidate pool (replaces the old prefix-cap test, which tested a
      mechanism this PR removes)
- [x] Verified against the real aws backend: a POI-covered US search
      (unaffected, as expected) and an international search that genuinely
      exercises Tier-3 naming (Verona, IT) — correct, real place names, no
      errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
