### PR TITLE
Fix TS build break in MilkyWayAbsent's visible-band sort

### DIFF
--- a/apps/web/src/report/MilkyWay.tsx
+++ b/apps/web/src/report/MilkyWay.tsx
@@ -170,9 +170,10 @@ export function MilkyWayAbsent({ report: r, waypoints = [] }: { report: NightRep
     reason = 'Galactic core is below the horizon during tonight\'s dark window'
   }
 
+  const bestAlt = (t: VisibleTarget) => Math.max(...t.windows.map(w => w.peak_alt_deg ?? -Infinity))
   const visibleBand = waypoints.length > 0
     ? [...waypoints]
-        .sort((a, b) => Math.max(...b.windows.map(w => w.peak_alt_deg)) - Math.max(...a.windows.map(w => w.peak_alt_deg)))
+        .sort((a, b) => bestAlt(b) - bestAlt(a))
         .map(t => t.name)
         .join(', ')
     : null


### PR DESCRIPTION
## Summary
- `main`'s build is currently broken (deploy run [32526781698](https://github.com/mbeher2200/DarkHours/actions/runs/32526781698) failed at `tsc -b` before `cdk deploy` ran, so production itself is unaffected) — a fix I pushed straight to main used `Math.max(...windows.map(w => w.peak_alt_deg))`, but `peak_alt_deg` is `number | null`, which `npx tsc --noEmit` didn't catch locally but CI's `tsc -b` did.
- Coerces null altitudes to `-Infinity` before the `Math.max` sort comparator so waypoints with no altitude data sort last instead of breaking the type check.

## Test plan
- [x] `npx tsc -b` (apps/web) — clean, matches CI's exact command
- [x] `npm run build` (apps/web) — full client+ssr+prerender chain succeeds
- [x] `python -m pytest -q` — 952 passed, 9 skipped