### PR TITLE
Fix Lighthouse accessibility findings (89 -> 100)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -331,13 +331,17 @@ export default function App() {
         </h1>
       </header>
 
+      <main>
       <form className="card query" onSubmit={onSubmit}>
         <div className="location-header">
-          <div className="mode-toggle" role="tablist" aria-label="Location input mode">
+          {/* Not a role="tablist": "Use my location" is an action button, not a
+              third tab, and mixing the two breaks the ARIA tabs contract
+              (a tablist's children must all be role="tab"). role="group" plus
+              aria-pressed on the two mode buttons describes this correctly. */}
+          <div className="mode-toggle" role="group" aria-label="Location input mode">
             <button
               type="button"
-              role="tab"
-              aria-selected={mode === 'place'}
+              aria-pressed={mode === 'place'}
               className={mode === 'place' ? 'active' : ''}
               onClick={() => setMode('place')}
             >
@@ -354,8 +358,7 @@ export default function App() {
             </button>
             <button
               type="button"
-              role="tab"
-              aria-selected={mode === 'coords'}
+              aria-pressed={mode === 'coords'}
               className={mode === 'coords' ? 'active' : ''}
               onClick={() => setMode('coords')}
             >
@@ -754,6 +757,7 @@ export default function App() {
           />
         </Suspense>
       )}
+      </main>
 
       {/* Hidden while loading: this is the last element on the page, so
           showing/hiding it never displaces anything else, but leaving it

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13,7 +13,7 @@
   /* ── Typography ─────────────────────────────────────────────── */
   --text-h: #111316;       /* Near-black heading ink */
   --text: #3B4455;         /* Dark gray body text */
-  --text-dim: #6B7585;     /* Dim labels, captions, metadata */
+  --text-dim: #565E6A;     /* Dim labels, captions, metadata — 4.5:1+ on --card and --field-bg */
   --accent: #4A5EA8;       /* Sun blue */
 
   /* ── Semantic Data ──────────────────────────────────────────── */

--- a/apps/web/src/styles/07-targets-milkyway.css
+++ b/apps/web/src/styles/07-targets-milkyway.css
@@ -851,7 +851,6 @@ html.red-mode .tg-blocked-toggle:hover { color: var(--text); }
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--text-dim);
-  opacity: 0.65;
 }
 .colophon-sources {
   color: var(--text-dim);
@@ -864,5 +863,4 @@ html.red-mode .tg-blocked-toggle:hover { color: var(--text); }
   margin: 0;
   font-size: 11px;
   color: var(--text-dim);
-  opacity: 0.7;
 }

--- a/apps/web/src/styles/09-empty-state.css
+++ b/apps/web/src/styles/09-empty-state.css
@@ -65,7 +65,6 @@
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--text-dim);
-  opacity: 0.65;
 }
 .es-quickstart-btns {
   display: flex;
@@ -118,7 +117,6 @@
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--text-dim);
-  opacity: 0.65;
   margin: 0 0 -6px;
 }
 html.red-mode .es-caps-label { color: var(--text-dim); }


### PR DESCRIPTION
## Summary

- **aria-required-children**: location-mode tablist mixed an action button in with the tabs. Switched to `role="group"` + `aria-pressed`.
- **landmark-one-main**: wrapped content in `<main>`.
- **color-contrast**: `--text-dim` was 3.49:1 (needs 4.5:1); darkened to `#565E6A`. Four labels also applied extra opacity on top, diluting it back below threshold — removed.

## Test plan

- [x] `npm run build:client`
- [x] Lighthouse accessibility audit against local production build: 5 failing -> 0, score 89 -> 100
- [x] Visual check, no layout regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)