### PR TITLE
Split io_wait into ds/wx/haze and time each weather provider leg

### DIFF
--- a/darkhours/predictor.py
+++ b/darkhours/predictor.py
@@ -45,6 +45,21 @@ log = logging.getLogger(__name__)
 _WX_CACHE_TTL = 3600
 
 
+def _timed_io(sink: dict, key: str, fn, *args):
+    """Run one I/O future, recording its own wall clock into ``sink[key]``.
+
+    io_wait_ms is the residual wait after Skyfield finishes, joined across
+    darksky + weather + live haze, so it can't say which of the three was slow.
+    These can, and they're the only way to tell a cold darksky S3 read apart
+    from a weather fetch.
+    """
+    _t0 = time.monotonic()
+    try:
+        return fn(*args)
+    finally:
+        sink[key] = round((time.monotonic() - _t0) * 1000)
+
+
 def _wx_serialize(points: list, source: str, fetched_at: str) -> dict:
     """Serialize weather forecast results for DynamoDB caching."""
     return {
@@ -539,7 +554,7 @@ def assemble_night(
         _max_workers = 9
 
     with _futures.ThreadPoolExecutor(max_workers=_max_workers) as _pool:
-        _ds_future = _pool.submit(_ds.lookup, lat, lon)
+        _ds_future = _pool.submit(_timed_io, _t, "ds_ms", _ds.lookup, lat, lon)
 
         # Aurora forecast — global SWPC products (cached, single-flight): the
         # 3-day Kp forecast within its horizon, the 27-day outlook beyond it
@@ -572,7 +587,7 @@ def assemble_night(
         _haze_future: _futures.Future | None = None
         _haze_days_ahead = (target - _now.date()).days
         if fetch_weather and -1 <= _haze_days_ahead <= 1 and _ff.enabled("live_haze"):
-            _haze_future = _pool.submit(_aqicn.current_haze, lat, lon)
+            _haze_future = _pool.submit(_timed_io, _t, "haze_ms", _aqicn.current_haze, lat, lon)
 
         # Heuristic: start weather for tonight-or-future dates without waiting for
         # sunrise. "Tonight" may be yesterday in UTC when the night spans midnight
@@ -599,7 +614,7 @@ def assemble_night(
                     except Exception as _ce:
                         log.debug("Weather cache write failed (non-fatal): %s", _ce)
                     return ("fresh", _fresh)
-            _wx_future = _pool.submit(_wx_io)
+            _wx_future = _pool.submit(_timed_io, _t, "wx_ms", _wx_io)
 
         # TLE fetches — start immediately, overlaps with ~600 ms of Skyfield work.
         if fetch_satellites:
@@ -1022,13 +1037,18 @@ def assemble_night(
     _t["scoring_ms"] = round((time.monotonic() - _tc) * 1000)
     _t["total_ms"] = round((time.monotonic() - _t0) * 1000)
 
+    # ds/wx/haze default to -1 for "future never submitted", not 0: wx_cached=False
+    # already conflates a genuine cache miss with a request that skipped the fetch
+    # entirely (past date, weather=false, date_only), and reading a 0 there as a
+    # fast fetch is how that gets misattributed.
     log.info(
         "assemble_night timing lat=%.2f lon=%.2f date=%s wx_cached=%s | "
         "sky_events=%dms event_parse=%dms moon=%dms lunar_cycle=%dms "
-        "io_wait=%dms sat_targets=%dms scoring=%dms total=%dms",
+        "io_wait=%dms ds=%dms wx=%dms haze=%dms sat_targets=%dms scoring=%dms total=%dms",
         lat, lon, target, _wx_cached is not None,
         _t["sky_events_ms"], _t["event_parse_ms"], _t["moon_ms"],
         _t["lunar_cycle_ms"], _t["io_wait_ms"],
+        _t.get("ds_ms", -1), _t.get("wx_ms", -1), _t.get("haze_ms", -1),
         _t.get("sat_targets_ms", 0), _t["scoring_ms"],
         _t["total_ms"],
     )

--- a/darkhours/weather.py
+++ b/darkhours/weather.py
@@ -19,10 +19,12 @@ Fields a provider cannot supply should be left as None.
 """
 
 import concurrent.futures as _futures
+import contextlib
 import json
 import logging
 import math
 import threading
+import time
 import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
@@ -790,6 +792,37 @@ def get_provider() -> WeatherProvider | None:
     return _provider
 
 
+def _timed_leg(sink: dict, name: str, fn, *args):
+    """Run one provider call, recording its own wall clock into ``sink[name]``."""
+    _t0 = time.monotonic()
+    try:
+        return fn(*args)
+    finally:
+        sink[name] = round((time.monotonic() - _t0) * 1000)
+
+
+@contextlib.contextmanager
+def _leg_timings(lat: float, lon: float):
+    """Yield a dict for _timed_leg to fill, and log the three legs on the way out.
+
+    forecast() fans out to Open-Meteo, 7Timer and Open-Meteo air-quality
+    concurrently, so its wall clock is the max of the three, not the sum — but
+    nothing downstream could see which one set it. Emitted on every exit path,
+    including the 7Timer fallback and the both-failed raise. One line per actual
+    fetch (cache hits never reach here).
+    """
+    legs: dict[str, int] = {}
+    t0 = time.monotonic()
+    try:
+        yield legs
+    finally:
+        log.info(
+            "weather.forecast timing lat=%.2f lon=%.2f | om=%dms 7t=%dms aq=%dms fetch=%dms",
+            lat, lon, legs.get("om", 0), legs.get("7t", 0), legs.get("aq", 0),
+            round((time.monotonic() - t0) * 1000),
+        )
+
+
 def forecast(lat: float, lon: float) -> tuple[list, str, str]:
     """
     Fetch a forecast for the given coordinates via Open-Meteo, then blend
@@ -808,14 +841,15 @@ def forecast(lat: float, lon: float) -> tuple[list, str, str]:
     7Timer and air quality are fetched concurrently with the primary provider
     so their latency is hidden rather than added on top.
     """
-    with _futures.ThreadPoolExecutor(max_workers=2) as _pool:
-        _seven_future = _pool.submit(SevenTimerProvider().forecast, lat, lon)
-        _aq_future    = _pool.submit(_fetch_air_quality, lat, lon)
+    with _leg_timings(lat, lon) as _legs, \
+         _futures.ThreadPoolExecutor(max_workers=2) as _pool:
+        _seven_future = _pool.submit(_timed_leg, _legs, "7t", SevenTimerProvider().forecast, lat, lon)
+        _aq_future    = _pool.submit(_timed_leg, _legs, "aq", _fetch_air_quality, lat, lon)
 
         primary = _provider if _provider is not None else OpenMeteoProvider()
         primary_err: str | None = None
         try:
-            points = primary.forecast(lat, lon)
+            points = _timed_leg(_legs, "om", primary.forecast, lat, lon)
             primary_name = primary.name
             fetched_at   = datetime.now(timezone.utc).isoformat()
         except RuntimeError as e:


### PR DESCRIPTION
## Summary

Phase 1 of the `_http` connection-pool re-attempt (CACHING.md item 3). Instrumentation only, no behaviour change. Independent of #226 — either can merge first.

- `predictor.py`: `io_wait_ms` is the residual wait joined across darksky + weather + live haze, but gets read as the weather fetch. Now reports `ds`/`wx`/`haze` separately.
- They default to **-1** when the future was never submitted, not 0. `wx_cached=False` already conflates a genuine cache miss with a request that skipped the fetch entirely (past date, `weather=false`, `date_only`) — 14.7% of `wx_cached=False` rows in the archived 14-day window did no weather work at all.
- `weather.py`: `forecast()` fans out to Open-Meteo, 7Timer and air-quality concurrently, so its wall clock is the max of three legs that were never separately visible. Each is now timed, logged on every exit path including the 7Timer fallback. One line per fetch.

## Test plan

- `python -m pytest -q` — 952 passed, 9 skipped.
- Real `assemble_night` runs confirm the split and the sentinel:
  - gated by Open-Meteo alone: `om=1000ms 7t=655ms aq=602ms`
  - both Open-Meteo hosts stalling together, 7Timer fine: `om=5860ms aq=5720ms 7t=477ms`
  - past date / `weather=false`: `wx_cached=False` with `wx=-1ms`, now separable from a real miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)