### PR TITLE
Fix LCP delay caused by font-loader.js's 3s stylesheet-swap fallback

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -83,18 +83,19 @@
          first-ever visit if the download isn't ~instant, instead of a swap
          that reflows already-painted text; once cached (every later visit)
          it applies immediately with nothing to swap. -->
-    <!-- Loaded as preload + swap-to-stylesheet, not a plain blocking <link
-         rel="stylesheet">: that was ~1s of PageSpeed's render-blocking-requests
-         budget for a stylesheet that only affects font rendering, which
-         display=optional above already makes non-critical. The swap can't use
-         the usual onload="this.rel='stylesheet'" attribute — the CSP's
-         script-src has no 'unsafe-inline' (see analytics-init.js) — so
-         font-loader.js does it instead. Deferred: font-loader.js has its own
-         timeout fallback (the preload "load" event isn't reliable enough to
-         depend on alone), so it doesn't need to block parsing to attach in
-         time — and running it synchronously just made it render-blocking
-         instead of the stylesheet it was replacing. -->
-    <link rel="preload" as="style" id="gfont-preload" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=optional">
+    <!-- Injected by font-loader.js instead of a plain blocking <link
+         rel="stylesheet"> here: that was ~1s of PageSpeed's render-blocking-
+         requests budget for a stylesheet that only affects font rendering,
+         which display=optional above already makes non-critical. Can't use
+         the usual preload+onload="this.rel='stylesheet'" swap — the CSP's
+         script-src has no 'unsafe-inline' (see analytics-init.js) so the
+         inline attribute is blocked, and DevTools tracing on production
+         showed Chrome never fires "load" on a rel=preload link while it's
+         still rel=preload, so a JS listener for it never fires either; only
+         a plain <link rel="stylesheet"> gets a reliable load event. Inserted
+         from a deferred script (not present in the parsed document) so it's
+         fetched and applied out of the critical rendering path without
+         needing preload or a swap step at all. -->
     <script defer src="/font-loader.js"></script>
     <noscript><link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=optional" rel="stylesheet"></noscript>
     <!-- Privacy-friendly analytics by Plausible -->

--- a/apps/web/public/font-loader.js
+++ b/apps/web/public/font-loader.js
@@ -1,18 +1,9 @@
-// Applies the preloaded Google Fonts stylesheet (index.html) without it being
-// a render-blocking <link rel="stylesheet">. Loaded with `defer` in
-// index.html — that's safe here specifically because of the timeout below:
-// the preload's "load" event isn't reliable enough across browsers/network
-// conditions to depend on alone, so this also force-applies on a timer as a
-// fallback. Guarded so it only runs once regardless of which fires first.
+// Injects the Google Fonts stylesheet from script (see index.html for why)
+// so it's fetched and applied without being render-blocking. Loaded with
+// `defer`, so this runs after the document has parsed.
 (function () {
-  var link = document.getElementById('gfont-preload')
-  if (!link) return
-  var applied = false
-  var apply = function () {
-    if (applied) return
-    applied = true
-    link.rel = 'stylesheet'
-  }
-  link.addEventListener('load', apply)
-  setTimeout(apply, 3000)
+  var link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;700&display=optional'
+  document.head.appendChild(link)
 })()


### PR DESCRIPTION
## Summary
- Root-caused the ~3.1-3.4s "Element render delay" LCP finding on `https://darkhours.app/` (mobile, PSI Slow 4G) to `font-loader.js`: the preload link's `load` event never fires while `rel=preload`, so every page load falls through to the 3s `setTimeout` fallback before the Google Fonts stylesheet activates -- and that activation's style recalc/repaint is what the browser's LCP algorithm anchors on for the homepage's marketing paragraph.
- Confirmed via real Chrome DevTools trace (Tracing CDP domain) and direct instrumentation of the preload link's `load` event on production.
- Replace the preload+swap dance with directly injecting a `<link rel="stylesheet">` from the deferred script -- no timer needed, stays non-render-blocking and CSP-safe.

## Test plan
- [x] Local production build (`npm run build`), verified via throttled Chrome trace (Lighthouse mobile profile: 1.6Mbps/750Kbps/150ms RTT, 4x CPU): real `p.es-body` LCP candidate moved from 3736ms (prod baseline) to 1104ms.
- [x] Confirmed Google Fonts stylesheet still applies (`document.styleSheets`), no console errors, no visual regression (screenshot).
- [x] `npm run build` clean; no new lint errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)