### PR TITLE
Fix uncaught Starlink TLE fetch failure crashing /night

### DIFF
--- a/darkhours/predictor.py
+++ b/darkhours/predictor.py
@@ -796,7 +796,11 @@ def assemble_night(
                                  _tle_result.lines, lat, lon, sunset, sunrise),
                 ))
             if _sl_future is not None:
-                _sl_tles, _, _sl_error = _sl_future.result()
+                try:
+                    _sl_tles, _, _sl_error = _sl_future.result()
+                except Exception as _sfe:
+                    log.debug("starlink TLE fetch failed (non-fatal): %s", _sfe)
+                    _sl_tles, _sl_error = [], str(_sfe)
                 if _sl_error and not _sl_tles:
                     sat_starlink_unavailable = True
                 elif _sl_tles:

--- a/darkhours/tle_provider.py
+++ b/darkhours/tle_provider.py
@@ -382,6 +382,18 @@ def get_starlink_train_tles(
                         log.warning("%s", err_msg)
                         _ph.record("celestrak", "error", str(e.reason)[:120])
                         _cb.on_failure("celestrak")
+                    except Exception as e:
+                        # A read timeout mid-response (e.g. ssl.SSLSocket.read()) raises a
+                        # raw TimeoutError, not urllib.error.URLError — urllib only wraps
+                        # connect-phase failures, not read-phase ones. Catch anything else
+                        # here too: this function's contract is "return (tles, stale,
+                        # error), never raise" (see get_tle()'s matching broad except),
+                        # and an uncaught exception here previously crashed the entire
+                        # /night response for callers that don't expect this to raise.
+                        err_msg = f"Celestrak Starlink group fetch failed: {e}"
+                        log.warning("%s", err_msg)
+                        _ph.record("celestrak", "error", str(e)[:120])
+                        _cb.on_failure("celestrak")
 
     if raw is None:
         # 3. Stale fallback — always try this; on 403 the stale data IS current

--- a/tests/test_predictor_feature_flags.py
+++ b/tests/test_predictor_feature_flags.py
@@ -93,6 +93,21 @@ def test_satellites_flag_on_by_default_still_fetches(monkeypatch, _mocks):
     monkeypatch.setattr(tle_provider, "get_tle", get_tle)
     monkeypatch.setattr(tle_provider, "get_starlink_train_tles", get_starlink)
     _assemble(_mocks, fetch_weather=False, fetch_satellites=True)
+
+
+def test_starlink_fetch_raising_does_not_crash_the_report(monkeypatch, _mocks):
+    """Not a feature-flag test — a resilience gap found live in production (a
+    Celestrak read timeout raised out of get_starlink_train_tles() and crashed the
+    whole /night response, tel_provider.py fixed at the source separately). This is
+    the defense-in-depth layer: even an unanticipated future failure mode here must
+    not take down weather/moon/darksky, which had already succeeded."""
+    get_tle = mock.MagicMock(return_value=types.SimpleNamespace(lines=None, stale=False))
+    get_starlink = mock.MagicMock(side_effect=TimeoutError("The read operation timed out"))
+    monkeypatch.setattr(tle_provider, "get_tle", get_tle)
+    monkeypatch.setattr(tle_provider, "get_starlink_train_tles", get_starlink)
+    report = _assemble(_mocks, fetch_weather=False, fetch_satellites=True)
+    assert report.sat_starlink_unavailable is True
+    assert report.starlink_trains == []
     assert get_tle.called
 
 

--- a/tests/test_tle_provider.py
+++ b/tests/test_tle_provider.py
@@ -403,3 +403,17 @@ class TestCircuitBreaker:
         assert stale is False
         assert error is not None
         assert "unreachable" in error.lower()
+
+    def test_starlink_group_read_timeout_does_not_raise(self):
+        """A read-phase timeout (e.g. ssl.SSLSocket.read() mid-response) raises a raw
+        TimeoutError, not urllib.error.URLError — urllib only wraps connect-phase
+        failures. Confirmed live in production: this previously propagated uncaught
+        out of get_starlink_train_tles() and crashed the entire /night response."""
+        mc = self._mock_cache(get_val=None, stale_val=None)
+        with mock.patch.object(tle_mod, '_cache', mc), \
+             mock.patch.object(tle_mod._http, 'urlopen',
+                               side_effect=TimeoutError("The read operation timed out")):
+            tles, stale, error = tle_mod.get_starlink_train_tles()
+        assert tles == []
+        assert stale is False
+        assert error is not None and "timed out" in error.lower()


### PR DESCRIPTION
## Summary

Found live while verifying #204 in production: a real `500` on `/night`.
Full traceback (CloudWatch) showed a Celestrak read timeout mid-response
raising a raw `TimeoutError` out of `get_starlink_train_tles()`, uncaught,
crashing the entire response even though weather/moon/darksky had already
succeeded.

**Root cause**: `urlopen()` only wraps *connect-phase* socket errors as
`urllib.error.URLError`; a timeout while *reading* the response body (past
`response.begin()`) raises a raw `TimeoutError` that slips past an except
clause listing only `HTTPError`/`URLError`. `get_tle()` (the individual-
satellite fetch — ISS, Tiangong, Hubble) already uses a broad
`except Exception`, so it was never at risk; only the Starlink-group
fetch had the narrower clause.

## Fix (two layers)

1. `darkhours/tle_provider.py`: broadened `get_starlink_train_tles()`'s
   except to also catch anything else, matching `get_tle()`'s existing
   "return `(tles, stale, error)`, never raise" contract — the same
   provider-health/circuit-breaker signaling as the existing branches.
2. `darkhours/predictor.py`: defense-in-depth `try/except` around the
   `.result()` collection, matching the pattern already used for every
   neighboring satellite-collection call site in the same function.

Confirmed live (twice, ~2 min apart) that the same request now returns a
normal `200` even under real Celestrak slowness, instead of intermittently
`500`ing.

## Test plan

- [x] `python -m pytest -q` — 952 passed, 9 skipped, 0 failed.
- [x] New test reproducing the exact production failure:
      `test_starlink_group_read_timeout_does_not_raise` (`tle_provider`
      returns a graceful tuple instead of raising on a raw `TimeoutError`).
- [x] New defense-in-depth test:
      `test_starlink_fetch_raising_does_not_crash_the_report` (`assemble_night()`
      degrades gracefully even if the Starlink fetch raises for some other,
      unanticipated reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)