### PR TITLE
Activate operator feature flags in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,4 +75,5 @@ jobs:
           PYNIGHTSKY_BLOG_BUCKET: ${{ secrets.PYNIGHTSKY_BLOG_BUCKET }}
           AQICN_TOKEN: ${{ secrets.AQICN_TOKEN }}
           PYNIGHTSKY_PROVIDER_HEALTH_TABLE: ${{ secrets.PYNIGHTSKY_PROVIDER_HEALTH_TABLE }}
+          PYNIGHTSKY_FEATURE_FLAGS_TABLE: ${{ secrets.PYNIGHTSKY_FEATURE_FLAGS_TABLE }}
         run: cdk deploy PyNightSkyLambda --require-approval never


### PR DESCRIPTION
## Summary

Phase 2 of the staged rollout described in `docs/FEATURE_FLAGS.md`. #202 shipped
the flag-checking code with `PYNIGHTSKY_FEATURE_FLAGS_TABLE` unset, so every
`feature_flags.enabled()` call returns its default unconditionally — verified
live after that deploy (`/healthz` showed `"feature_flags":{}`, full `/night`
report worked normally).

This wires the already-deployed `PyNightSkyFeatureFlags` table's name into
`PyNightSkyLambda`'s deploy env, via a new repo secret
(`PYNIGHTSKY_FEATURE_FLAGS_TABLE`, already set) — same pattern already used for
`PYNIGHTSKY_PROVIDER_HEALTH_TABLE`. Only after this merges do the API and worker
Lambdas actually start reading the table.

## Why

Not a code change — this is the activation switch for the runtime feature-flag
system, kept as its own deploy so the code (#202) and the activation aren't
bundled into one all-or-nothing change, per the rollout plan.

## Test plan

- [x] `PyNightSkyFeatureFlags` table deployed and confirmed working (`cdk deploy`,
      `scripts/local-flags/*.sh` exercised against it — real writes/reads).
- [x] `PYNIGHTSKY_FEATURE_FLAGS_TABLE` secret set in the repo.
- [ ] After merge: confirm `/healthz`'s `feature_flags` starts reflecting real
      reads, confirm the API/worker Lambda roles only got a `GetItem` grant (no
      write actions), confirm a real flag flip via `scripts/local-flags/*.sh`
      changes live behavior within the ~30s cache window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)