### PR TITLE
Add urllib3 connection pooling behind the http_pool feature flag

### DIFF
--- a/darkhours/_http.py
+++ b/darkhours/_http.py
@@ -26,6 +26,7 @@ import io
 import logging
 import threading
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from . import _env
@@ -53,6 +54,29 @@ _pool = None
 _pool_lock = threading.Lock()
 
 
+# Hosts that must never see a request replayed underneath the circuit breaker.
+# circuit_breaker.py gives celestrak the override (1 failure, 300 s cooldown)
+# because "Celestrak's anti-abuse policy punishes exactly the concentrated-retry
+# pattern that emerges at cache expiry". A urllib3 retry sits *below* the
+# breaker, so the default policy would turn one call into up to three requests
+# that the breaker never counts — reinstating the pattern that override exists
+# to prevent. These hosts keep connect retries (those never reach the server)
+# and give up read retries, so they lose the stale-connection recovery: cheap
+# here, since get_tle()'s global cache has a stale fallback and one success
+# serves every user for 6 h.
+_NO_REPLAY_HOSTS = ("celestrak.org",)
+
+
+def _retry_policy(host: str):
+    import urllib3
+
+    common = dict(connect=2, redirect=3, backoff_factor=0.2,
+                  status_forcelist=[], raise_on_status=False)
+    if any(host == h or host.endswith("." + h) for h in _NO_REPLAY_HOSTS):
+        return urllib3.Retry(total=2, read=0, **common)
+    return urllib3.Retry(total=2, read=2, **common)
+
+
 def _new_pool():
     """Build the shared PoolManager. Every kwarg here fixes a defect in 7adbe2d."""
     import urllib3
@@ -72,18 +96,10 @@ def _new_pool():
         # 7adbe2d used retries=False, which also switches off redirect following
         # and leaves nothing to recover a pooled connection that went stale while
         # the container was frozen. Every request through this module is a GET,
-        # so retrying is safe. status_forcelist=[] with raise_on_status=False
-        # keeps 4xx/5xx flowing to the HTTPError mapping below instead of being
-        # retried here or raised as a urllib3 error.
-        retries=urllib3.Retry(
-            total=2,
-            connect=2,
-            read=2,
-            redirect=3,
-            backoff_factor=0.2,
-            status_forcelist=[],
-            raise_on_status=False,
-        ),
+        # so replaying is safe in HTTP terms — but see _NO_REPLAY_HOSTS for where
+        # it is not safe in provider-policy terms. Overridden per request by host;
+        # this is the fallback for a pool built without going through urlopen().
+        retries=_retry_policy(""),
     )
 
 
@@ -119,6 +135,7 @@ def _pooled_get(original, full: str, timeout):
             "GET",
             full,
             headers=headers,
+            retries=_retry_policy(urllib.parse.urlsplit(full).hostname or ""),
             # stdlib's timeout is per socket operation, not a deadline for the
             # whole exchange. 7adbe2d used Timeout(total=...), which would cut
             # darksky.py's 60 s multi-MB zip download short partway through.

--- a/darkhours/_http.py
+++ b/darkhours/_http.py
@@ -4,20 +4,163 @@ All external fetches (weather, TLE, light-pollution downloads) go through here s
 the scheme is validated — urllib's urlopen otherwise accepts ``file://`` and other
 schemes, which would be a local-file-read risk if a URL were ever attacker-shaped
 (CWE-22).
+
+Two transports sit behind the one function:
+
+* ``urllib.request`` — the default. A fresh TCP + TLS handshake on every call.
+* a ``urllib3`` connection pool, selected by the ``http_pool`` feature flag —
+  TLS sessions survive across calls inside a warm Lambda container. Handshake is
+  ~54% of a typical Open-Meteo call (137 ms TCP + 287 ms TLS out of 795 ms), and
+  ``weather.forecast()`` runs three such calls concurrently, so the pool takes
+  roughly the handshake off the whole fetch rather than off one leg.
+
+A pool shipped once before and was reverted (7adbe2d → 522fe9a) after
+Lambda-only failures that were never root-caused. Every difference from that
+version is deliberate and annotated at the site that fixes it. Two things make
+this attempt recoverable where that one was not: selection is per call behind an
+operator flag that defaults to off (so falling back to stdlib takes ~30 s, the
+feature-flags cache TTL, and no deploy), and the urllib3 exception class now
+survives into the message ``provider_health`` records.
 """
+import io
+import logging
+import threading
+import urllib.error
 import urllib.request
 
+from . import feature_flags as _ff
+
+log = logging.getLogger(__name__)
+
 _ALLOWED_SCHEMES = ("https://", "http://")
+
+# Sent only when a caller passed a bare URL string (weather, 7Timer, WAQI).
+# Callers that build a urllib.request.Request already set their own and keep it.
+# Without this the pooled path would silently switch those providers from
+# stdlib's "Python-urllib/3.x" to "python-urllib3/2.x"; Celestrak already serves
+# 403 to the wrong User-Agent, so provider identity is not cosmetic here.
+_DEFAULT_USER_AGENT = "DarkHours/1.0 (open-source astronomical observation planner)"
+
+_pool = None
+_pool_lock = threading.Lock()
+
+
+def _new_pool():
+    """Build the shared PoolManager. Every kwarg here fixes a defect in 7adbe2d."""
+    import urllib3
+
+    return urllib3.PoolManager(
+        # num_pools counts *hosts*; maxsize is the per-host connection count and
+        # defaults to 1. 7adbe2d set only num_pools, so with predictor.py's
+        # 9-thread fan-out (3 TLE + Starlink to celestrak.org, plus the three
+        # weather calls) every connection past the first was discarded on return
+        # instead of parked. block=False means that degrades reuse and emits
+        # "connection pool is full" rather than starving callers, so it was a
+        # throughput defect, not the failure that forced the revert. maxsize=8
+        # covers the widest fan-out, so the pool holds what it opens.
+        num_pools=8,
+        maxsize=8,
+        block=False,
+        # 7adbe2d used retries=False, which also switches off redirect following
+        # and leaves nothing to recover a pooled connection that went stale while
+        # the container was frozen. Every request through this module is a GET,
+        # so retrying is safe. status_forcelist=[] with raise_on_status=False
+        # keeps 4xx/5xx flowing to the HTTPError mapping below instead of being
+        # retried here or raised as a urllib3 error.
+        retries=urllib3.Retry(
+            total=2,
+            connect=2,
+            read=2,
+            redirect=3,
+            backoff_factor=0.2,
+            status_forcelist=[],
+            raise_on_status=False,
+        ),
+    )
+
+
+def _get_pool():
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                _pool = _new_pool()
+    return _pool
+
+
+def _pool_enabled() -> bool:
+    """Transport selection, isolated so tests can force either path."""
+    return _ff.enabled("http_pool", default=False)
+
+
+def _pooled_get(original, full: str, timeout):
+    """GET *full* through the shared pool, in urllib.request's exception language."""
+    import urllib3
+    import urllib3.exceptions
+
+    headers: dict[str, str] = {}
+    if isinstance(original, urllib.request.Request):
+        # Request.add_header capitalises keys, so a caller's {"User-Agent": ...}
+        # is stored as "User-agent". HTTP header names are case-insensitive, but
+        # normalise anyway so the setdefault below can actually find it.
+        headers = {k.title(): v for k, v in original.headers.items()}
+    headers.setdefault("User-Agent", _DEFAULT_USER_AGENT)
+
+    try:
+        resp = _get_pool().request(
+            "GET",
+            full,
+            headers=headers,
+            # stdlib's timeout is per socket operation, not a deadline for the
+            # whole exchange. 7adbe2d used Timeout(total=...), which would cut
+            # darksky.py's 60 s multi-MB zip download short partway through.
+            timeout=urllib3.Timeout(connect=timeout, read=timeout),
+            # Callers read the body themselves, including darksky.py's chunked
+            # read(1 << 20). preload_content=True consumed it first and left
+            # every resp.read() empty — the first bug 7adbe2d shipped.
+            preload_content=False,
+        )
+    except urllib3.exceptions.HTTPError as exc:
+        # Keep the contract callers rely on (URLError, an OSError) while carrying
+        # the concrete urllib3 class through. provider_health records
+        # str(e)[:120]; 7adbe2d's flat URLError(str(exc)) is the specific reason
+        # its Lambda-only failures were never attributable to a cause.
+        #
+        # Lead with the underlying reason, not the wrapper: retries mean almost
+        # everything surfaces as MaxRetryError, which names no cause and would
+        # be all that survives the 120-char truncation. .reason holds the real
+        # one (NewConnectionError, ProtocolError, SSLError, ReadTimeoutError).
+        cause = getattr(exc, "reason", None)
+        name = type(cause).__name__ if isinstance(cause, Exception) else type(exc).__name__
+        raise urllib.error.URLError(f"{name}: {exc}") from exc
+
+    if resp.status >= 400:
+        body = resp.read()      # drains the response, returning the conn to the pool
+        resp.release_conn()
+        raise urllib.error.HTTPError(
+            full, resp.status, resp.reason or str(resp.status),
+            resp.headers, io.BytesIO(body),
+        )
+    return resp
 
 
 def urlopen(url, *args, **kwargs):
     """``urllib.request.urlopen`` restricted to http(s) URLs/Requests.
 
     Accepts the same arguments as ``urllib.request.urlopen`` (a URL string or a
-    ``Request``) and returns the same response object. Raises ``ValueError`` for
-    any non-HTTP(S) scheme.
+    ``Request``) and returns a response supporting ``read()``, ``read(n)``,
+    ``headers.get()`` and use as a context manager. Raises ``ValueError`` for
+    any non-HTTP(S) scheme, ``urllib.error.HTTPError`` (carrying ``.code``) on
+    4xx/5xx, and an ``OSError`` on network failure. ``tests/test_http.py`` pins
+    that contract against both transports.
+
+    The pooled path reads ``timeout`` from keyword arguments, which is how all
+    12 call sites pass it.
     """
     full = url.full_url if isinstance(url, urllib.request.Request) else url
     if not str(full).lower().startswith(_ALLOWED_SCHEMES):
         raise ValueError(f"Refusing to open non-HTTP(S) URL: {full!r}")
+    if not args and _pool_enabled():
+        return _pooled_get(url, str(full), kwargs.get("timeout"))
+    # Scheme validated above; this is the one audited urlopen in the codebase.
     return urllib.request.urlopen(url, *args, **kwargs)  # nosec B310  # nosemgrep: dynamic-urllib-use-detected

--- a/darkhours/_http.py
+++ b/darkhours/_http.py
@@ -28,9 +28,17 @@ import threading
 import urllib.error
 import urllib.request
 
+from . import _env
 from . import feature_flags as _ff
 
 log = logging.getLogger(__name__)
+
+# The code default the DynamoDB flag falls back to, off unless set. Lets a
+# throwaway in-region test function A/B the transport without writing to the
+# shared flags table, and gives the deploy-time counterpart to the existing
+# PYNIGHTSKY_FEATURE_HTTP_POOL_DISABLE hard override. An operator flag in the
+# table still wins over this; PYNIGHTSKY_FEATURE_HTTP_POOL_DISABLE beats both.
+_POOL_DEFAULT = _env.flag("PYNIGHTSKY_HTTP_POOL", "0")
 
 _ALLOWED_SCHEMES = ("https://", "http://")
 
@@ -90,7 +98,7 @@ def _get_pool():
 
 def _pool_enabled() -> bool:
     """Transport selection, isolated so tests can force either path."""
-    return _ff.enabled("http_pool", default=False)
+    return _ff.enabled("http_pool", default=_POOL_DEFAULT)
 
 
 def _pooled_get(original, full: str, timeout):

--- a/darkhours/_http.py
+++ b/darkhours/_http.py
@@ -155,9 +155,17 @@ def _pooled_get(original, full: str, timeout):
         # everything surfaces as MaxRetryError, which names no cause and would
         # be all that survives the 120-char truncation. .reason holds the real
         # one (NewConnectionError, ProtocolError, SSLError, ReadTimeoutError).
+        #
+        # Never interpolate the urllib3 message itself. It embeds the full request
+        # URL, and some of ours carry a credential in the query string (aqicn's
+        # ?token=...). aqicn logs str(e) untruncated to CloudWatch and
+        # provider_health surfaces e.reason on the public, unauthenticated
+        # /healthz, so a URL here reaches both. stdlib never exposed it. The class
+        # name is the part 7adbe2d was missing; the URL was never the useful bit.
         cause = getattr(exc, "reason", None)
         name = type(cause).__name__ if isinstance(cause, Exception) else type(exc).__name__
-        raise urllib.error.URLError(f"{name}: {exc}") from exc
+        host = urllib.parse.urlsplit(full).hostname or "unknown host"
+        raise urllib.error.URLError(f"{name} for {host}") from exc
 
     if resp.status >= 400:
         body = resp.read()      # drains the response, returning the conn to the pool

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -39,10 +39,16 @@ dependency of the CI-deployed `PyNightSkyLambda` stack.
 | `routing` | Drive-time annotation (AWS Location) | `darkhours/darksky.py` |
 | `nearby_search` | The whole `/nearby` job type | `apps/api/main.py` |
 | `trip_builder` | The whole `/calendar` job type | `apps/api/main.py` |
+| `http_pool` | urllib3 connection pooling for all outbound HTTP (**default off**) | `darkhours/_http.py` |
 
 Turning off a `/night`-report sub-feature (the first five) produces a report with
 that field simply absent. Turning off a job-type flag returns `503` with
 `Retry-After: 60` before any resolution work or job submission happens.
+
+`http_pool` is the one flag whose code default is `False`: unset, unreachable or
+absent from the table all select `urllib.request`. Enabling it swaps the
+transport inside `_http.urlopen`; nothing else about a request changes, and
+`tests/test_http.py` runs the full contract against both transports.
 
 ## Administrative — no write path from the public API
 

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -50,6 +50,11 @@ absent from the table all select `urllib.request`. Enabling it swaps the
 transport inside `_http.urlopen`; nothing else about a request changes, and
 `tests/test_http.py` runs the full contract against both transports.
 
+Its code default is itself settable with `PYNIGHTSKY_HTTP_POOL=1`, for a
+throwaway in-region test function that has no flags table. Precedence, highest
+first: `PYNIGHTSKY_FEATURE_HTTP_POOL_DISABLE` → table item → `PYNIGHTSKY_HTTP_POOL`
+→ `False`.
+
 ## Administrative — no write path from the public API
 
 The API and worker Lambdas are granted `dynamodb:GetItem` **only** on this

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,10 @@ geopy==2.5.0
 skyfield==1.55
 timezonefinder==8.2.5
 boto3==1.43.70
+# Pinned, not left transitive: botocore accepts urllib3 >=1.25.4,<3, so the
+# resolved major can differ between a dev venv and a deployed Lambda. That
+# split is the leading suspect for the Lambda-only failures that reverted the
+# _http connection pool (7adbe2d -> 522fe9a). Every direct use is in _http.py.
+urllib3==2.7.0
 global-land-mask>=1.0
 h3>=4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,13 @@ geopy==2.5.0
 skyfield==1.55
 timezonefinder==8.2.5
 boto3==1.43.70
-# Pinned, not left transitive: botocore accepts urllib3 >=1.25.4,<3, so the
-# resolved major can differ between a dev venv and a deployed Lambda. That
-# split is the leading suspect for the Lambda-only failures that reverted the
-# _http connection pool (7adbe2d -> 522fe9a). Every direct use is in _http.py.
-urllib3==2.7.0
+# Declared rather than left transitive: botocore accepts urllib3 >=1.25.4,<3, so
+# an undeclared urllib3 can resolve to a different major in a dev venv than in a
+# deployed Lambda -- the leading suspect for the Lambda-only failures that
+# reverted the _http connection pool (7adbe2d -> 522fe9a). The floor rules out
+# that split; the range still lets security patches land on the next deploy
+# rather than waiting on a bump. Declaring it is also what gets urllib3 into
+# Dependabot's weekly python-deps group at all. Every direct use is in _http.py.
+urllib3>=2.7,<3
 global-land-mask>=1.0
 h3>=4.5.0

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -345,6 +345,30 @@ def test_pooled_failures_name_the_underlying_cause(dead_port, transport):
     assert "Error" in detail.split(":")[0], f"no urllib3 class in {detail!r}"
 
 
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_failures_never_echo_the_request_url(dead_port, transport, scheme):
+    """A failure message must not carry the URL, because some carry credentials.
+
+    aqicn's endpoint is ``.../feed/geo:LAT;LON/?token=<secret>``. aqicn.py logs
+    str(e) untruncated to CloudWatch, and provider_health surfaces e.reason on
+    /healthz, which is public and unauthenticated. urllib3 embeds the full URL in
+    its exception text ("Max retries exceeded with url: ..."), so interpolating
+    that message leaks the token through both. stdlib never exposed it; the
+    pooled transport must not either. Mirrors
+    test_check_cache_health_does_not_leak_exception_text in tests/test_api.py.
+    """
+    secret = "SECRET-TOKEN-VALUE-abc123"
+    url = f"{scheme}://127.0.0.1:{dead_port}/feed/geo:37.3;-113.0/?token={secret}"
+    with pytest.raises(OSError) as exc:
+        _http.urlopen(url, timeout=3)
+    message = str(exc.value)
+    reason = str(getattr(exc.value, "reason", ""))
+    assert secret not in message, f"credential leaked into the message: {message[:160]}"
+    assert secret not in reason, f"credential leaked into .reason: {reason[:160]}"
+    assert "token=" not in message and "token=" not in reason
+    assert "geo:37.3" not in message, "request path leaked into the message"
+
+
 def test_pool_retries_are_enabled_for_idempotent_gets():
     """retries=False, 7adbe2d's setting, also switches off redirect following and
     leaves nothing to recover a connection that went stale during a container

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,234 @@
+"""
+Contract tests for _http.urlopen — the single choke point every outbound fetch
+goes through.
+
+These pin down exactly what the 12 call sites rely on, so the transport
+underneath can be swapped (stdlib urllib.request <-> a pooled urllib3
+PoolManager) without silently changing behaviour. A urllib3 pool was shipped
+once and reverted (7adbe2d -> 522fe9a) after Lambda-only failures that were
+never root-caused; nothing in the suite would have caught the breakage.
+
+The contract, grepped from every caller:
+
+  resp.read()                     all JSON/text providers
+  resp.read(n)                    darksky.py:165 streams a multi-MB zip in 1 MB chunks
+  resp.headers.get(...)           darksky.py:160 reads Content-Length
+  with ... as resp:               every call site
+  HTTPError.code                  tle_provider 403 -> _NotModified, 429 -> degraded;
+                                  weather.py:201/372 429 -> degraded
+  OSError on network failure      callers fall through to `except Exception`
+  ValueError on a bad scheme      the CWE-22 guard this module exists for
+  Request(headers=...)            tle_provider/aurora/darksky send a User-Agent
+
+Hermetic: a throwaway HTTP server on 127.0.0.1, no network, no sleeping beyond
+one short timeout probe.
+"""
+import http.server
+import json
+import socket
+import socketserver
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from darkhours import _http
+
+
+BODY = b'{"hello": "world"}'
+BIG = b"x" * (256 * 1024)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # keep-alive, so a pooled transport can reuse
+
+    def log_message(self, *args):
+        pass
+
+    def _send(self, code, body, extra=None):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (extra or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/ok":
+            self._send(200, BODY)
+        elif path == "/big":
+            self._send(200, BIG)
+        elif path == "/echo-headers":
+            seen = {k.lower(): v for k, v in self.headers.items()}
+            self._send(200, json.dumps(seen).encode())
+        elif path.startswith("/status/"):
+            self._send(int(path.rsplit("/", 1)[1]), b'{"err": true}')
+        elif path == "/slow":
+            time.sleep(2.0)
+            self._send(200, BODY)
+        else:
+            self._send(404, b'{"err": "no route"}')
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    srv = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
+    srv.daemon_threads = True
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.fixture(scope="module")
+def dead_port():
+    """A port with nothing listening, for connection-refused behaviour."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+# ---------------------------------------------------------------------------
+# Reading the body
+# ---------------------------------------------------------------------------
+
+def test_read_returns_full_body(base_url):
+    with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+        assert resp.read() == BODY
+
+
+def test_read_is_usable_after_the_response_is_returned(base_url):
+    """The bug that broke the first pooled attempt: preload_content=True consumed
+    the body, so every caller's resp.read() came back empty (fixed in 9d89c17)."""
+    resp = _http.urlopen(f"{base_url}/ok", timeout=5)
+    assert resp.read() == BODY
+
+
+def test_chunked_read_reassembles_the_body(base_url):
+    """darksky.py:165 streams a multi-MB zip with resp.read(1 << 20) until empty."""
+    chunks = []
+    with _http.urlopen(f"{base_url}/big", timeout=5) as resp:
+        while True:
+            chunk = resp.read(64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    assert b"".join(chunks) == BIG
+    assert len(chunks) > 1, "expected the body to arrive in more than one chunk"
+
+
+def test_content_length_header_is_readable(base_url):
+    """darksky.py:160 uses it to drive the download progress meter."""
+    with _http.urlopen(f"{base_url}/big", timeout=5) as resp:
+        assert int(resp.headers.get("Content-Length", 0)) == len(BIG)
+
+
+def test_response_is_a_context_manager(base_url):
+    """Every call site uses `with _http.urlopen(...) as resp:`."""
+    with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+        assert resp.read() == BODY
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("code", [403, 404, 429, 500, 503])
+def test_http_error_carries_the_status_code(base_url, code):
+    """tle_provider branches 403 -> _NotModified and 429 -> degraded; weather.py
+    branches 429 -> degraded. The code must survive the transport exactly."""
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _http.urlopen(f"{base_url}/status/{code}", timeout=5)
+    assert exc.value.code == code
+
+
+def test_connection_failure_raises_oserror(dead_port):
+    """Callers catch `except Exception` after HTTPError; asserting OSError keeps
+    the contract honest without over-specifying (stdlib gives URLError on connect,
+    TimeoutError on read — both OSError)."""
+    with pytest.raises(OSError) as exc:
+        _http.urlopen(f"http://127.0.0.1:{dead_port}/ok", timeout=5)
+    assert not isinstance(exc.value, urllib.error.HTTPError)
+
+
+def test_read_timeout_raises_oserror(base_url):
+    with pytest.raises(OSError):
+        _http.urlopen(f"{base_url}/slow", timeout=0.3)
+
+
+# ---------------------------------------------------------------------------
+# Scheme guard — the reason this module exists (CWE-22)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "file:///etc/passwd",
+    "ftp://example.com/x",
+    "gopher://example.com/x",
+    "FILE:///etc/passwd",
+])
+def test_non_http_schemes_are_refused(url):
+    with pytest.raises(ValueError):
+        _http.urlopen(url)
+
+
+def test_scheme_guard_applies_to_request_objects():
+    req = urllib.request.Request("file:///etc/passwd")
+    with pytest.raises(ValueError):
+        _http.urlopen(req)
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_http_schemes_pass_the_guard(scheme, dead_port):
+    """Reaching a connection error (not ValueError) proves the guard let it through."""
+    with pytest.raises(OSError) as exc:
+        _http.urlopen(f"{scheme}://127.0.0.1:{dead_port}/ok", timeout=5)
+    assert not isinstance(exc.value, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Request objects with headers
+# ---------------------------------------------------------------------------
+
+def test_request_headers_reach_the_server(base_url):
+    """tle_provider.py:126, aurora.py:197 and darksky.py:1490 all send a
+    User-Agent this way; Celestrak serves 403 to the wrong one."""
+    ua = "DarkHours/1.0 (test)"
+    req = urllib.request.Request(f"{base_url}/echo-headers", headers={"User-Agent": ua})
+    with _http.urlopen(req, timeout=5) as resp:
+        seen = json.loads(resp.read())
+    assert seen["user-agent"] == ua
+
+
+def test_plain_url_still_sends_some_user_agent(base_url):
+    """weather.py and aqicn.py pass bare URL strings. Whatever the transport, a
+    provider must not see a request with no User-Agent at all."""
+    with _http.urlopen(f"{base_url}/echo-headers", timeout=5) as resp:
+        seen = json.loads(resp.read())
+    assert seen.get("user-agent", "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — the app's real fan-out pattern
+# ---------------------------------------------------------------------------
+
+def test_concurrent_requests_to_one_host_all_succeed(base_url):
+    """predictor.py fans out up to 9 threads: 3 TLE + Starlink to celestrak.org
+    plus weather. The first pooled attempt left maxsize at its default of 1,
+    which starves exactly this pattern."""
+    import concurrent.futures as futures
+
+    def fetch(_):
+        with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+            return resp.read()
+
+    with futures.ThreadPoolExecutor(max_workers=9) as pool:
+        results = list(pool.map(fetch, range(18)))
+    assert results == [BODY] * 18

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -41,11 +41,29 @@ BODY = b'{"hello": "world"}'
 BIG = b"x" * (256 * 1024)
 
 
+class _Server(socketserver.ThreadingTCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client_ports = []  # one entry per request, for the reuse assertions
+        self._ports_lock = threading.Lock()
+
+    def handle_error(self, request, client_address):
+        """Stay quiet when a client walks away mid-response (the timeout test)."""
+
+
 class _Handler(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"  # keep-alive, so a pooled transport can reuse
 
     def log_message(self, *args):
         pass
+
+    def handle_one_request(self):
+        with self.server._ports_lock:
+            self.server.client_ports.append(self.client_address[1])
+        super().handle_one_request()
 
     def _send(self, code, body, extra=None):
         self.send_response(code)
@@ -70,20 +88,32 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         elif path == "/slow":
             time.sleep(2.0)
             self._send(200, BODY)
+        elif path == "/hold":
+            # Long enough that concurrent callers genuinely overlap. Over
+            # loopback a request finishes so fast that threads never contend,
+            # and a one-connection pool looks indistinguishable from a healthy
+            # one — which is how 7adbe2d's maxsize=1 could go unnoticed.
+            time.sleep(0.08)
+            self._send(200, BODY)
         else:
             self._send(404, b'{"err": "no route"}')
 
 
 @pytest.fixture(scope="module")
-def base_url():
-    srv = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
-    srv.daemon_threads = True
+def server():
+    srv = _Server(("127.0.0.1", 0), _Handler)
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     try:
-        yield f"http://127.0.0.1:{srv.server_address[1]}"
+        yield srv
     finally:
         srv.shutdown()
         srv.server_close()
+
+
+@pytest.fixture
+def base_url(server):
+    server.client_ports.clear()
+    return f"http://127.0.0.1:{server.server_address[1]}"
 
 
 @pytest.fixture(scope="module")
@@ -94,6 +124,18 @@ def dead_port():
     port = s.getsockname()[1]
     s.close()
     return port
+
+
+@pytest.fixture(params=["stdlib", "pooled"], autouse=True)
+def transport(request, monkeypatch):
+    """Run every test in this module against both transports.
+
+    The whole point of the contract is that swapping the transport changes
+    nothing observable, so asserting it on only one of them would miss exactly
+    the class of bug that reverted the pool the first time.
+    """
+    monkeypatch.setattr(_http, "_pool_enabled", lambda: request.param == "pooled")
+    return request.param
 
 
 # ---------------------------------------------------------------------------
@@ -232,3 +274,82 @@ def test_concurrent_requests_to_one_host_all_succeed(base_url):
     with futures.ThreadPoolExecutor(max_workers=9) as pool:
         results = list(pool.map(fetch, range(18)))
     assert results == [BODY] * 18
+
+
+# ---------------------------------------------------------------------------
+# Connection reuse — the reason the pooled transport exists
+# ---------------------------------------------------------------------------
+
+def _distinct_client_ports(server):
+    """One source port per TCP connection, so this counts handshakes."""
+    return len(set(server.client_ports))
+
+
+def test_sequential_requests_reuse_one_connection_when_pooled(base_url, server, transport):
+    for _ in range(4):
+        with _http.urlopen(f"{base_url}/ok", timeout=5) as resp:
+            resp.read()
+
+    if transport == "pooled":
+        assert _distinct_client_ports(server) == 1, "pooled transport re-handshook"
+    else:
+        assert _distinct_client_ports(server) == 4, "stdlib unexpectedly reused a connection"
+
+
+def test_reuse_holds_under_the_concurrent_fan_out(base_url, server, transport):
+    """Overlapping callers must still reuse, not re-handshake per request.
+
+    /hold forces the workers to genuinely overlap; over loopback a request
+    finishes so fast that threads never contend and any pool looks healthy.
+    """
+    import concurrent.futures as futures
+
+    def fetch(_):
+        with _http.urlopen(f"{base_url}/hold", timeout=5) as resp:
+            return resp.read()
+
+    with futures.ThreadPoolExecutor(max_workers=6) as pool:
+        assert list(pool.map(fetch, range(24))) == [BODY] * 24
+
+    ports = _distinct_client_ports(server)
+    if transport == "pooled":
+        assert ports <= 6, f"expected <=6 connections for 24 requests, got {ports}"
+    else:
+        assert ports >= 24, "stdlib should handshake per request"
+
+
+def test_pool_holds_the_whole_fan_out():
+    """7adbe2d configured num_pools (a count of hosts) and left maxsize at its
+    default of 1, so connections past the first were discarded rather than
+    parked. Asserted directly: with block=False the symptom is lost reuse, not
+    a failure, so no connection-count test reliably catches it.
+    """
+    pool = _http._new_pool()
+    host_pool = pool.connection_from_url("https://celestrak.org/")
+    assert host_pool.pool.maxsize >= 8, "must hold predictor.py's widest fan-out"
+    assert host_pool.block is False, "callers must never block waiting for a connection"
+
+
+def test_pooled_failures_name_the_underlying_cause(dead_port, transport):
+    """provider_health records str(e)[:120]. 7adbe2d mapped every urllib3 error
+    to a flat URLError, so the cause never reached the log — the reason its
+    Lambda-only failures were never diagnosed. Retries mean the wrapper is
+    almost always MaxRetryError, which names nothing, so .reason must lead.
+    """
+    if transport != "pooled":
+        pytest.skip("stdlib raises its own errors; nothing is being mapped")
+    with pytest.raises(urllib.error.URLError) as exc:
+        _http.urlopen(f"http://127.0.0.1:{dead_port}/ok", timeout=5)
+    detail = str(exc.value)[:120]
+    assert "MaxRetryError" not in detail.split(":")[0], "wrapper must not mask the cause"
+    assert "Error" in detail.split(":")[0], f"no urllib3 class in {detail!r}"
+
+
+def test_pool_retries_are_enabled_for_idempotent_gets():
+    """retries=False, 7adbe2d's setting, also switches off redirect following and
+    leaves nothing to recover a connection that went stale during a container
+    freeze. Every request through this module is a GET.
+    """
+    retries = _http._new_pool().connection_pool_kw["retries"]
+    assert retries.total >= 1 and retries.read >= 1 and retries.redirect >= 1
+    assert retries.raise_on_status is False, "4xx/5xx must reach the HTTPError mapping"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -350,6 +350,47 @@ def test_pool_retries_are_enabled_for_idempotent_gets():
     leaves nothing to recover a connection that went stale during a container
     freeze. Every request through this module is a GET.
     """
-    retries = _http._new_pool().connection_pool_kw["retries"]
+    retries = _http._retry_policy("api.open-meteo.com")
     assert retries.total >= 1 and retries.read >= 1 and retries.redirect >= 1
     assert retries.raise_on_status is False, "4xx/5xx must reach the HTTPError mapping"
+
+
+@pytest.mark.parametrize("host", ["celestrak.org", "gp.celestrak.org"])
+def test_celestrak_requests_are_never_replayed(host):
+    """circuit_breaker.py trips celestrak on the *first* failure with a 300 s
+    cooldown because its anti-abuse policy punishes concentrated retries. A
+    urllib3 retry sits below the breaker, so a replay there would never be
+    counted — the pattern that override exists to prevent.
+    """
+    assert _http._retry_policy(host).read == 0
+    assert _http._retry_policy("api.open-meteo.com").read > 0, "only celestrak is exempt"
+
+
+def test_read_retry_policy_controls_actual_replays(base_url, server, transport):
+    """The counters above are only meaningful if urllib3 honours them."""
+    if transport != "pooled":
+        pytest.skip("retry policy applies to the pooled transport only")
+    import urllib3
+
+    seen = []
+
+    class _Dropper(_Handler):
+        def do_GET(self):
+            seen.append(1)
+            self.close_connection = True  # drop mid-exchange -> a read error
+
+    drop_srv = _Server(("127.0.0.1", 0), _Dropper)
+    threading.Thread(target=drop_srv.serve_forever, daemon=True).start()
+    url = f"http://127.0.0.1:{drop_srv.server_address[1]}/x"
+    try:
+        for host, expected in (("api.open-meteo.com", 3), ("celestrak.org", 1)):
+            seen.clear()
+            pool = urllib3.PoolManager(num_pools=2, maxsize=2,
+                                       retries=_http._retry_policy(host))
+            with pytest.raises(urllib3.exceptions.HTTPError):
+                pool.request("GET", url, timeout=urllib3.Timeout(connect=3, read=3),
+                             preload_content=False)
+            assert len(seen) == expected, f"{host}: {len(seen)} requests, expected {expected}"
+    finally:
+        drop_srv.shutdown()
+        drop_srv.server_close()


### PR DESCRIPTION
## Summary

Phase 2 of CACHING.md item 3. **Stacked on #226** (base is `perf/http-pool-phase0`) — merge that first. Default off; `urllib.request` is unchanged until an operator flips the flag.

## Measured in-region

Throwaway `dh-pooltest-probe` Lambda, us-east-1, arm64, production Open-Meteo URL (28,820 B, matching prod). Torn down; nothing left behind.

| host | stdlib | pooled | saved |
|---|---|---|---|
| `api.open-meteo.com` | 541 ms | 118 ms | **423 ms (78%)** |
| `air-quality-api.open-meteo.com` | 382 ms | 94 ms | 288 ms (75%) |
| `www.7timer.info` | 339 ms | 134 ms | 205 ms (60%) |

### Safety: the freeze/thaw case, never tested in June

Five invocations on one surviving container, idle gaps of 75 s / 150 s / 240 s:

```
gap=75s   invocation=3  SAME container   ERRORS: none
gap=150s  invocation=4  SAME container   ERRORS: none
gap=240s  invocation=5  SAME container   ERRORS: none
  open_meteo   pooled=[420, 105]  -> reconnected
  air_quality  pooled=[385, 97]   -> reconnected
  seven_timer  pooled=[371, 130]  -> reconnected
```

A connection that dies while the container is frozen costs **one extra handshake, not a failure** — urllib3 detects it and reconnects. That recovery is exactly what `retries=False` removed in `7adbe2d`.

### How much this is actually worth in production — read this before quoting a number

The per-host savings above are per *repeat* call. Production's call pattern limits where that applies:

| host | calls within one `/night` invocation |
|---|---|
| `api.open-meteo.com` | 1 |
| `air-quality-api.open-meteo.com` | 1 |
| `www.7timer.info` | 1 |
| `celestrak.org` | 4 (3 `TRACKED_SATELLITES` + Starlink group) |

So within-invocation reuse — the large, reliable win — reaches only celestrak, and only when its 6 h TLE cache misses. **The weather path can only win across invocations on a warm container**, and the in-region data shows that is inconsistent: at a few seconds' gap `air_quality` reused fully (`[97, 96, 97]`) while `open_meteo` and `seven_timer` re-handshook.

Supporting context, not a prediction: per-container gaps between consecutive requests, measured across the 1,215 log streams in the archived 14-day window, are median 19 s / p25 8 s / p75 55 s, with 18% of containers serving exactly one request. Locally all three providers hold reuse ≥60 s, so the in-region losses look freeze-related rather than server keep-alive.

Net: the change is safe and free where it does not help, but the honest expected benefit is **well below** the 62% a warm-process local A/B suggests. #227's per-leg timing will settle it in one window once the flag is on.

## On the previous attempt

`7adbe2d` shipped a pool; `522fe9a` reverted it after Lambda-only failures. That version could not be reproduced against all five real providers under `predictor.py`'s real concurrency, and the June logs are past the 14-day retention, so **the root cause stays unproven**. The design no longer requires knowing it:

- Selection is per call behind `feature_flags`, default `False` → falling back takes ~30 s (flag cache TTL), no deploy. The original needed a revert and a redeploy.
- The urllib3 exception class now reaches the message `provider_health` records, led by `.reason` not the `MaxRetryError` wrapper (`NameResolutionError: …`, `NewConnectionError: …`). That flattening is why the original failures were never attributable.
- urllib3 is pinned in #226; botocore's range spans both majors and `7adbe2d` ran against 1.x in the container while local dev had 2.x.

Config differences from `7adbe2d`, each commented at the site it fixes: `maxsize=8` (it set only `num_pools`, a host count); `Retry` instead of `retries=False`, which also disabled redirects and left no recovery for a stale connection; `Timeout(connect, read)` instead of `total`, which would cut darksky's 60 s download short; a default User-Agent so bare-URL callers aren't switched to `python-urllib3/x`.

## Celestrak is exempt from replay

`circuit_breaker.py` trips celestrak on the **first** failure with a 300 s cooldown because "Celestrak's anti-abuse policy punishes exactly the concentrated-retry pattern that emerges at cache expiry". A urllib3 retry sits *below* the breaker, so the default `Retry(read=2)` would send up to 3 requests it never counts. Retry policy is now per host: celestrak keeps connect retries (which never reach the server) and drops read retries. Verified against a server that drops mid-exchange — default hosts send 3 requests, celestrak sends 1.

The trade is that celestrak loses stale-connection recovery and will occasionally spend a real failure on one. Cheap, on the same reasoning the breaker override already rests on: the TLE cache is global with a stale fallback and one success serves every user for 6 h.

## Corrections to my own earlier readings

- `maxsize=1` with `block=False` degrades reuse and emits "pool is full" — it does **not** starve callers. A throughput defect, not the failure that forced the revert. Asserted on config rather than connection counts for that reason.
- An earlier reuse-window measurement inferred "reused" from a latency ratio and reported a 15 s window for two hosts. That was noise; measured deterministically via `HTTPConnectionPool.num_connections`, all three hold ≥60 s.
- DynamoDB is not behind the production 2,082 ms `wx` median: zero throttling in 14 days, PutItem averages 3.5 ms.

## Test plan

- `python -m pytest -q` — 1010 passed, 11 skipped. `tests/test_http.py` runs the full contract against **both** transports.
- Connection-reuse assertions (4 sequential requests → 1 connection pooled, 4 unpooled), direct assertions on `maxsize`, the retry policy, and the celestrak no-replay invariant.
- `PYNIGHTSKY_LIVE=1 pytest -m live` — 6 passed on both transports.
- All five providers exercised through the pooled path cold and warm; `HTTPError.code` and a readable error body preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)