### PR TITLE
Bump brace-expansion to fix high-severity DoS

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1541,16 +1541,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## Summary

- Fixes the other high-severity `npm audit` finding flagged alongside the nanoid one: `brace-expansion` has two chained DoS advisories in versions `>=4.0.0 <5.0.9` — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (unbounded expansion length, OOM crash) and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (unbounded intermediate arrays, bypasses the first fix).
- `brace-expansion` is a transitive dev dependency of `minimatch` (build-time only, never shipped to the browser bundle). Bumped `5.0.7` -> `5.0.9`, already within minimatch's own `^5.0.5` range, so no other lockfile changes were needed.
- Independent of and unrelated to #207 (the nanoid fix) — separate dependency chain, can merge in either order.

## Test plan

- [x] `npm update brace-expansion` inside `apps/web`, confirmed resolved version is `5.0.9`
- [x] `npm audit` no longer lists `brace-expansion`
- [x] `npm run build:client` — builds clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)