### PR TITLE
Trim narration in perf-fix comments to the essential why

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,26 +1,14 @@
-# Two things that look like style but are not, and broke this file once each:
-#
-# 1. No blank line between "User-agent:" and its rules. A blank line terminates
-#    the group, orphaning every Disallow below it.
-# 2. No blanket "Allow: /". Everything is crawlable by default so it adds
-#    nothing, but it makes the Disallow rules ambiguous: Google resolves
-#    conflicts by longest match (Disallow wins) while first-match-wins parsers
-#    hand the blanket Allow the victory and ignore every Disallow.
-#
-# The Disallow list is the SPA's JSON endpoints (see apps/web/src/api.ts). They
-# return data, not pages, and nothing indexable depends on a crawler fetching
-# them: the shareable report URLs that call them (/?q=...&date=...) all
-# canonicalize to /. Real Googlebot was spending 22 of 156 requests there over
-# 18 days, against a crawl budget of roughly 15 requests a day, while /dark-sky/
-# and two of the three destination guides had never been fetched at all.
+# No blank line after User-agent (terminates the group) or blanket "Allow: /"
+# (creates Disallow ambiguity for first-match parsers) — both broke this file before.
 User-agent: *
 Disallow: /night
 Disallow: /suggest
 Disallow: /nearby
 Disallow: /calendar
 Disallow: /jobs
+# Above: SPA JSON endpoints (apps/web/src/api.ts), not pages — Googlebot was spending
+# 22/156 requests here over 18 days vs. ~15/day budget, while /dark-sky/ and 2 of 3
+# guides went uncrawled. Shareable URLs (/?q=...&date=...) canonicalize to / anyway.
 
-# One entry point. /sitemap.xml is a <sitemapindex> pointing at sitemap-pages.xml
-# plus the blog and dark-sky sitemaps published by their own repos' CI. Declaring
-# all three here separately let them drift out of sync with the index.
+# sitemap.xml is a sitemapindex; declaring sub-sitemaps here too let them drift.
 Sitemap: https://darkhours.app/sitemap.xml

--- a/apps/web/scripts/prerender.mjs
+++ b/apps/web/scripts/prerender.mjs
@@ -66,14 +66,10 @@ if (jsonLd.featureList.length !== FEATURES.length) {
 }
 const finalHtml = html.replace(jsonLdMatch[0], `${jsonLdMatch[1]}\n    ${JSON.stringify(jsonLd, null, 2)}\n    ${jsonLdMatch[3]}`)
 
-// main.tsx loads the ~80KB aws-rum-web chunk via setTimeout(() => import('./rum.ts'), 0)
-// so its parse/init doesn't compete with first render -- but that also means the
-// *network fetch* can't start until the main bundle has already loaded and executed,
-// serializing it behind the main bundle instead of racing it in parallel (confirmed via
-// Lighthouse's network-dependency-tree: this was the longest chain on the page). A
-// modulepreload hint fetches it in parallel with everything else while leaving the
-// setTimeout in main.tsx to control *when it runs* — fetchpriority="low" so it still
-// doesn't compete with anything that actually gates first render.
+// main.tsx's setTimeout(() => import('./rum.ts'), 0) delays the ~80KB rum-web
+// fetch behind the main bundle load+exec (was the longest network chain on the
+// page). This modulepreload fetches it in parallel instead, fetchpriority="low"
+// so it still doesn't compete with first render; setTimeout still controls when it runs.
 const rumChunk = readdirSync(join(webDir, 'dist', 'assets')).find((f) => /^rum-.*\.js$/.test(f))
 if (!rumChunk) {
   fail('could not find the built rum-*.js chunk in dist/assets — has main.tsx\'s RUM import changed?')

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,16 +44,10 @@ export default function App() {
   const [place, setPlace] = useState('')
   const [lat, setLat] = useState('')
   const [lon, setLon] = useState('')
-  // tonightIso() reads the visitor's local clock, which the static prerender
-  // can't know at build time -- seeding this from tonightIso() directly baked
-  // a build-time date into the prerendered HTML that drifts stale the moment
-  // real time moves past the last deploy (or just differs by timezone), so
-  // every hydration mismatched it against the client's real "today" and
-  // forced React to tear down and rebuild the whole form section (visible as
-  // a large layout shift). Empty string matches what the prerender emits
-  // (DatePicker and the availability calc below already treat a falsy date
-  // as "not chosen yet"), then the layout effect fixes it up synchronously
-  // before the first paint.
+  // Empty, not tonightIso(): the prerender can't know the visitor's local date,
+  // so seeding it here caused a hydration mismatch and full form-section reflow.
+  // DatePicker/availability already treat falsy as "not chosen"; the layout
+  // effect below fills the real date in synchronously before first paint.
   const [date, setDate] = useState('')
   useLayoutEffect(() => { setDate(d => d || tonightIso()) }, [])
   const [scopeOpen, setScopeOpen] = useState(true)
@@ -107,14 +101,10 @@ export default function App() {
     localStorage.setItem('units', imp ? 'imperial' : 'si')
   }
 
-  // Lazy-init from the URL so a deep-linked report (?q= or ?lat=&lon=, e.g. a
-  // shared "copy link" URL) never paints the marketing empty-state first: that
-  // block is ~2000px of Features/FAQ content, and briefly mounting it before
-  // the mount effect below flips loading to true was the largest source of
-  // real-user layout shift on this page (confirmed via Lighthouse mobile
-  // CPU/network throttling — see the loading-mount effect a few lines down).
-  // window is undefined during the SSR prerender (see entry-server.tsx), which
-  // must keep producing the empty-state view unconditionally, hence the guard.
+  // Lazy-init from the URL so a deep-linked report (?q= or ?lat=&lon=) skips
+  // briefly painting the ~2000px marketing empty-state first (was the largest
+  // source of real-user CLS). window is undefined during SSR prerender
+  // (entry-server.tsx), which must always produce the empty-state, hence the guard.
   const [loading, setLoading] = useState(() => {
     if (typeof window === 'undefined') return false
     const p = new URLSearchParams(window.location.search)

--- a/apps/web/src/ReportCard.tsx
+++ b/apps/web/src/ReportCard.tsx
@@ -17,17 +17,11 @@ import { LightDomePanel } from './report/LightDomePanel'
 
 const AUTO_CALENDAR_DAYS = 30
 
-// ReportCard fully unmounts and remounts on every /night fetch, including
-// same-location day navigation (App.tsx only renders it once `report` is set
-// and `loading` is false — see the `report && !loading` gate). Without this,
-// the effect below would re-hit /calendar on every single day-nav click. Cache
-// the in-flight promise (not just the settled result) at module scope, keyed
-// by location, so remounts for a location already loading/loaded reuse it —
-// this also collapses React StrictMode's dev-mode double-invoke into one call.
-// TTL matches the server's own weather cache freshness window (_WX_CACHE_TTL,
-// 30 min in predictor.py) — this is an in-memory, tab-lifetime cache with no
-// other invalidation, so without a TTL a long-lived tab would keep serving a
-// result computed hours/days ago even after the underlying data changes.
+// ReportCard remounts on every /night fetch incl. same-location day nav
+// (App.tsx's `report && !loading` gate), which would re-hit /calendar each
+// time. Module-scope promise cache, keyed by location, dedupes that (and
+// StrictMode's double-invoke). TTL matches server _WX_CACHE_TTL (30 min,
+// predictor.py) — no other invalidation, so a long-lived tab needs one.
 const _AUTO_CALENDAR_TTL_MS = 30 * 60 * 1000
 const _autoCalendarCache = new Map<string, { promise: Promise<CalendarResult>; at: number }>()
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,17 +3,9 @@ import { hydrateRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-// hydrateRoot, not createRoot: scripts/prerender.mjs bakes a real server-
-// rendered snapshot into dist/index.html specifically so first paint doesn't
-// wait on JS. createRoot ignores that markup and rebuilds the DOM from
-// scratch once React loads — the prerendered text was still painting fast,
-// but Lighthouse (and real users) saw that get thrown away and redone a
-// beat later, which is most of what LCP's "element render delay" was
-// measuring here (~3.3s of it, confirmed via PageSpeed's LCP breakdown).
-// For a deep-linked report URL the client's first render differs from the
-// prerendered (always-empty-state) snapshot — hydrateRoot detects that
-// mismatch and falls back to a client re-render for that case, same as
-// createRoot does today, so this only helps and never regresses.
+// hydrateRoot, not createRoot: reuses prerender.mjs's server-rendered snapshot
+// instead of discarding and rebuilding it (was ~3.3s of LCP). Deep-linked report
+// URLs still fall back to a client re-render on mismatch, as before.
 hydrateRoot(
   document.getElementById('root')!,
   <StrictMode>


### PR DESCRIPTION
## Summary
Several comments (robots.txt, main.tsx, App.tsx, prerender.mjs, ReportCard.tsx) read as investigation write-ups — citing how something was "confirmed via Lighthouse/PageSpeed" — rather than stating the constraint. Condensed each to keep the fact (the number, the reason, the past incident) and drop the narration, matching this repo's terser comment convention.

No functional changes.

## Test plan
- [x] Comment-only diff, no logic touched
- [x] `git diff` reviewed per file to confirm no code lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWMhiZ3tzJeSvJNgGjbyjb