### PR TITLE
Stop the Google Fonts stylesheet from blocking first paint

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -83,7 +83,20 @@
          first-ever visit if the download isn't ~instant, instead of a swap
          that reflows already-painted text; once cached (every later visit)
          it applies immediately with nothing to swap. -->
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=optional" rel="stylesheet">
+    <!-- Loaded as preload + swap-to-stylesheet, not a plain blocking <link
+         rel="stylesheet">: that was ~1s of PageSpeed's render-blocking-requests
+         budget for a stylesheet that only affects font rendering, which
+         display=optional above already makes non-critical. The swap can't use
+         the usual onload="this.rel='stylesheet'" attribute — the CSP's
+         script-src has no 'unsafe-inline' (see analytics-init.js) — so
+         font-loader.js does it instead. Deferred: font-loader.js has its own
+         timeout fallback (the preload "load" event isn't reliable enough to
+         depend on alone), so it doesn't need to block parsing to attach in
+         time — and running it synchronously just made it render-blocking
+         instead of the stylesheet it was replacing. -->
+    <link rel="preload" as="style" id="gfont-preload" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=optional">
+    <script defer src="/font-loader.js"></script>
+    <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=optional" rel="stylesheet"></noscript>
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-dNdadDzL5KmlgdiqqJYJx.js"></script>
     <script defer src="/analytics-init.js"></script>

--- a/apps/web/public/font-loader.js
+++ b/apps/web/public/font-loader.js
@@ -1,0 +1,18 @@
+// Applies the preloaded Google Fonts stylesheet (index.html) without it being
+// a render-blocking <link rel="stylesheet">. Loaded with `defer` in
+// index.html — that's safe here specifically because of the timeout below:
+// the preload's "load" event isn't reliable enough across browsers/network
+// conditions to depend on alone, so this also force-applies on a timer as a
+// fallback. Guarded so it only runs once regardless of which fires first.
+(function () {
+  var link = document.getElementById('gfont-preload')
+  if (!link) return
+  var applied = false
+  var apply = function () {
+    if (applied) return
+    applied = true
+    link.rel = 'stylesheet'
+  }
+  link.addEventListener('load', apply)
+  setTimeout(apply, 3000)
+})()


### PR DESCRIPTION
## Summary

PageSpeed's render-blocking-requests finding (~1s combined, app CSS + font CSS). App's own CSS correctly stays blocking. Font stylesheet switched to preload + swap via `font-loader.js` — can't use `onload=` (CSP has no `unsafe-inline` in script-src), so the swap happens in an external script with a 3s timeout fallback since preload's `load` event isn't reliable enough alone. `display=optional` (already in place) means a late swap doesn't cause reflow.

Also tried bumping Vite's build target for the "Legacy JavaScript" finding in the AWS RUM bundle — reverted, byte-identical output, that code is baked into the pre-built vendor dist rather than something our build re-transpiles.

## Test plan

- [x] `npm run build:client`
- [x] Font still applies (`document.fonts`, link `rel` flips to `stylesheet`)
- [x] Lighthouse: font stylesheet no longer in render-blocking-insight, only app CSS remains (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)