### PR TITLE
Fix feature-flags cache: wall-clock time, not monotonic

### DIFF
--- a/darkhours/feature_flags.py
+++ b/darkhours/feature_flags.py
@@ -37,7 +37,7 @@ _ENABLED = _flag("PYNIGHTSKY_FEATURE_FLAGS_ENABLED", "1")
 _TABLE = os.environ.get("PYNIGHTSKY_FEATURE_FLAGS_TABLE", "").strip()
 
 _lock = threading.Lock()
-# flag name -> (enabled_or_None, fetched_at_monotonic). None results (miss/error)
+# flag name -> (enabled_or_None, fetched_at_wall_clock). None results (miss/error)
 # are cached too, so a broken table read costs its timeout once per TTL.
 _cache: dict[str, tuple[bool | None, float]] = {}
 _ddb_table = None
@@ -83,7 +83,15 @@ def reset() -> None:
 # --------------------------------------------------------------------------
 
 def _cached_value(name: str) -> bool | None:
-    now = time.monotonic()
+    # time.time(), not time.monotonic(): this cache must stay correct across a
+    # Lambda container's freeze/thaw between invocations, where the monotonic
+    # clock doesn't reliably advance while frozen — a container idle between
+    # sparse requests could otherwise never perceive the TTL as expired and get
+    # stuck serving a stale value indefinitely. Wall-clock time doesn't have
+    # that problem; it isn't used here to measure a duration within one
+    # continuous execution (where monotonic would be the right tool), only to
+    # answer "how long ago, in the real world, was this fetched."
+    now = time.time()
     with _lock:
         cached = _cache.get(name)
         if cached is not None and now - cached[1] < _CACHE_TTL_SECONDS:

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -11,7 +11,9 @@ from darkhours import feature_flags as ff
 
 
 class FakeClock:
-    """Controllable stand-in for time.monotonic."""
+    """Controllable stand-in for time.time() — wall-clock, not monotonic (see
+    _cached_value's docstring: monotonic doesn't reliably advance across a
+    Lambda container's freeze/thaw, so the cache deliberately uses time.time())."""
 
     def __init__(self, start=1_000.0):
         self.t = start
@@ -26,7 +28,7 @@ class FakeClock:
 @pytest.fixture
 def clock(monkeypatch):
     c = FakeClock()
-    monkeypatch.setattr(ff, "time", types.SimpleNamespace(monotonic=c))
+    monkeypatch.setattr(ff, "time", types.SimpleNamespace(time=c))
     ff.reset()
     yield c
     ff.reset()


### PR DESCRIPTION
## Summary

`darkhours/feature_flags.py`'s TTL cache used `time.monotonic()`. Found live,
post-activation (#203): after re-enabling a flag on the real table, several
already-warm Lambda containers kept serving the stale value for many minutes
past the documented ~30s TTL, while a container forced fresh via a config
touch read correctly on its very first try.

## Why

Lambda freezes a container's execution environment between invocations.
`time.monotonic()` doesn't reliably keep advancing while frozen, so a
container idle between sparse requests can perceive almost no time passing
and never expire its cache entry — worst case, stuck on a stale flag value
indefinitely. `time.time()` (wall-clock) doesn't have this problem.

Ruled out before landing on this, in order: bad write (direct
`aws dynamodb get-item` showed the correct value the whole time), wrong
table/env var (confirmed exact match on the deployed Lambda), CloudFront
edge caching (a guaranteed-unique cache-busted query string still reached
the origin per CloudWatch logs and was still stale), and a broken read path
(a forced-fresh container read correctly immediately).

Note: `darkhours/circuit_breaker.py` has the identical pattern for its own
DynamoDB-backed monitor cache — pre-existing, not touched here, lower
stakes there (delays recognizing a recovery signal vs. sticking a flag in
the wrong state). Left alone.

## Test plan

- [x] `python -m pytest -q` — 950 passed, 9 skipped, 0 failed.
- [x] `tests/test_feature_flags.py` updated to fake `time.time()` instead of
      `time.monotonic()`, all 16 pass.
- [ ] After merge/deploy: force-recycle Lambda containers, flip a flag on the
      real table, confirm it now actually propagates within ~30s without
      needing a forced cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)