### PR TITLE
Probe the cache on cold containers instead of reporting a hollow ok

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -141,14 +141,25 @@ _MAX_CALENDAR_DAYS = 30              # /calendar range-length cap (mirrors old _
 # ── health check helpers ──────────────────────────────────────────────────────
 
 _CACHE_CHECK_TTL = 60   # reuse cache round-trip result this long (seconds)
-_cache_check_state: dict = {"ts": 0.0, "result": {}}
+# ts is None until the first real probe, never 0.0: the clock below is wall time,
+# but this used to be time.monotonic(), which is uptime-relative. A 0.0 sentinel
+# against a monotonic clock means "now - 0.0 < TTL" is true for the whole first
+# minute of a host's life, so a cold Lambda container returned the empty result
+# below without ever probing the cache — and healthz() reads a missing "status"
+# as neither error nor degraded, i.e. reports ok.
+_cache_check_state: dict = {"ts": None, "result": {}}
 
 
 def _check_cache_health() -> dict:
     """Round-trip the active cache backend. For the local backend, also checks disk space.
     Result is cached for _CACHE_CHECK_TTL seconds so rapid health polls don't hammer DynamoDB."""
-    now = time.monotonic()
-    if now - _cache_check_state["ts"] < _CACHE_CHECK_TTL:
+    # time.time(), not time.monotonic(): the monotonic clock doesn't reliably
+    # advance while a Lambda container is frozen between invocations, so a
+    # sparsely-invoked container could serve a stale probe far longer than the
+    # TTL in real time. Same reasoning as feature_flags._cached_value().
+    now = time.time()
+    last = _cache_check_state["ts"]
+    if last is not None and now - last < _CACHE_CHECK_TTL:
         return _cache_check_state["result"]
     try:
         from darkhours import ports as _p

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,11 +73,35 @@ def test_check_cache_health_does_not_leak_exception_text(monkeypatch):
         raise RuntimeError(_sensitive_marker)
 
     monkeypatch.setattr(_ports.get_backend().cache, "set", _boom)
-    monkeypatch.setitem(main_mod._cache_check_state, "ts", 0.0)  # force a fresh check
+    monkeypatch.setitem(main_mod._cache_check_state, "ts", None)  # force a fresh check
     result = main_mod._check_cache_health()
     assert result["status"] == "error"
     assert result["detail"] == "cache health check failed"
     assert _sensitive_marker not in result["detail"]
+
+
+def test_cache_health_probes_on_a_freshly_booted_host(monkeypatch):
+    """A cold Lambda container must still probe the cache.
+
+    The TTL guard used to compare an uptime-relative time.monotonic() against a
+    0.0 sentinel, so for the first _CACHE_CHECK_TTL seconds of a host's life
+    "now - 0.0 < TTL" held and the empty seed result was returned unprobed.
+    healthz() reads a missing "status" as neither error nor degraded, so the
+    endpoint reported ok having never touched the cache. This test pins the
+    fresh-clock case; the suite otherwise only ever runs on a long-uptime host.
+    """
+    calls = []
+    monkeypatch.setattr(main_mod, "_cache_check_state", {"ts": None, "result": {}})
+    monkeypatch.setattr(main_mod.time, "time", lambda: 5.0)  # 5 s since boot
+
+    from darkhours import ports as _ports
+    real_set = _ports.get_backend().cache.set
+    monkeypatch.setattr(_ports.get_backend().cache, "set",
+                        lambda *a, **kw: (calls.append(1), real_set(*a, **kw))[1])
+
+    result = main_mod._check_cache_health()
+    assert calls, "cache was never probed on a freshly-booted host"
+    assert result.get("status") in {"ok", "degraded", "error"}, result
 
 
 def test_healthz_includes_feature_flags_snapshot(monkeypatch):


### PR DESCRIPTION
## Summary

Independent bug fix off `main`. Surfaced as the flaky CI failure on #226, but it is not related to that change and blocks all three PRs in the `_http` stack.

`_cache_check_state` seeded `ts` to `0.0` and the TTL guard compared it against `time.monotonic()`, which is **uptime-relative**. For the first `_CACHE_CHECK_TTL` (60 s) of a host's life, `now - 0.0 < 60` holds, so `_check_cache_health()` returned the empty seed result without probing anything.

`healthz()` then reads a missing `"status"` as neither error nor degraded:

```python
statuses = {c.get("status") for c in checks.values()}
overall = "error" if "error" in statuses else "degraded" if "degraded" in statuses else "ok"
```

So `/healthz` answered **`overall: "ok"` having never touched the cache** — for the first minute of every cold Lambda container.

Two changes:

- `ts` is `None` until the first real probe, so the sentinel can't be mistaken for a recent check.
- The clock moves to `time.time()`. `time.monotonic()` doesn't reliably advance while a container is frozen between invocations, so a sparsely-invoked container could serve a stale probe far past the TTL in real time. Same reasoning `feature_flags._cached_value()` already documents.

### Why it looked flaky

`test_check_cache_health_does_not_leak_exception_text` forced a fresh check with `ts = 0.0`, which does nothing on a runner whose uptime is under 60 s. It passed locally and on long-lived runners and failed on freshly booted ones — one `gate` run passed and another failed on the same commit.

## Test plan

- `python -m pytest -q` — 953 passed, 9 skipped.
- New `test_cache_health_probes_on_a_freshly_booted_host` pins the cold-clock case directly; the suite otherwise only ever exercises a long-uptime host.
- Verified the test catches the original bug: with the old `0.0` sentinel on a 5 s-old host, `_check_cache_health()` returns `{}`; with `None` it returns a real status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)