### PR TITLE
Declare a urllib3 range and lock the _http.urlopen contract with tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,10 @@ geopy==2.5.0
 skyfield==1.55
 timezonefinder==8.2.5
 boto3==1.43.70
+# Pinned, not left transitive: botocore accepts urllib3 >=1.25.4,<3, so the
+# resolved major can differ between a dev venv and a deployed Lambda. That
+# split is the leading suspect for the Lambda-only failures that reverted the
+# _http connection pool (7adbe2d -> 522fe9a). Every direct use is in _http.py.
+urllib3==2.7.0
 global-land-mask>=1.0
 h3>=4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,13 @@ geopy==2.5.0
 skyfield==1.55
 timezonefinder==8.2.5
 boto3==1.43.70
-# Pinned, not left transitive: botocore accepts urllib3 >=1.25.4,<3, so the
-# resolved major can differ between a dev venv and a deployed Lambda. That
-# split is the leading suspect for the Lambda-only failures that reverted the
-# _http connection pool (7adbe2d -> 522fe9a). Every direct use is in _http.py.
-urllib3==2.7.0
+# Declared rather than left transitive: botocore accepts urllib3 >=1.25.4,<3, so
+# an undeclared urllib3 can resolve to a different major in a dev venv than in a
+# deployed Lambda -- the leading suspect for the Lambda-only failures that
+# reverted the _http connection pool (7adbe2d -> 522fe9a). The floor rules out
+# that split; the range still lets security patches land on the next deploy
+# rather than waiting on a bump. Declaring it is also what gets urllib3 into
+# Dependabot's weekly python-deps group at all. Every direct use is in _http.py.
+urllib3>=2.7,<3
 global-land-mask>=1.0
 h3>=4.5.0

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,234 @@
+"""
+Contract tests for _http.urlopen — the single choke point every outbound fetch
+goes through.
+
+These pin down exactly what the 12 call sites rely on, so the transport
+underneath can be swapped (stdlib urllib.request <-> a pooled urllib3
+PoolManager) without silently changing behaviour. A urllib3 pool was shipped
+once and reverted (7adbe2d -> 522fe9a) after Lambda-only failures that were
+never root-caused; nothing in the suite would have caught the breakage.
+
+The contract, grepped from every caller:
+
+  resp.read()                     all JSON/text providers
+  resp.read(n)                    darksky.py:165 streams a multi-MB zip in 1 MB chunks
+  resp.headers.get(...)           darksky.py:160 reads Content-Length
+  with ... as resp:               every call site
+  HTTPError.code                  tle_provider 403 -> _NotModified, 429 -> degraded;
+                                  weather.py:201/372 429 -> degraded
+  OSError on network failure      callers fall through to `except Exception`
+  ValueError on a bad scheme      the CWE-22 guard this module exists for
+  Request(headers=...)            tle_provider/aurora/darksky send a User-Agent
+
+Hermetic: a throwaway HTTP server on 127.0.0.1, no network, no sleeping beyond
+one short timeout probe.
+"""
+import http.server
+import json
+import socket
+import socketserver
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from darkhours import _http
+
+
+BODY = b'{"hello": "world"}'
+BIG = b"x" * (256 * 1024)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # keep-alive, so a pooled transport can reuse
+
+    def log_message(self, *args):
+        pass
+
+    def _send(self, code, body, extra=None):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (extra or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/ok":
+            self._send(200, BODY)
+        elif path == "/big":
+            self._send(200, BIG)
+        elif path == "/echo-headers":
+            seen = {k.lower(): v for k, v in self.headers.items()}
+            self._send(200, json.dumps(seen).encode())
+        elif path.startswith("/status/"):
+            self._send(int(path.rsplit("/", 1)[1]), b'{"err": true}')
+        elif path == "/slow":
+            time.sleep(2.0)
+            self._send(200, BODY)
+        else:
+            self._send(404, b'{"err": "no route"}')
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    srv = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
+    srv.daemon_threads = True
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.fixture(scope="module")
+def dead_port():
+    """A port with nothing listening, for connection-refused behaviour."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+# ---------------------------------------------------------------------------
+# Reading the body
+# ---------------------------------------------------------------------------
+
+def test_read_returns_full_body(base_url):
+    with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+        assert resp.read() == BODY
+
+
+def test_read_is_usable_after_the_response_is_returned(base_url):
+    """The bug that broke the first pooled attempt: preload_content=True consumed
+    the body, so every caller's resp.read() came back empty (fixed in 9d89c17)."""
+    resp = _http.urlopen(f"{base_url}/ok", timeout=5)
+    assert resp.read() == BODY
+
+
+def test_chunked_read_reassembles_the_body(base_url):
+    """darksky.py:165 streams a multi-MB zip with resp.read(1 << 20) until empty."""
+    chunks = []
+    with _http.urlopen(f"{base_url}/big", timeout=5) as resp:
+        while True:
+            chunk = resp.read(64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    assert b"".join(chunks) == BIG
+    assert len(chunks) > 1, "expected the body to arrive in more than one chunk"
+
+
+def test_content_length_header_is_readable(base_url):
+    """darksky.py:160 uses it to drive the download progress meter."""
+    with _http.urlopen(f"{base_url}/big", timeout=5) as resp:
+        assert int(resp.headers.get("Content-Length", 0)) == len(BIG)
+
+
+def test_response_is_a_context_manager(base_url):
+    """Every call site uses `with _http.urlopen(...) as resp:`."""
+    with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+        assert resp.read() == BODY
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("code", [403, 404, 429, 500, 503])
+def test_http_error_carries_the_status_code(base_url, code):
+    """tle_provider branches 403 -> _NotModified and 429 -> degraded; weather.py
+    branches 429 -> degraded. The code must survive the transport exactly."""
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _http.urlopen(f"{base_url}/status/{code}", timeout=5)
+    assert exc.value.code == code
+
+
+def test_connection_failure_raises_oserror(dead_port):
+    """Callers catch `except Exception` after HTTPError; asserting OSError keeps
+    the contract honest without over-specifying (stdlib gives URLError on connect,
+    TimeoutError on read — both OSError)."""
+    with pytest.raises(OSError) as exc:
+        _http.urlopen(f"http://127.0.0.1:{dead_port}/ok", timeout=5)
+    assert not isinstance(exc.value, urllib.error.HTTPError)
+
+
+def test_read_timeout_raises_oserror(base_url):
+    with pytest.raises(OSError):
+        _http.urlopen(f"{base_url}/slow", timeout=0.3)
+
+
+# ---------------------------------------------------------------------------
+# Scheme guard — the reason this module exists (CWE-22)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "file:///etc/passwd",
+    "ftp://example.com/x",
+    "gopher://example.com/x",
+    "FILE:///etc/passwd",
+])
+def test_non_http_schemes_are_refused(url):
+    with pytest.raises(ValueError):
+        _http.urlopen(url)
+
+
+def test_scheme_guard_applies_to_request_objects():
+    req = urllib.request.Request("file:///etc/passwd")
+    with pytest.raises(ValueError):
+        _http.urlopen(req)
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_http_schemes_pass_the_guard(scheme, dead_port):
+    """Reaching a connection error (not ValueError) proves the guard let it through."""
+    with pytest.raises(OSError) as exc:
+        _http.urlopen(f"{scheme}://127.0.0.1:{dead_port}/ok", timeout=5)
+    assert not isinstance(exc.value, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Request objects with headers
+# ---------------------------------------------------------------------------
+
+def test_request_headers_reach_the_server(base_url):
+    """tle_provider.py:126, aurora.py:197 and darksky.py:1490 all send a
+    User-Agent this way; Celestrak serves 403 to the wrong one."""
+    ua = "DarkHours/1.0 (test)"
+    req = urllib.request.Request(f"{base_url}/echo-headers", headers={"User-Agent": ua})
+    with _http.urlopen(req, timeout=5) as resp:
+        seen = json.loads(resp.read())
+    assert seen["user-agent"] == ua
+
+
+def test_plain_url_still_sends_some_user_agent(base_url):
+    """weather.py and aqicn.py pass bare URL strings. Whatever the transport, a
+    provider must not see a request with no User-Agent at all."""
+    with _http.urlopen(f"{base_url}/echo-headers", timeout=5) as resp:
+        seen = json.loads(resp.read())
+    assert seen.get("user-agent", "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — the app's real fan-out pattern
+# ---------------------------------------------------------------------------
+
+def test_concurrent_requests_to_one_host_all_succeed(base_url):
+    """predictor.py fans out up to 9 threads: 3 TLE + Starlink to celestrak.org
+    plus weather. The first pooled attempt left maxsize at its default of 1,
+    which starves exactly this pattern."""
+    import concurrent.futures as futures
+
+    def fetch(_):
+        with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+            return resp.read()
+
+    with futures.ThreadPoolExecutor(max_workers=9) as pool:
+        results = list(pool.map(fetch, range(18)))
+    assert results == [BODY] * 18


### PR DESCRIPTION
## Summary

Phase 0 of the `_http` connection-pool re-attempt (CACHING.md item 3). No behaviour change.

**Declare `urllib3>=2.7,<3`.** It was transitive-only via botocore (`>=1.25.4,<3`), so a dev venv and a deployed Lambda could resolve different majors — `7adbe2d` records the container on 1.x while local dev had 2.x, the leading suspect for the Lambda-only failures behind `522fe9a`.

A range rather than an exact pin, deliberately:

- The floor rules out the 1.x/2.x split, which is the actual identified hazard.
- Deploys re-resolve on every merge to `main`, so **security patches keep arriving without waiting on a bump**. An exact pin would park urllib3 until a Dependabot PR was reviewed and merged — and `security.yml` is scan-only, so a CVE would surface without blocking anything.
- Declaring it at all is what gets urllib3 into Dependabot's weekly `python-deps` group. Transitive deps appear in no manifest, so it has **zero** version-update coverage today.
- Matches `global-land-mask` and `h3`, already ranges in this file.

The trade is reproducibility across dev and Lambda *within* 2.x, which is accepted.

**Add `tests/test_http.py`** — 22 hermetic tests pinning what the 12 call sites rely on: `read()`, chunked `read(n)` (darksky streams a zip in 1 MB chunks), `Content-Length`, context-manager use, `HTTPError.code` (tle_provider maps 403 → `_NotModified`, 429 → degraded), `OSError` on connect/read failure, the CWE-22 scheme guard, `Request` headers, and a 9-thread fan-out matching `predictor.py`'s concurrency.

`_http` had no test coverage, which is why the pooled transport could be added and reverted without a single test noticing.

## Test plan

- `python -m pytest -q` — 974 passed, 9 skipped.
- `pip install --dry-run -r requirements.txt` resolves cleanly against `boto3==1.43.70`.
- `pip-audit -r requirements-api.txt` — no known vulnerabilities.
- New tests pass against the current stdlib transport and are written to hold for a pooled one (#228 runs them against both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)