### PR TITLE
Hydrate the prerendered homepage instead of discarding it

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,9 +1,21 @@
 import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { hydrateRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
+// hydrateRoot, not createRoot: scripts/prerender.mjs bakes a real server-
+// rendered snapshot into dist/index.html specifically so first paint doesn't
+// wait on JS. createRoot ignores that markup and rebuilds the DOM from
+// scratch once React loads — the prerendered text was still painting fast,
+// but Lighthouse (and real users) saw that get thrown away and redone a
+// beat later, which is most of what LCP's "element render delay" was
+// measuring here (~3.3s of it, confirmed via PageSpeed's LCP breakdown).
+// For a deep-linked report URL the client's first render differs from the
+// prerendered (always-empty-state) snapshot — hydrateRoot detects that
+// mismatch and falls back to a client re-render for that case, same as
+// createRoot does today, so this only helps and never regresses.
+hydrateRoot(
+  document.getElementById('root')!,
   <StrictMode>
     <App />
   </StrictMode>,


### PR DESCRIPTION
## Summary

`main.tsx` used `createRoot`, which ignores the existing DOM and rebuilds from scratch — but `prerender.mjs` bakes a real server-rendered snapshot into `dist/index.html` specifically so first paint doesn't wait on JS. The text was painting fast, then getting discarded and redone once React loaded. PageSpeed's LCP breakdown attributed ~3.3s of "element render delay" to that second render.

Switched to `hydrateRoot`. For a deep-linked report URL, the client's first render differs from the prerendered (always-empty-state) snapshot — confirmed `hydrateRoot` detects that mismatch (React error #418 in console) and falls back to a full client re-render, same as `createRoot` did for every load before this change. That path is a no-op, not a regression.

## Test plan

- [x] `npm run build` (full client+ssr+prerender pipeline)
- [x] Bare homepage: no hydration errors, content renders correctly
- [x] Deep-linked URL: hydration mismatch logged and recovered gracefully, report renders correctly
- [ ] Local Lighthouse runs were too noisy on this machine for a reliable before/after (three runs on identical code: 4.6s / 1.6s / 4.4s element-render-delay) — verifying against a real PageSpeed run post-deploy, same approach as the CLS fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)