### PR TITLE
Fix React hydration mismatch from a stale prerendered date

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, lazy, Suspense, type FormEvent } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, lazy, Suspense, type FormEvent } from 'react'
 import './App.css'
 import { LocateFixed, ChevronLeft, ChevronRight, Clock, MapPin, X } from 'lucide-react'
 import { ApiRequestError, fetchNight, fetchSuggestions, type NightQuery } from './api'
@@ -44,7 +44,18 @@ export default function App() {
   const [place, setPlace] = useState('')
   const [lat, setLat] = useState('')
   const [lon, setLon] = useState('')
-  const [date, setDate] = useState(tonightIso())
+  // tonightIso() reads the visitor's local clock, which the static prerender
+  // can't know at build time -- seeding this from tonightIso() directly baked
+  // a build-time date into the prerendered HTML that drifts stale the moment
+  // real time moves past the last deploy (or just differs by timezone), so
+  // every hydration mismatched it against the client's real "today" and
+  // forced React to tear down and rebuild the whole form section (visible as
+  // a large layout shift). Empty string matches what the prerender emits
+  // (DatePicker and the availability calc below already treat a falsy date
+  // as "not chosen yet"), then the layout effect fixes it up synchronously
+  // before the first paint.
+  const [date, setDate] = useState('')
+  useLayoutEffect(() => { setDate(d => d || tonightIso()) }, [])
   const [scopeOpen, setScopeOpen] = useState(true)
   const [imperial, setImperial] = useState<boolean>(defaultImperial)
   const [locating, setLocating] = useState(false)


### PR DESCRIPTION
## Summary
- The date field's default was seeded via `tonightIso()` in `useState`, evaluated once at prerender/build time and again at hydration time -- any gap since the last deploy (always) makes these diverge, confirmed live as a real React error (#418, hydration text mismatch) on every homepage load, forcing React to discard and rebuild the date/form subtree.
- Fix follows React's documented pattern: seed with `''` (DatePicker and the availability calc already treat that as "not chosen yet"), correct to the real date in a `useLayoutEffect` so it's fixed before first paint.
- Checked this against the CLS report that originally flagged it: the mismatch repaint happens *before* first paint, which CLS's spec excludes -- confirmed with the real `web-vitals` library (CLS = 0 on production with the bug present). So this fixes a real bug (wrong date, wasted re-render, console error) but isn't expected to move the CLS number.

## Test plan
- [x] Local build: zero console errors on the bare homepage (previously threw #418 on every load), correct date shown immediately.
- [x] `tonightIso()`'s existing "before 6am rolls to previous night" logic is preserved -- correction happens client-side against the real local clock, same as before.
- [x] Verified via Chrome Coverage/PerformanceObserver that no visible flash occurs (useLayoutEffect fires before paint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)