### PR TITLE
Bump nanoid to fix high-severity DoS (CVE-2026-67213)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -2514,9 +2514,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- Fixes Dependabot alert #8 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high severity): `nanoid`'s `customAlphabet`/`customRandom` spin in an infinite loop when given size `0`, a DoS vector.
- `nanoid` is a transitive dependency of `postcss` (build-time only — used by Vite, never shipped to the browser bundle). Bumped `3.3.16` -> `3.3.18`, the latest patch in postcss's existing `^3.3.16` range, so no other lockfile changes were needed.

## Test plan

- [x] `npm update nanoid` inside `apps/web`, confirmed resolved version is `3.3.18`
- [x] `npm audit` no longer lists `nanoid` (one unrelated pre-existing high-severity finding, `brace-expansion`, is out of scope for this PR)
- [x] `npm run build:client` — builds clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)