### PR TITLE
Read the COSPAR designator as a launch number, not a day of the year

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ through `ports.py`. The same engine runs against local files (CLI) or cloud serv
 - `live` — hits real provider APIs; runs only with `PYNIGHTSKY_LIVE=1`
   (`tests/test_provider_smoke.py` covers Open-Meteo, 7Timer, Celestrak, Nominatim, AWS Location).
 
-A default run stays offline and deterministic (1007 tests collected as of 2026-08-23;
+A default run stays offline and deterministic (1019 tests collected as of 2026-08-23;
 aws/live auto-skip). Per-file inventory: `tests/README.md`.
 
 ## Ship flow (CI/CD)

--- a/apps/warmer/handler.py
+++ b/apps/warmer/handler.py
@@ -8,8 +8,9 @@ data silently disappears from every request. That is why it verifies its own wri
 and alarms on failure rather than reporting a status derived from the fetch alone.
 
 TLE is GLOBAL (one dataset for every user and every location), so there is nothing
-per-region to warm — this refreshes the handful of tracked-satellite TLEs plus the
-filtered Starlink train list, under the same keys the request path reads.
+per-region to warm — this refreshes the handful of tracked-satellite TLEs, the
+recent-launch dates the train filter needs, and the filtered Starlink train list,
+under the same keys the request path reads.
 
 Imports stay light on purpose: ``tle_provider`` only touches the cache port
 (DynamoDB), never the raster adapter (which would pull in rasterio/GDAL — 335 MB).
@@ -35,6 +36,12 @@ def _emit_key_metrics(key_result) -> None:
     back out of the cache after the write, so it cannot report success for a write
     that was silently rejected. TleCachedBytes exists so an item creeping toward
     DynamoDB's 400 KB ceiling is visible on a graph before it crosses it.
+
+    TleWarmItems is how many entries the value holds. A verified write of an empty
+    list is a success by every other measure here, and for the Starlink train key an
+    empty list is also the normal state between launches — which is exactly how a
+    filter that could never match anything stayed invisible. The count separates
+    "nothing to show tonight" from "nothing, for weeks".
     """
     emf = {
         "_aws": {
@@ -45,12 +52,14 @@ def _emit_key_metrics(key_result) -> None:
                 "Metrics": [
                     {"Name": "TleWarmSuccess", "Unit": "Count"},
                     {"Name": "TleCachedBytes", "Unit": "Bytes"},
+                    {"Name": "TleWarmItems", "Unit": "Count"},
                 ],
             }],
         },
         "Key": key_result.label,
         "TleWarmSuccess": 1 if key_result.verified else 0,
         "TleCachedBytes": key_result.bytes,
+        "TleWarmItems": key_result.count,
     }
     print(json.dumps(emf))
 

--- a/darkhours/satellites.py
+++ b/darkhours/satellites.py
@@ -20,7 +20,7 @@ Public API:
 
 import logging
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
 
@@ -427,22 +427,20 @@ def _az_diff(az1: float, az2: float) -> float:
     return min(diff, 360 - diff)
 
 
-def _parse_cospar_launch_date(line1: str) -> Optional[date]:
-    """
-    Extract the launch date from the TLE line 1 International Designator (cols 9-16).
+def _entry_launch_date(entry) -> Optional[date]:
+    """Read the launch date tle_provider carries alongside the TLE.
 
-    Format: YYLAUNCH_DOY + PIECE, e.g. "24191G" = 2024, day-of-year 191, piece G.
-    Returns None if the field is absent, a placeholder ("TBA"), or malformed.
+    It is not derivable from the TLE. Line 1 columns 10-17 hold the launch *number*
+    within its year, not a day of the year, so reading "26159" as day 159 dates the
+    11 July 2026 launch to 8 June. tle_provider joins the real dates on from the
+    SATCAT at filter time and passes them through as a fourth element; entries
+    without one (an older cache row) simply have no launch date to show.
     """
+    if len(entry) < 4:
+        return None
     try:
-        intl = line1[9:17].strip()
-        if len(intl) < 5 or not intl[:2].isdigit() or not intl[2:5].isdigit():
-            return None
-        year_2d = int(intl[:2])
-        year    = 2000 + year_2d if year_2d < 57 else 1900 + year_2d
-        doy     = int(intl[2:5])
-        return date(year, 1, 1) + timedelta(days=doy - 1)
-    except (ValueError, IndexError):
+        return date.fromisoformat(entry[3])
+    except (TypeError, ValueError):
         return None
 
 
@@ -457,9 +455,11 @@ def starlink_train_passes(
     Detect Starlink train passes over (*lat*, *lon*) between *t_start* and *t_end*.
 
     Accepts a pre-filtered list of raising-phase Starlink TLEs from
-    tle_provider.cached_starlink_trains().  Uses a lightweight single-point
-    sunlit check at pass peak (no shadow-window scan) since trains are
-    displayed as group summaries rather than precise rise/set events.
+    tle_provider.cached_starlink_trains(), as (name, line1, line2, launch_date_iso)
+    entries; three-element entries are accepted without a launch date.  Uses a
+    lightweight single-point sunlit check at pass peak (no shadow-window scan)
+    since trains are displayed as group summaries rather than precise rise/set
+    events.
 
     Groups passes into trains when:
       - Rise times of consecutive members are ≤ _TRAIN_GAP_S seconds apart
@@ -485,7 +485,9 @@ def starlink_train_passes(
 
         all_passes: list[dict] = []
 
-        for name, line1, line2 in train_tles:
+        for entry in train_tles:
+            name, line1, line2 = entry[0], entry[1], entry[2]
+            launch_date        = _entry_launch_date(entry)
             try:
                 satellite = EarthSatellite(line1, line2, name, ts)
 
@@ -526,7 +528,7 @@ def starlink_train_passes(
                         "dur_min":     float(dur_min),
                         "sky_dark":    sun_alt < _CIVIL_TWILIGHT_ALT,
                         "moon_sep":    moon_sep,
-                        "launch_date": _parse_cospar_launch_date(line1),
+                        "launch_date": launch_date,
                     })
             except Exception:
                 continue

--- a/darkhours/tle_provider.py
+++ b/darkhours/tle_provider.py
@@ -20,9 +20,9 @@ flag to misconfigure and no new call site that can quietly reintroduce a fetch.
 
 Public API:
     cached_tle(norad_id)                 → TLEResult              (request path)
-    cached_starlink_trains()             → (list[tuple], stale, error)
+    cached_starlink_trains()             → (list[tuple], stale, error)   (request path)
     refresh_tle(norad_id, timeout=…)     → TLEResult              (warmer/CLI)
-    refresh_starlink_trains(timeout=…)   → (list[tuple], stale, error)
+    refresh_starlink_trains(timeout=…, launch_dates=…)                   (warmer/CLI)
     warm_cache(timeout=…, force=True)    → WarmSummary            (warmer/CLI)
     get_tle(norad_id, timeout=…)         → TLEResult              (CLI convenience)
     get_starlink_train_tles(timeout=…)   → (list[tuple], stale, error)
@@ -31,12 +31,15 @@ Public API:
     TRACKED_SATELLITES                   → [(norad_id, display_name), ...]
 """
 
+import csv
+import io
 import json
 import logging
 import threading
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
 
 from . import cache as _cache
 from . import circuit_breaker as _cb
@@ -128,6 +131,7 @@ class WarmKeyResult:
     status: str            # human-readable, for the log line
     verified: bool         # the value was read back out of the cache afterwards
     bytes: int = 0         # serialized size of the verified value
+    count: int = 0         # how many items the value holds, where that is meaningful
     error: str | None = None
 
 
@@ -140,7 +144,8 @@ class WarmSummary:
         return {
             "ok": self.ok,
             "results": {
-                k.label: {"status": k.status, "verified": k.verified, "bytes": k.bytes}
+                k.label: {"status": k.status, "verified": k.verified,
+                          "bytes": k.bytes, "count": k.count}
                 for k in self.keys
             },
         }
@@ -250,13 +255,16 @@ def cached_tle(norad_id: int) -> TLEResult:
     return TLEResult(lines=None, stale=False, error=msg)
 
 
-def cached_starlink_trains() -> tuple[list[tuple[str, str, str]], bool, str | None]:
+def cached_starlink_trains() -> tuple[list[tuple[str, str, str, str | None]], bool, str | None]:
     """Return the cached Starlink train TLEs, or a degraded result. Never fetches.
 
     An empty list is a legitimate answer — there is frequently no launch in the
     raising phase — so every check here is ``is not None``, not truthiness. Reading
     an empty cached list as "nothing cached" would send us back to fetching on the
     request path for the most common case.
+
+    Each entry is ``(name, line1, line2, launch_date_iso)``. The launch date rides
+    along because it is not derivable from the TLE — see ``_cospar_designator``.
     """
     key = _STARLINK_TRAINS_CACHE_KEY
 
@@ -274,12 +282,32 @@ def cached_starlink_trains() -> tuple[list[tuple[str, str, str]], bool, str | No
     return [], False, msg
 
 
-def _as_tle_tuples(value) -> list[tuple[str, str, str]]:
-    """Coerce the cached JSON (lists of 3 strings) back to the tuples callers expect."""
-    out: list[tuple[str, str, str]] = []
+def _as_tle_tuples(value) -> list[tuple[str, str, str, str | None]]:
+    """Coerce the cached JSON back to the tuples callers expect.
+
+    Entries are ``[name, line1, line2, launch_date]``. The launch date travels
+    with the TLE because it cannot be recovered from one: line 1 carries the
+    launch *number* within its year, not a date (see ``_cospar_designator``).
+    Three-element entries written by an older build are still accepted and read
+    as an unknown launch date.
+    """
+    out: list[tuple[str, str, str, str | None]] = []
     for entry in value or []:
-        if isinstance(entry, (list, tuple)) and len(entry) == 3:
-            out.append((entry[0], entry[1], entry[2]))
+        if isinstance(entry, (list, tuple)) and len(entry) >= 3:
+            launch = entry[3] if len(entry) > 3 else None
+            out.append((entry[0], entry[1], entry[2],
+                        launch if isinstance(launch, str) else None))
+    return out
+
+
+def _as_launch_dates(value) -> dict[str, date]:
+    """Coerce the cached ``{designator: "YYYY-MM-DD"}`` map back to dates."""
+    out: dict[str, date] = {}
+    for designator, iso in (value or {}).items():
+        try:
+            out[designator] = date.fromisoformat(iso)
+        except (TypeError, ValueError):
+            continue
     return out
 
 
@@ -301,9 +329,31 @@ _STARLINK_GROUP_URL       = ("https://celestrak.org/NORAD/elements/gp.php"
 # never read back in the wrong shape.
 _STARLINK_TRAINS_CACHE_KEY = "tle|starlink|trains"
 
-_STARLINK_TRAIN_MM_MIN    = 15.5   # rev/day → altitude ≲ 430 km → raising phase
-                                   # (operational Starlink sits at ~550 km / ~15.1 rev/day)
+# Celestrak's SATCAT is the only place a launch *date* exists. GP/TLE data carries
+# a launch number, not a date (see _cospar_designator), so the recency half of the
+# train filter has no other source. Warmer path only, like every fetch here.
+_STARLINK_SATCAT_URL      = ("https://celestrak.org/satcat/records.php"
+                             "?GROUP=starlink&FORMAT=CSV")
+_STARLINK_LAUNCH_DATES_CACHE_KEY = "tle|starlink|launch_dates"
+
+# rev/day. Every operational Starlink shell sits at or below ~15.12 rev/day
+# (530-560 km); above this line a satellite has not reached its shell yet. The
+# previous value of 15.5 (~345 km) described only the lowest insertion orbit, and
+# dropped batches deployed directly at ~465 km — three of the four most recent
+# launches in the feed on 2026-08-23.
+_STARLINK_TRAIN_MM_MIN    = 15.2
 _STARLINK_RECENT_DAYS     = 21     # only launches within this window can form a visible train
+
+# The cached launch-date map is pruned to this window. The filter only ever asks
+# about _STARLINK_RECENT_DAYS; the wider margin keeps the item small (tens of
+# entries out of ~700 Starlink launches) while leaving headroom to widen the
+# train window without needing a second change here.
+_STARLINK_LAUNCH_DATE_WINDOW_DAYS = 90
+
+# Whole-transfer bounds for the SATCAT fetch — same reasoning as the group fetch
+# below. The CSV is ~1 MB today.
+_SATCAT_MAX_BYTES         = 16 * 1024 * 1024
+_SATCAT_TRANSFER_DEADLINE = 45.0
 
 # Ceiling on what we will store. The observed raising-phase population is ~880
 # satellites (~150 KB serialized) before the recency filter narrows it; capping the
@@ -326,61 +376,182 @@ def _parse_mean_motion(line2: str) -> float | None:
         return None
 
 
-def _parse_launch_date(line1: str):
-    """
-    Parse the launch date from the TLE line 1 International Designator (cols 9-16).
+def _cospar_designator(line1: str) -> str | None:
+    """Return the launch's COSPAR designator from TLE line 1, e.g. ``"2026-159"``.
 
-    Format: YYLAUNCHDAY_OF_YEAR + PIECE, e.g. "24191G" = 2024, day 191, piece G.
-    Returns a date object or None if the field is absent / malformed.
+    Columns 10-17 hold ``YYNNNPPP``: two-digit year, launch number *within that
+    year*, and piece. NNN is a sequence number, not a day of the year — 1998-067A
+    (the ISS) launched on 20 November 1998, and day 67 of 1998 is 8 March.
+
+    This identifies a launch; it cannot date one. Reading NNN as a day-of-year is
+    what made the train filter match nothing: it re-dated every launch to somewhere
+    in the first third of its year, so on 2026-08-23 the newest launch in the feed
+    (2026-159, launched 11 July) presented as 8 June and fell outside every window
+    the filter could reasonably use. Launch dates come from the SATCAT instead —
+    see _fetch_starlink_launch_dates.
     """
-    from datetime import date, timedelta
-    try:
-        intl = line1[9:17].strip()
-        if len(intl) < 5 or not intl[:2].isdigit() or not intl[2:5].isdigit():
-            return None
-        year_2d = int(intl[:2])
-        year    = 2000 + year_2d if year_2d < 57 else 1900 + year_2d
-        doy     = int(intl[2:5])
-        return date(year, 1, 1) + timedelta(days=doy - 1)
-    except (ValueError, IndexError):
+    intl = line1[9:17].strip()
+    if len(intl) < 5 or not intl[:5].isdigit():
         return None
+    year_2d = int(intl[:2])
+    year    = 2000 + year_2d if year_2d < 57 else 1900 + year_2d
+    return f"{year}-{intl[2:5]}"
 
 
-def _filter_train_tles(raw: str) -> list[tuple[str, str, str]]:
+def _parse_satcat_launch_dates(csv_text: str, today: date) -> dict[str, date]:
+    """Build ``{designator: launch date}`` from a SATCAT CSV, pruned to recent launches."""
+    cutoff = today - timedelta(days=_STARLINK_LAUNCH_DATE_WINDOW_DAYS)
+    out: dict[str, date] = {}
+    for row in csv.DictReader(io.StringIO(csv_text)):
+        object_id = (row.get("OBJECT_ID") or "").strip()
+        raw_date  = (row.get("LAUNCH_DATE") or "").strip()
+        if len(object_id) < 8:
+            continue
+        try:
+            launched = date.fromisoformat(raw_date)
+        except ValueError:
+            continue
+        if launched >= cutoff:
+            out[object_id[:8]] = launched
+    return out
+
+
+def _filter_train_tles(
+    raw: str, launch_dates: dict[str, date]
+) -> list[tuple[str, str, str, str]]:
     """
     Parse a multi-TLE block and return only raising-phase Starlinks from recent launches.
 
     Two-part filter:
-      1. Mean motion ≥ _STARLINK_TRAIN_MM_MIN — satellite is below operational altitude
-      2. Launch date within _STARLINK_RECENT_DAYS — satellite is from a recent deployment;
-         older batches have spread out and no longer form a visible train even if they
-         haven't yet reached full operational altitude
+      1. Mean motion ≥ _STARLINK_TRAIN_MM_MIN — the satellite is still below every
+         operational shell, so it has not been handed over to service yet.
+      2. The launch is within _STARLINK_RECENT_DAYS, per *launch_dates* — an older
+         batch has spread around its orbit and no longer crosses the sky as a train
+         even while it is still raising.
+
+    Recency is the load-bearing half, and it is why this needs the SATCAT. Mean
+    motion alone is not a train signal: ~880 of the ~10,700 satellites in the group
+    are above the threshold at any moment, and most are old satellites being lowered
+    for re-entry rather than new ones being raised.
+
+    An empty *launch_dates* therefore fails closed. Without dates the two populations
+    are indistinguishable, and emitting the raising-phase set unfiltered would put
+    hundreds of decaying satellites on screen labelled as trains.
+
+    Ordered newest launch first so _STARLINK_MAX_TRAINS truncates the oldest batch
+    rather than an arbitrary one.
 
     The recency cutoff is evaluated here, at filter time, and the result is what gets
     cached — so it is frozen for up to one refresh interval (6 h) against a 21-day
     window. That drift is immaterial; caching the raw block instead is what was not.
     """
-    from datetime import datetime, timedelta, timezone
+    if not launch_dates:
+        log.error("No Starlink launch dates available — cannot tell a train from a "
+                  "decaying satellite, so no trains will be reported",
+                  extra={"service": "celestrak"})
+        return []
+
     cutoff = datetime.now(timezone.utc).date() - timedelta(days=_STARLINK_RECENT_DAYS)
 
     lines  = [l.strip() for l in raw.splitlines() if l.strip()]
-    result = []
+    dated: list[tuple[date, tuple[str, str, str, str]]] = []
+    raising = 0
     i = 0
     while i + 2 <= len(lines) - 1:
         name, l1, l2 = lines[i], lines[i + 1], lines[i + 2]
         if l1.startswith("1 ") and l2.startswith("2 "):
-            mm          = _parse_mean_motion(l2)
-            launch_date = _parse_launch_date(l1)
-            is_raising  = mm is not None and mm >= _STARLINK_TRAIN_MM_MIN
-            # Include if launch date is unknown (un-catalogued) OR within the cutoff
-            is_recent   = launch_date is None or launch_date >= cutoff
-            if is_raising and is_recent:
-                result.append((name, l1, l2))
+            mm = _parse_mean_motion(l2)
+            if mm is not None and mm >= _STARLINK_TRAIN_MM_MIN:
+                raising += 1
+                launched = launch_dates.get(_cospar_designator(l1) or "")
+                if launched is not None and launched >= cutoff:
+                    dated.append((launched, (name, l1, l2, launched.isoformat())))
             i += 3
         else:
             i += 1
-    log.debug("Filtered %d Starlink train candidates from group TLE", len(result))
-    return result
+
+    dated.sort(key=lambda entry: entry[0], reverse=True)
+    log.debug("Filtered %d Starlink train candidates from group TLE (%d raising)",
+              len(dated), raising)
+    return [entry for _, entry in dated]
+
+
+def _prune_expired_trains(
+    trains: list[tuple[str, str, str, str | None]],
+) -> list[tuple[str, str, str, str | None]]:
+    """Drop cached entries whose launch has aged out of the train window.
+
+    Celestrak's 403 means the group has not changed, so there is nothing to
+    re-filter — but the 21-day window has still moved since the list was built, and
+    the raw block is deliberately not kept. Each entry carries its own launch date,
+    so the cached list can be aged without refetching anything.
+    """
+    cutoff = datetime.now(timezone.utc).date() - timedelta(days=_STARLINK_RECENT_DAYS)
+    kept: list[tuple[str, str, str, str | None]] = []
+    for entry in trains:
+        try:
+            launched = date.fromisoformat(entry[3])
+        except (TypeError, ValueError):
+            continue
+        if launched >= cutoff:
+            kept.append(entry)
+    return kept
+
+
+def _fetch_starlink_launch_dates(timeout: float = _WARM_FETCH_TIMEOUT) -> dict[str, date]:
+    """Fetch recent Starlink launch dates from Celestrak's SATCAT, and cache them.
+
+    Falls back to the cached map (fresh, then expired) on any failure: a launch date
+    does not change once it is set, so a stale map is as good as a new one for every
+    launch it already covers, and losing the map entirely disables the train filter.
+    """
+    key = _STARLINK_LAUNCH_DATES_CACHE_KEY
+
+    if not _cb.allow("celestrak"):
+        log.debug("SATCAT fetch skipped — celestrak circuit open")
+    else:
+        req = urllib.request.Request(_STARLINK_SATCAT_URL,
+                                     headers={"User-Agent": _USER_AGENT})
+        try:
+            with _rl.acquire("celestrak"), _http.urlopen(req, timeout=timeout) as resp:
+                body = _http.read_capped(
+                    resp, _SATCAT_MAX_BYTES, _SATCAT_TRANSFER_DEADLINE
+                )
+            dates = _parse_satcat_launch_dates(
+                body.decode("utf-8"), datetime.now(timezone.utc).date()
+            )
+            _ph.record("celestrak", "ok")
+            _cb.on_success("celestrak")
+            if dates:
+                _cache.set(key, {d: v.isoformat() for d, v in dates.items()},
+                           ttl_seconds=TLE_TTL)
+                log.debug("Fetched %d recent Starlink launch dates from SATCAT", len(dates))
+                return dates
+            # Reached Celestrak and it had nothing recent. Not a transport failure,
+            # so it must not touch the breaker.
+            log.warning("Celestrak SATCAT listed no Starlink launch in the last %d days",
+                        _STARLINK_LAUNCH_DATE_WINDOW_DAYS)
+        except urllib.error.HTTPError as e:
+            log.warning("Celestrak SATCAT HTTP %d", e.code)
+            _ph.record("celestrak",
+                       "degraded" if e.code == 429 else "error", f"HTTP {e.code}")
+            _cb.on_failure("celestrak")
+        except urllib.error.URLError as e:
+            log.warning("Celestrak SATCAT unreachable: %s", e.reason)
+            _ph.record("celestrak", "error", str(e.reason)[:120])
+            _cb.on_failure("celestrak")
+        except Exception as e:
+            log.warning("Celestrak SATCAT fetch failed: %s", e)
+            _ph.record("celestrak", "error", str(e)[:120])
+            _cb.on_failure("celestrak")
+
+    cached = _cache.get(key)
+    if cached is None:
+        cached = _cache.get_stale(key)
+    if cached:
+        log.debug("Using cached Starlink launch dates")
+        return _as_launch_dates(cached)
+    return {}
 
 
 # ---------------------------------------------------------------------------
@@ -442,7 +613,8 @@ def refresh_tle(norad_id: int, timeout: float = _WARM_FETCH_TIMEOUT) -> TLEResul
 
 def refresh_starlink_trains(
     timeout: float = _WARM_FETCH_TIMEOUT,
-) -> tuple[list[tuple[str, str, str]], bool, str | None]:
+    launch_dates: dict[str, date] | None = None,
+) -> tuple[list[tuple[str, str, str, str | None]], bool, str | None]:
     """Fetch the Starlink group, filter it to raising-phase trains, and cache that.
 
     Returns (tles, stale, error). Never raises: a read timeout mid-response arrives
@@ -450,11 +622,35 @@ def refresh_starlink_trains(
     connect-phase failures), and an uncaught exception here previously crashed the
     entire /night response for callers that do not expect this to raise.
 
+    *launch_dates* is fetched here when the caller does not supply one; warm_cache
+    passes the map it already has so a warm run makes exactly one SATCAT request.
+
     The filtered list is what reaches the cache — see _STARLINK_TRAINS_CACHE_KEY for
     why caching the raw response could never work.
     """
     key = _STARLINK_TRAINS_CACHE_KEY
     err_msg: str | None = None
+
+    if launch_dates is None:
+        launch_dates = _fetch_starlink_launch_dates(timeout)
+
+    if not launch_dates:
+        # Nothing to gain from downloading 1.8 MB we cannot filter: without launch
+        # dates the group is indistinguishable from a list of decaying satellites
+        # (see _filter_train_tles). Returning here also keeps a SATCAT failure
+        # reported as itself, rather than as a group fetch that quietly never ran
+        # because the shared celestrak breaker had already opened underneath it.
+        if not _cb.allow("celestrak"):
+            # An open breaker is a deliberate skip, not a failure — same silent-skip
+            # contract the group fetch below honours.
+            log.debug("Starlink train refresh skipped — celestrak circuit open")
+        else:
+            err_msg = "no Starlink launch dates available — cannot identify trains"
+            log.warning("%s", err_msg)
+        cached = _cache.get_stale(key)
+        if cached is not None:
+            return _prune_expired_trains(_as_tle_tuples(cached)), True, err_msg
+        return [], False, err_msg
 
     with _lock_for(key):
         if not _cb.allow("celestrak"):
@@ -468,7 +664,7 @@ def refresh_starlink_trains(
                         resp, _STARLINK_MAX_BYTES, _STARLINK_TRANSFER_DEADLINE
                     )
                 raw    = body.decode("utf-8").strip()
-                trains = _filter_train_tles(raw)[:_STARLINK_MAX_TRAINS]
+                trains = _filter_train_tles(raw, launch_dates)[:_STARLINK_MAX_TRAINS]
                 _cache.set(key, trains, ttl_seconds=TLE_TTL)
                 log.debug("Fetched Starlink group TLE (%d bytes → %d trains)",
                           len(raw), len(trains))
@@ -483,12 +679,14 @@ def refresh_starlink_trains(
                     # keeps confirming it.
                     cached = _cache.get_stale(key)
                     if cached is not None:
-                        _cache.set(key, cached, ttl_seconds=TLE_TTL)
+                        trains = _prune_expired_trains(_as_tle_tuples(cached))
+                        _cache.set(key, [list(t) for t in trains], ttl_seconds=TLE_TTL)
                         log.info("Celestrak Starlink group 403 — revalidated, "
-                                 "TTL extended to %d h", TLE_TTL // 3600)
+                                 "%d trains still in window, TTL extended to %d h",
+                                 len(trains), TLE_TTL // 3600)
                         _ph.record("celestrak", "ok")
                         _cb.on_success("celestrak")
-                        return _as_tle_tuples(cached), False, None
+                        return trains, False, None
                     # 403 with nothing cached: re-asking returns the same 403, so
                     # treat it as a failure and let the breaker open rather than
                     # retrying on every request.
@@ -558,7 +756,8 @@ def warm_cache(timeout: float = _WARM_FETCH_TIMEOUT, force: bool = True) -> Warm
     """
     summary = WarmSummary()
 
-    def _record(key: str, label: str, status: str, error: str | None = None) -> None:
+    def _record(key: str, label: str, status: str, error: str | None = None,
+                count: int = 0) -> None:
         verified, size = _verify(key)
         if not verified:
             status = f"{status} but NOT CACHED"
@@ -566,7 +765,8 @@ def warm_cache(timeout: float = _WARM_FETCH_TIMEOUT, force: bool = True) -> Warm
         if error is not None:
             summary.ok = False
         summary.keys.append(WarmKeyResult(key=key, label=label, status=status,
-                                          verified=verified, bytes=size, error=error))
+                                          verified=verified, bytes=size,
+                                          count=count, error=error))
 
     for norad, label in TRACKED_SATELLITES:
         key = _tle_key(norad)
@@ -581,17 +781,43 @@ def warm_cache(timeout: float = _WARM_FETCH_TIMEOUT, force: bool = True) -> Warm
         else:
             _record(key, label, "ok")
 
+    # Launch dates first: the train filter cannot run without them, and warming
+    # them under their own key means a SATCAT failure shows up as itself rather
+    # than as an unexplained empty train list.
+    dates_key    = _STARLINK_LAUNCH_DATES_CACHE_KEY
+    launch_dates: dict[str, date] = {}
+    if not force and _cache.get(dates_key) is not None:
+        launch_dates = _as_launch_dates(_cache.get(dates_key))
+        _record(dates_key, "starlink-launch-dates", "fresh (skipped)",
+                count=len(launch_dates))
+    else:
+        launch_dates = _fetch_starlink_launch_dates(timeout=timeout)
+        if launch_dates:
+            _record(dates_key, "starlink-launch-dates",
+                    f"ok ({len(launch_dates)} launches)", count=len(launch_dates))
+        else:
+            _record(dates_key, "starlink-launch-dates", "FAIL",
+                    error="no Starlink launch dates from SATCAT")
+
     key = _STARLINK_TRAINS_CACHE_KEY
     if not force and _cache.get(key) is not None:
-        _record(key, "starlink", "fresh (skipped)")
+        _record(key, "starlink", "fresh (skipped)",
+                count=len(_as_tle_tuples(_cache.get(key))))
     else:
-        trains, stale, err = refresh_starlink_trains(timeout=timeout)
+        trains, stale, err = refresh_starlink_trains(timeout=timeout,
+                                                     launch_dates=launch_dates)
         if err is not None:
-            _record(key, "starlink", "FAIL", error=err)
+            _record(key, "starlink", "FAIL", error=err, count=len(trains))
         elif stale:
-            _record(key, "starlink", "stale", error="stale")
+            _record(key, "starlink", "stale", error="stale", count=len(trains))
         else:
-            _record(key, "starlink", f"ok ({len(trains)} trains)")
+            # A train list is legitimately empty most of the time, so this is not a
+            # failure — but it is the state that hid a broken filter for months, and
+            # the count is what makes a permanent zero visible on a graph.
+            newest = max((t[3] for t in trains if len(t) > 3 and t[3]), default=None)
+            detail = f" (newest launch {newest})" if newest else ""
+            _record(key, "starlink", f"ok ({len(trains)} trains){detail}",
+                    count=len(trains))
 
     return summary
 
@@ -625,7 +851,7 @@ def get_tle(norad_id: int, timeout: float = _FETCH_TIMEOUT) -> TLEResult:
 
 def get_starlink_train_tles(
     timeout: float = _FETCH_TIMEOUT,
-) -> tuple[list[tuple[str, str, str]], bool, str | None]:
+) -> tuple[list[tuple[str, str, str, str | None]], bool, str | None]:
     """Return (tles, stale, error) for Starlink satellites currently in raising phase,
     fetching if the cache has no fresh entry."""
     cached = _cache.get(_STARLINK_TRAINS_CACHE_KEY)

--- a/docs/TLE_CACHE.md
+++ b/docs/TLE_CACHE.md
@@ -10,7 +10,8 @@ path reads the cache and never fetches.**
 | `cached_tle(norad_id)` | no | `predictor.assemble_night` |
 | `cached_starlink_trains()` | no | `predictor.assemble_night` |
 | `refresh_tle(norad_id, timeout)` | yes | `warm_cache` |
-| `refresh_starlink_trains(timeout)` | yes | `warm_cache` |
+| `refresh_starlink_trains(timeout, launch_dates)` | yes | `warm_cache` |
+| `_fetch_starlink_launch_dates(timeout)` | yes | `warm_cache`, `refresh_starlink_trains` |
 | `warm_cache(timeout, force)` | yes | `apps/warmer/handler.py` (`force=True`), `darkhours.py --satellites` (`force=False`) |
 | `get_tle(norad_id, timeout)` | on miss | CLI only |
 | `get_starlink_train_tles(timeout)` | on miss | CLI only |
@@ -20,13 +21,51 @@ path reads the cache and never fetches.**
 | Key | Value | Bytes |
 |---|---|---|
 | `tle\|25544` / `tle\|20580` / `tle\|48274` | raw 3-line TLE text | ~172 |
-| `tle\|starlink\|trains` | `list[[name, line1, line2]]`, filtered, capped at `_STARLINK_MAX_TRAINS` (400) | 2 – 66,400 |
+| `tle\|starlink\|trains` | `list[[name, line1, line2, launch_date]]`, filtered, capped at `_STARLINK_MAX_TRAINS` (400) | 2 – 78,400 |
+| `tle\|starlink\|launch_dates` | `{COSPAR designator: "YYYY-MM-DD"}`, launches within `_STARLINK_LAUNCH_DATE_WINDOW_DAYS` (90) | ~30 – 1,500 |
+
+Three-element `tle\|starlink\|trains` rows are read as a train with no launch date.
 
 TTL: `TLE_TTL` = 24 h retention. Warm schedule: 6 h. `warm_cache(force=True)`
 re-`set`s every key on every run, so `expires` stays within one interval of 24 h.
 
 The Starlink group response is ~1.8 MB and is never cached. `DynamoCache.set`
 refuses any item over `_MAX_ITEM_BYTES` (380,000) and returns `False`.
+
+## Starlink train filter
+
+`_filter_train_tles` keeps a satellite only if both hold:
+
+| Gate | Constant | Value | Source |
+|---|---|---|---|
+| mean motion ≥ | `_STARLINK_TRAIN_MM_MIN` | 15.2 rev/day | TLE line 2, cols 52-63 |
+| launch within | `_STARLINK_RECENT_DAYS` | 21 days | SATCAT `LAUNCH_DATE` |
+
+Every operational Starlink shell is at or below ~15.12 rev/day (530–560 km).
+
+Launch dates are **not** derivable from a TLE. The International Designator
+(line 1, cols 10-17) is `YYNNNPPP` where `NNN` is the launch's sequence number
+within its year, not a day of the year: `1998-067A` is the ISS, launched
+1998-11-20. `_cospar_designator` returns `"YYYY-NNN"`; the date comes from SATCAT.
+
+An empty launch-date map fails the filter closed (0 trains, ERROR logged,
+`service=celestrak`) and skips the group fetch entirely.
+
+## Upstream sources
+
+| Data | Endpoint | Update policy |
+|---|---|---|
+| tracked TLEs | `gp.php?CATNR=<id>&FORMAT=TLE` | 403 = unchanged since last download |
+| Starlink group | `gp.php?GROUP=starlink&FORMAT=TLE` | 2 h; 403 = unchanged |
+| launch dates | `satcat/records.php?GROUP=starlink&FORMAT=CSV` | no download policy |
+
+GP element sets and SATCAT entries do not appear together. Observed 2026-08-23:
+SATCAT listed Starlink launches through 2026-08-12 (designators to `2026-184`,
+catalog numbers ≥ 100000), while GP data existed only through `2026-159`
+(2026-07-11). `GROUP=last-30-days` was empty, and `INTDES=`/`CATNR=` queries for
+the newer launches returned `No GP data found`. No trains are reportable while
+the newest GP launch is older than `_STARLINK_RECENT_DAYS`; `TleWarmItems` on
+`Key=starlink` is where that shows up.
 
 ## Degradation (request path)
 
@@ -46,7 +85,11 @@ Namespace `PyNightSky/Tle`, EMF from the warmer.
 |---|---|---|
 | `TleWarmSuccess` | `Key` | 1 = value read back out of the cache after the write |
 | `TleCachedBytes` | `Key` | serialized size of the verified value |
+| `TleWarmItems` | `Key` | entries in the verified value (trains, launches) |
 | `TleWarmFailure` | — | keys not verified this run; emitted as 0 on a clean run |
+
+`TleWarmSuccess=1` with `TleWarmItems=0` on `Key=starlink` is a verified write of an
+empty train list. Normal between launches; sustained over weeks it is not.
 
 `PyNightSkyWarmer` alarms: `TleWarmFailureAlarm`, `TleWarmerErrorsAlarm`,
 `TleWarmerDeadMansSwitchAlarm`. See [`OBSERVABILITY.md`](OBSERVABILITY.md).

--- a/tests/README.md
+++ b/tests/README.md
@@ -56,8 +56,8 @@ Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 | `test_meteor_shower_decay.py` | `targets.py` | — | `effective_zhr()` IMO decay model, half-window solver, catalog constants |
 | `test_aurora_model.py` | `aurora.py` | — | Geomagnetic latitude, Kp viewline, visibility tiers, look bearing |
 | `test_aurora_provider.py` | `aurora.py` | — | SWPC 3-day/27-day fetch, parse, cache, night rollup |
-| `test_tle_provider.py` | `tle_provider.py` | — | TLE parsing, Starlink train filter, `get_tle()` state machine, forced refresh |
-| `test_tle_request_path.py` | `tle_provider.py`, `predictor.py` | — | The request path never fetches TLEs; filtered-not-raw Starlink caching |
+| `test_tle_provider.py` | `tle_provider.py` | — | TLE parsing, COSPAR designator, Starlink train filter, `get_tle()` state machine, forced refresh |
+| `test_tle_request_path.py` | `tle_provider.py`, `predictor.py`, `satellites.py` | — | The request path never fetches TLEs; filtered-not-raw Starlink caching; SATCAT launch-date join |
 | `test_aqicn.py` | `aqicn.py` | — | WAQI haze cross-check: station distance filter, thresholds, caching |
 
 **Dark-sky search, rasters & indexes**
@@ -86,13 +86,14 @@ Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 | `test_jobs.py` | `apps/jobs.py` | — | Inline/SQS job lifecycle, worker handler, 202→done flow |
 | `test_warmer.py` | `apps/warmer` | — | TLE warmer handler: warm-all-ok, failure reporting, stale detection |
 | `test_aws_smoke.py` | `darksky.py` / `cache.py` | `aws` | Real DynamoDB cache round-trip; real S3 grid lookups (VIIRS + Falchi) |
-| `test_provider_smoke.py` | providers | `live` | Live connectivity: Open-Meteo, 7Timer, Celestrak, Nominatim, AWS Location |
+| `test_provider_smoke.py` | providers | `live` | Live connectivity: Open-Meteo, 7Timer, Celestrak GP + SATCAT, Nominatim, AWS Location |
 
 ## Known gaps (future work)
 
 - **`satellites.py`** — `satellite_passes()` staleness guard and
   `starlink_train_passes()` grouping still lack direct coverage (need real TLEs +
-  Skyfield).
+  Skyfield). Its launch-date handoff from `tle_provider` is covered in
+  `test_tle_request_path.py`.
 - **`trip.py`** — `plan_trip()` ranking and dual-TTL caching.
 - **Rendering** — `render_report.py`, `render_calendar.py`, `render_trip.py`,
   `format_ctx.py` pure-function helpers.

--- a/tests/test_provider_smoke.py
+++ b/tests/test_provider_smoke.py
@@ -8,7 +8,7 @@ is set (keeps the default `pytest` run offline and deterministic). Run with:
 Covers every outbound data provider the engine depends on:
   * Open-Meteo            — primary weather forecast
   * 7Timer ASTRO         — seeing / transparency weather
-  * Celestrak            — satellite TLEs
+  * Celestrak            — satellite TLEs + SATCAT launch dates
   * NOAA SWPC            — Kp forecast + 27-day outlook (aurora)
   * Nominatim            — forward geocoding (local backend)
   * AWS Location         — forward geocoding (aws backend; additionally needs the
@@ -58,6 +58,26 @@ def test_celestrak_live():
     lines = [ln for ln in raw.splitlines() if ln.strip()]
     assert any(ln.startswith("1 ") for ln in lines), "no TLE line 1 from Celestrak"
     assert any(ln.startswith("2 ") for ln in lines), "no TLE line 2 from Celestrak"
+
+
+def test_celestrak_satcat_live():
+    """SATCAT is the only source of launch dates — a TLE carries a launch number.
+
+    Also reports the freshness gap that decides whether trains are reportable at
+    all: no train can be found while the newest launch with GP elements is older
+    than _STARLINK_RECENT_DAYS.
+    """
+    from datetime import datetime, timezone
+    from darkhours import tle_provider
+
+    dates = tle_provider._fetch_starlink_launch_dates()
+    assert dates, "Celestrak SATCAT returned no recent Starlink launches"
+    assert all(d.count("-") == 1 for d in dates), "designators must be YYYY-NNN"
+
+    newest = max(dates.values())
+    age = (datetime.now(timezone.utc).date() - newest).days
+    print(f"\nnewest Starlink launch in SATCAT: {newest} ({age}d ago); "
+          f"train window is {tle_provider._STARLINK_RECENT_DAYS}d")
 
 
 # ── NOAA SWPC (aurora) ───────────────────────────────────────────────────────

--- a/tests/test_tle_provider.py
+++ b/tests/test_tle_provider.py
@@ -9,8 +9,8 @@ import pytest
 
 from darkhours import tle_provider as tle_mod
 from darkhours.tle_provider import (
+    _cospar_designator,
     _filter_train_tles,
-    _parse_launch_date,
     _parse_mean_motion,
     get_tle,
 )
@@ -59,40 +59,32 @@ class TestParseMeanMotion:
 
 
 # ---------------------------------------------------------------------------
-# _parse_launch_date — COSPAR International Designator parsing
+# _cospar_designator — International Designator parsing
+#
+# These previously asserted the day-of-year reading as ground truth ("98067A" →
+# day 67), which is what made the Starlink train filter match nothing: NNN is the
+# launch's sequence number within its year, not a day of it.
 # ---------------------------------------------------------------------------
 
-class TestParseLaunchDate:
-    def test_iss_launch_1998(self):
-        """ISS intl designator '98067A' → year=1998, DOY=67 (March 8)."""
-        d = _parse_launch_date(_ISS_L1)
-        assert d is not None
-        assert d.year == 1998
-        assert d.timetuple().tm_yday == 67
+class TestCosparDesignator:
+    def test_iss_is_the_67th_launch_of_1998_not_day_67(self):
+        """1998-067A is the ISS. It launched on 20 November 1998; day 67 is 8 March."""
+        assert _cospar_designator(_ISS_L1) == "1998-067"
 
     def test_year_below_57_maps_to_2000s(self):
-        # year_2d=20 < 57 → 2000+20=2020, DOY=001
         l1 = "1 00001U 20001A   24191.50000000  .00000000  00000-0  00000-0 0  9999"
-        d = _parse_launch_date(l1)
-        assert d is not None
-        assert d.year == 2020
-        assert d.timetuple().tm_yday == 1
+        assert _cospar_designator(l1) == "2020-001"
 
     def test_year_57_maps_to_1957(self):
-        # year_2d=57 ≥ 57 → 1900+57=1957 (Sputnik era)
         l1 = "1 00002U 57001A   24191.50000000  .00000000  00000-0  00000-0 0  9999"
-        d = _parse_launch_date(l1)
-        assert d is not None
-        assert d.year == 1957
-        assert d.timetuple().tm_yday == 1
+        assert _cospar_designator(l1) == "1957-001"
 
     def test_blank_intl_designator_returns_none(self):
-        # All spaces in cols 9-16 → stripped to "" → len < 5 → None
         l1 = "1 00001U         24191.50000000  .00000000  00000-0  00000-0 0  9999"
-        assert _parse_launch_date(l1) is None
+        assert _cospar_designator(l1) is None
 
     def test_too_short_line_returns_none(self):
-        assert _parse_launch_date("1 00001U") is None
+        assert _cospar_designator("1 00001U") is None
 
 
 # ---------------------------------------------------------------------------
@@ -102,25 +94,17 @@ class TestParseLaunchDate:
 def _make_train_block() -> str:
     """
     Build a multi-TLE block with four synthetic Starlink satellites:
-      RECENT-HIGH   — launched 5 days ago, MM=15.60 → INCLUDE
-      RECENT-LOW    — launched 5 days ago, MM=15.30 → EXCLUDE (operational altitude)
-      OLD-HIGH      — launched 30 days ago, MM=15.70 → EXCLUDE (stale batch)
-      UNKNOWN-DATE  — empty intl designator, MM=15.55 → INCLUDE (no date = conservative)
+      RECENT-HIGH   — launch 2026-040, 5 days ago,  MM=15.60 → INCLUDE
+      RECENT-LOW    — launch 2026-040, 5 days ago,  MM=15.06 → EXCLUDE (on station)
+      OLD-HIGH      — launch 2026-030, 30 days ago, MM=15.70 → EXCLUDE (stale batch)
+      UNKNOWN-DATE  — blank designator,             MM=15.55 → EXCLUDE (undatable)
+
+    UNKNOWN-DATE used to be included on the theory that an unknown launch date was
+    safest treated as recent. It is the opposite: an undatable satellite at high mean
+    motion is far more likely to be an old one on its way down.
     """
-    today  = date.today()
-    recent = today - timedelta(days=5)
-    old    = today - timedelta(days=30)
-
-    def _doy(d: date) -> int:
-        return (d - date(d.year, 1, 1)).days + 1
-
-    def _l1(n: int, d: date | None, piece: str = "A") -> str:
-        if d is None:
-            intl = "        "   # blank = unknown launch
-        else:
-            yy  = d.year % 100
-            doy = _doy(d)
-            intl = f"{yy:02d}{doy:03d}{piece}  "[:8]
+    def _l1(n: int, designator: str) -> str:
+        intl = f"{designator}  "[:8] if designator else "        "
         return f"1 {n:05d}U {intl}24001.50000000  .00000000  00000-0  00000-0 0  9999"
 
     def _l2(n: int, mm: float) -> str:
@@ -128,52 +112,52 @@ def _make_train_block() -> str:
         return prefix + f"{mm:.8f}00001 0"
 
     return "\n".join([
-        "STARLINK-RECENT-HIGH",
-        _l1(10001, recent),
-        _l2(10001, 15.60),
-
-        "STARLINK-RECENT-LOW",
-        _l1(10002, recent),
-        _l2(10002, 15.30),
-
-        "STARLINK-OLD-HIGH",
-        _l1(10003, old),
-        _l2(10003, 15.70),
-
-        "STARLINK-UNKNOWN-DATE",
-        _l1(10004, None),
-        _l2(10004, 15.55),
+        "STARLINK-RECENT-HIGH",  _l1(10001, "26040A"), _l2(10001, 15.60),
+        "STARLINK-RECENT-LOW",   _l1(10002, "26040B"), _l2(10002, 15.06),
+        "STARLINK-OLD-HIGH",     _l1(10003, "26030A"), _l2(10003, 15.70),
+        "STARLINK-UNKNOWN-DATE", _l1(10004, ""),       _l2(10004, 15.55),
     ])
+
+
+_TODAY        = date.today()
+_LAUNCH_DATES = {
+    "2026-040": _TODAY - timedelta(days=5),
+    "2026-030": _TODAY - timedelta(days=30),
+}
 
 
 class TestFilterTrainTles:
     def setup_method(self):
-        self.block = _make_train_block()
-        self.results = _filter_train_tles(self.block)
-        self.names = {r[0] for r in self.results}
+        self.block   = _make_train_block()
+        self.results = _filter_train_tles(self.block, _LAUNCH_DATES)
+        self.names   = {r[0] for r in self.results}
 
     def test_recent_high_mm_included(self):
         assert "STARLINK-RECENT-HIGH" in self.names
 
-    def test_recent_low_mm_excluded(self):
+    def test_operational_mean_motion_excluded(self):
         assert "STARLINK-RECENT-LOW" not in self.names
 
     def test_old_high_mm_excluded(self):
         assert "STARLINK-OLD-HIGH" not in self.names
 
-    def test_unknown_date_high_mm_included(self):
-        assert "STARLINK-UNKNOWN-DATE" in self.names
+    def test_unknown_date_excluded(self):
+        assert "STARLINK-UNKNOWN-DATE" not in self.names
 
-    def test_each_result_is_three_tuple(self):
+    def test_each_result_carries_its_launch_date(self):
         for entry in self.results:
-            assert len(entry) == 3   # (name, line1, line2)
+            assert len(entry) == 4          # (name, line1, line2, launch_date)
+            assert entry[3] == (_TODAY - timedelta(days=5)).isoformat()
 
     def test_empty_block_returns_empty(self):
-        assert _filter_train_tles("") == []
+        assert _filter_train_tles("", _LAUNCH_DATES) == []
 
     def test_malformed_block_skipped_gracefully(self):
         block = "JUNK LINE\nNOT A TLE\nALSO JUNK"
-        assert _filter_train_tles(block) == []
+        assert _filter_train_tles(block, _LAUNCH_DATES) == []
+
+    def test_no_launch_dates_matches_nothing(self):
+        assert _filter_train_tles(self.block, {}) == []
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +316,15 @@ class TestGetTle:
 # circuit breaker integration
 # ---------------------------------------------------------------------------
 
+_GROUP_TEST_LAUNCH_DATES = {"2026-040": date.today() - timedelta(days=3)}
+
+
+def _with_launch_dates():
+    """Stub the SATCAT leg so the group fetch below is what is under test."""
+    return mock.patch.object(tle_mod, "_fetch_starlink_launch_dates",
+                             return_value=dict(_GROUP_TEST_LAUNCH_DATES))
+
+
 class TestCircuitBreaker:
     @staticmethod
     def _mock_cache(get_val=None, stale_val=None):
@@ -384,16 +377,17 @@ class TestCircuitBreaker:
 
         # The cached value is the *filtered train list*, not the raw group block —
         # see _STARLINK_TRAINS_CACHE_KEY for why the raw block could never be stored.
-        cached = [["STARLINK-1", "1 aaa", "2 bbb"]]
+        recent = (date.today() - timedelta(days=3)).isoformat()
+        cached = [["STARLINK-1", "1 aaa", "2 bbb", recent]]
         mc = self._mock_cache(get_val=None, stale_val=cached)
         err = urllib.error.HTTPError(url="x", code=403, msg="Forbidden",
                                      hdrs=None, fp=None)
-        with mock.patch.object(tle_mod, '_cache', mc), \
+        with _with_launch_dates(), mock.patch.object(tle_mod, '_cache', mc), \
              mock.patch.object(tle_mod._http, 'urlopen', side_effect=err):
             tles, stale, error = tle_mod.get_starlink_train_tles()
         assert error is None
         assert stale is False, "revalidated data is current, not stale"
-        assert tles == [("STARLINK-1", "1 aaa", "2 bbb")]
+        assert tles == [("STARLINK-1", "1 aaa", "2 bbb", recent)]
         mc.set.assert_called_once()
         assert mc.set.call_args.kwargs["ttl_seconds"] == tle_mod.TLE_TTL
 
@@ -409,7 +403,7 @@ class TestCircuitBreaker:
         mc = self._mock_cache(get_val=None, stale_val=None)
         err = urllib.error.HTTPError(url="x", code=403, msg="Forbidden",
                                      hdrs=None, fp=None)
-        with mock.patch.object(tle_mod, '_cache', mc), \
+        with _with_launch_dates(), mock.patch.object(tle_mod, '_cache', mc), \
              mock.patch.object(tle_mod._http, 'urlopen', side_effect=err):
             tles, stale, error = tle_mod.get_starlink_train_tles()
         assert tles == []
@@ -425,7 +419,7 @@ class TestCircuitBreaker:
         import urllib.error
 
         mc = self._mock_cache(get_val=None, stale_val=None)
-        with mock.patch.object(tle_mod, '_cache', mc), \
+        with _with_launch_dates(), mock.patch.object(tle_mod, '_cache', mc), \
              mock.patch.object(tle_mod._http, 'urlopen',
                                side_effect=urllib.error.URLError("dns failure")):
             tles, stale, error = tle_mod.get_starlink_train_tles()
@@ -434,13 +428,26 @@ class TestCircuitBreaker:
         assert error is not None
         assert "unreachable" in error.lower()
 
+    def test_no_launch_dates_skips_the_group_fetch_entirely(self):
+        """SATCAT unreachable → no launch dates → the group cannot be filtered into
+        trains, so downloading 1.8 MB of it buys nothing. Surface the reason instead."""
+        mc = self._mock_cache(get_val=None, stale_val=None)
+        with mock.patch.object(tle_mod, "_fetch_starlink_launch_dates",
+                               return_value={}), \
+             mock.patch.object(tle_mod, '_cache', mc), \
+             mock.patch.object(tle_mod._http, 'urlopen') as urlopen:
+            tles, stale, error = tle_mod.get_starlink_train_tles()
+        urlopen.assert_not_called()
+        assert tles == []
+        assert error is not None and "launch dates" in error
+
     def test_starlink_group_read_timeout_does_not_raise(self):
         """A read-phase timeout (e.g. ssl.SSLSocket.read() mid-response) raises a raw
         TimeoutError, not urllib.error.URLError — urllib only wraps connect-phase
         failures. Confirmed live in production: this previously propagated uncaught
         out of get_starlink_train_tles() and crashed the entire /night response."""
         mc = self._mock_cache(get_val=None, stale_val=None)
-        with mock.patch.object(tle_mod, '_cache', mc), \
+        with _with_launch_dates(), mock.patch.object(tle_mod, '_cache', mc), \
              mock.patch.object(tle_mod._http, 'urlopen',
                                side_effect=TimeoutError("The read operation timed out")):
             tles, stale, error = tle_mod.get_starlink_train_tles()

--- a/tests/test_tle_request_path.py
+++ b/tests/test_tle_request_path.py
@@ -11,7 +11,7 @@ cached_starlink_trains, which contain no network code. These tests hold that lin
 Everything here is hermetic — no network, no ephemeris, no AWS.
 """
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest import mock
 from zoneinfo import ZoneInfo
 
@@ -174,20 +174,26 @@ def test_cached_readers_contain_no_network_call(no_network):
 # The root cause: what actually gets written
 # ---------------------------------------------------------------------------
 
-def _synthetic_group(n_sats: int) -> str:
+_TODAY      = datetime.now(timezone.utc).date()
+_DESIGNATOR = f"{_TODAY.year}-042"
+
+
+def _synthetic_group(n_sats: int, designator_suffix: str = "042") -> str:
     """A GROUP=starlink-shaped block. The real one is ~1.8 MB / ~10,700 satellites."""
-    today = datetime.now(timezone.utc).date()
-    doy   = today.timetuple().tm_yday
-    yy    = today.year % 100
+    yy  = _TODAY.year % 100
     out = []
     for i in range(n_sats):
-        # Mean motion 15.90 → raising phase; today's launch date → inside the window.
+        # Mean motion 15.90 → below every operational shell → raising phase.
         out.append(f"STARLINK-{i:05d}")
-        out.append(f"1 {50000 + i:05d}U {yy:02d}{doy:03d}A   26235.50000000  "
+        out.append(f"1 {50000 + i:05d}U {yy:02d}{designator_suffix}A   26235.50000000  "
                    f".00002182  00000+0  40768-4 0  9992")
         out.append(f"2 {50000 + i:05d}  53.0000 100.0000 0001000  90.0000 270.0000 "
                    f"15.90000000    10")
     return "\n".join(out)
+
+
+def _recent_launch_dates(days_ago: int = 1) -> dict:
+    return {_DESIGNATOR: _TODAY - timedelta(days=days_ago)}
 
 
 def test_starlink_refresh_caches_the_filtered_list_not_the_raw_group(monkeypatch):
@@ -207,7 +213,9 @@ def test_starlink_refresh_caches_the_filtered_list_not_the_raw_group(monkeypatch
     resp.__enter__.return_value.read.side_effect = [raw.encode(), b""]
     monkeypatch.setattr(_http, "urlopen", mock.MagicMock(return_value=resp))
 
-    trains, stale, error = tle.refresh_starlink_trains()
+    trains, stale, error = tle.refresh_starlink_trains(
+        launch_dates=_recent_launch_dates()
+    )
 
     assert error is None and stale is False
     stored = cache.written[tle._STARLINK_TRAINS_CACHE_KEY]
@@ -233,9 +241,139 @@ def test_cached_starlink_trains_reads_an_empty_list_as_data_not_as_a_miss(monkey
 
 def test_cached_starlink_trains_round_trips_the_json_shape(monkeypatch):
     """The cache stores JSON, so tuples come back as lists — callers expect tuples."""
+    cache = _StateCache(fresh={
+        tle._STARLINK_TRAINS_CACHE_KEY: [["S-1", "1 aaa", "2 bbb", "2026-08-12"]]
+    })
+    monkeypatch.setattr(tle, "_cache", cache)
+
+    trains, _, _ = tle.cached_starlink_trains()
+
+    assert trains == [("S-1", "1 aaa", "2 bbb", "2026-08-12")]
+
+
+def test_cached_starlink_trains_tolerates_a_three_element_row(monkeypatch):
+    """Rows written before the launch date rode along must still be readable —
+    they are simply a train whose launch date we cannot show."""
     cache = _StateCache(fresh={tle._STARLINK_TRAINS_CACHE_KEY: [["S-1", "1 aaa", "2 bbb"]]})
     monkeypatch.setattr(tle, "_cache", cache)
 
     trains, _, _ = tle.cached_starlink_trains()
 
-    assert trains == [("S-1", "1 aaa", "2 bbb")]
+    assert trains == [("S-1", "1 aaa", "2 bbb", None)]
+
+
+# ---------------------------------------------------------------------------
+# The launch date: a TLE carries a launch *number*, not a date
+# ---------------------------------------------------------------------------
+
+def test_cospar_designator_reads_a_launch_number_not_a_day_of_year():
+    """The bug that made the feature render nothing, pinned to ground truth.
+
+    The International Designator's middle field is the launch's sequence number
+    within its year. The ISS is 1998-067A and launched on 1998-11-20; day 67 of
+    1998 is 8 March. Starlink 2026-159 launched on 2026-07-11; day 159 is 8 June —
+    which is exactly the date the old day-of-year reading produced, putting the
+    newest launch in the feed 76 days in the past and outside every train window.
+    """
+    iss = "1 25544U 98067A   24191.72490000  .00022888  00000+0  40424-3 0  9998"
+    assert tle._cospar_designator(iss) == "1998-067"
+
+    starlink = "1 69975U 26159A   26235.52033823  .00235854  00000+0  15329-2 0  9991"
+    assert tle._cospar_designator(starlink) == "2026-159"
+
+    assert tle._cospar_designator("1 25544U          24191.72490000") is None
+
+
+def test_filter_needs_launch_dates_and_fails_closed_without_them(caplog):
+    """No launch dates → no trains, loudly.
+
+    Mean motion alone cannot tell a raising batch from an old satellite being
+    lowered for re-entry: ~880 of the ~10,700 satellites in the real group are above
+    the threshold at any moment, and most are decaying. Emitting them unfiltered
+    would put hundreds of stale satellites on screen labelled as trains.
+    """
+    raw = _synthetic_group(30)
+
+    with caplog.at_level("ERROR"):
+        assert tle._filter_train_tles(raw, {}) == []
+    assert "launch dates" in caplog.text
+
+
+def test_filter_drops_raising_satellites_from_an_old_launch():
+    """Still raising is not the same as still a train — an older batch has spread
+    around its orbit even while it climbs."""
+    raw = _synthetic_group(30)
+
+    inside  = tle._filter_train_tles(raw, _recent_launch_dates(days_ago=1))
+    edge    = tle._filter_train_tles(
+        raw, _recent_launch_dates(days_ago=tle._STARLINK_RECENT_DAYS))
+    outside = tle._filter_train_tles(
+        raw, _recent_launch_dates(days_ago=tle._STARLINK_RECENT_DAYS + 1))
+
+    assert len(inside) == 30
+    assert len(edge) == 30, "the cutoff is inclusive"
+    assert outside == []
+
+
+def test_filter_carries_the_launch_date_and_orders_newest_first():
+    """satellites.py renders "launched Nd ago" from this, and the cap must truncate
+    the oldest batch rather than an arbitrary one."""
+    older_designator = f"{_TODAY.year}-041"
+    raw = _synthetic_group(2) + "\n" + _synthetic_group(2, designator_suffix="041")
+    dates = {
+        _DESIGNATOR:      _TODAY - timedelta(days=2),
+        older_designator: _TODAY - timedelta(days=9),
+    }
+
+    trains = tle._filter_train_tles(raw, dates)
+
+    assert len(trains) == 4
+    assert all(len(t) == 4 for t in trains)
+    assert [t[3] for t in trains] == [
+        (_TODAY - timedelta(days=2)).isoformat()] * 2 + [
+        (_TODAY - timedelta(days=9)).isoformat()] * 2
+
+
+def test_satcat_parsing_keeps_recent_launches_keyed_by_designator():
+    csv_text = (
+        "OBJECT_NAME,OBJECT_ID,NORAD_CAT_ID,LAUNCH_DATE\n"
+        "STARLINK-38024,2026-159A,69975,2026-07-11\n"
+        "STARLINK-37993,2026-159B,69976,2026-07-11\n"
+        "STARLINK-1008,2019-074B,44714,2019-11-11\n"
+        "BROKEN,2026-160A,99999,\n"
+    )
+    dates = tle._parse_satcat_launch_dates(csv_text, date(2026, 8, 23))
+
+    assert dates == {"2026-159": date(2026, 7, 11)}, \
+        "old launches are pruned, undated rows are skipped, pieces collapse to a launch"
+
+
+def test_revalidation_ages_the_cached_train_list():
+    """Celestrak's 403 says the group has not changed, but the 21-day window has
+    moved and the raw block is deliberately not kept. Each entry carries its own
+    launch date so the list can be aged in place."""
+    fresh = ("S-1", "1 a", "2 b", (_TODAY - timedelta(days=3)).isoformat())
+    aged  = ("S-2", "1 c", "2 d",
+             (_TODAY - timedelta(days=tle._STARLINK_RECENT_DAYS + 5)).isoformat())
+    undated = ("S-3", "1 e", "2 f", None)
+
+    assert tle._prune_expired_trains([fresh, aged, undated]) == [fresh]
+
+
+def test_satellites_reads_the_launch_date_tle_provider_attaches():
+    """The seam, pinned from both sides.
+
+    satellites.py used to re-derive the launch date from the TLE with the same
+    day-of-year misreading, so "launched 5d ago" in the report was wrong whenever it
+    appeared at all. It now reads the date tle_provider attached, and the two halves
+    have to agree on the tuple shape or the report silently loses the date again.
+    """
+    from darkhours.satellites import _entry_launch_date
+
+    raw = _synthetic_group(1)
+    launched = _TODAY - timedelta(days=4)
+    entry = tle._filter_train_tles(raw, {_DESIGNATOR: launched})[0]
+
+    assert _entry_launch_date(entry) == launched
+    assert _entry_launch_date(entry[:3]) is None, "a legacy 3-element row has no date"
+    assert _entry_launch_date(("n", "1", "2", "not-a-date")) is None

--- a/tests/test_warmer.py
+++ b/tests/test_warmer.py
@@ -7,6 +7,7 @@ exactly what it did in production for months.
 """
 import json
 import time
+from datetime import date
 
 import pytest
 
@@ -50,18 +51,38 @@ def fake_cache(monkeypatch):
     return c
 
 
+def _ok_launch_dates(monkeypatch, cache):
+    """Wire the SATCAT leg to succeed and populate *cache*, as the real one does.
+
+    warm_cache warms the launch-date map under its own key: the train filter cannot
+    run without it, so a SATCAT failure has to show up as itself rather than as an
+    unexplained empty train list.
+    """
+    dates = {"2026-040": date(2026, 8, 12)}
+
+    def fake_fetch_dates(timeout=None):
+        cache.set(tle._STARLINK_LAUNCH_DATES_CACHE_KEY,
+                  {d: v.isoformat() for d, v in dates.items()},
+                  ttl_seconds=tle.TLE_TTL)
+        return dict(dates)
+
+    monkeypatch.setattr(tle, "_fetch_starlink_launch_dates", fake_fetch_dates)
+    return dates
+
+
 def _ok_refreshers(monkeypatch, cache, trains=1):
     """Wire refresh_* to succeed and actually populate *cache*, as the real ones do."""
     seen = {}
+    _ok_launch_dates(monkeypatch, cache)
 
     def fake_refresh_tle(norad, timeout=None):
         seen["tle"] = timeout
         cache.set(tle._tle_key(norad), "NAME\nline1\nline2", ttl_seconds=tle.TLE_TTL)
         return tle.TLEResult(lines=("NAME", "line1", "line2"), stale=False, error=None)
 
-    def fake_refresh_group(timeout=None):
+    def fake_refresh_group(timeout=None, launch_dates=None):
         seen["group"] = timeout
-        value = [["S", "1 x", "2 x"]] * trains
+        value = [["S", "1 x", "2 x", "2026-08-12"]] * trains
         cache.set(tle._STARLINK_TRAINS_CACHE_KEY, value, ttl_seconds=tle.TLE_TTL)
         return value, False, None
 
@@ -83,8 +104,9 @@ def test_warm_all_ok(monkeypatch, fake_cache):
 def test_warm_reports_failures(monkeypatch, fake_cache):
     monkeypatch.setattr(tle, "refresh_tle",
                         lambda n, timeout=None: tle.TLEResult(lines=None, stale=False, error="HTTP 503"))
+    _ok_launch_dates(monkeypatch, fake_cache)
     monkeypatch.setattr(tle, "refresh_starlink_trains",
-                        lambda timeout=None: ([], True, "timed out"))
+                        lambda timeout=None, launch_dates=None: ([], True, "timed out"))
     out = h.handler({}, None)
     assert out["ok"] is False
     assert "FAIL" in out["results"]["ISS"]["status"]
@@ -95,8 +117,9 @@ def test_warm_stale_is_not_ok(monkeypatch, fake_cache):
     monkeypatch.setattr(
         tle, "refresh_tle",
         lambda n, timeout=None: tle.TLEResult(lines=("a", "b", "c"), stale=True, error="HTTP 500"))
+    _ok_launch_dates(monkeypatch, fake_cache)
     monkeypatch.setattr(tle, "refresh_starlink_trains",
-                        lambda timeout=None: ([("a", "b", "c")], False, None))
+                        lambda timeout=None, launch_dates=None: ([("a", "b", "c")], False, None))
     out = h.handler({}, None)
     assert out["ok"] is False
     assert "stale" in out["results"]["ISS"]["status"]
@@ -116,8 +139,9 @@ def test_warm_is_not_ok_when_the_write_is_silently_dropped(monkeypatch):
     monkeypatch.setattr(
         tle, "refresh_tle",
         lambda n, timeout=None: tle.TLEResult(lines=("a", "b", "c"), stale=False, error=None))
+    _ok_launch_dates(monkeypatch, dead)
     monkeypatch.setattr(tle, "refresh_starlink_trains",
-                        lambda timeout=None: ([("a", "b", "c")], False, None))
+                        lambda timeout=None, launch_dates=None: ([("a", "b", "c")], False, None))
 
     out = h.handler({}, None)
 
@@ -140,13 +164,15 @@ def test_warmer_forces_a_refresh_even_when_the_cache_is_fresh(monkeypatch, fake_
     for norad, _ in tle.TRACKED_SATELLITES:
         fake_cache.set(tle._tle_key(norad), "NAME\nl1\nl2", ttl_seconds=tle.TLE_TTL)
     fake_cache.set(tle._STARLINK_TRAINS_CACHE_KEY, [], ttl_seconds=tle.TLE_TTL)
+    _ok_launch_dates(monkeypatch, fake_cache)
 
     calls = []
     monkeypatch.setattr(tle, "refresh_tle", lambda n, timeout=None: (
         calls.append(n),
         tle.TLEResult(lines=("a", "b", "c"), stale=False, error=None))[1])
-    monkeypatch.setattr(tle, "refresh_starlink_trains", lambda timeout=None: (
-        calls.append("group"), ([], False, None))[1])
+    monkeypatch.setattr(tle, "refresh_starlink_trains",
+                        lambda timeout=None, launch_dates=None: (
+                            calls.append("group"), ([], False, None))[1])
 
     h.handler({}, None)
 
@@ -165,8 +191,13 @@ def test_cli_warm_skips_refresh_when_already_fresh(monkeypatch, fake_cache):
     fake_cache.set(tle._STARLINK_TRAINS_CACHE_KEY, [], ttl_seconds=tle.TLE_TTL)
 
     calls = []
+    fake_cache.set(tle._STARLINK_LAUNCH_DATES_CACHE_KEY, {"2026-040": "2026-08-12"},
+                   ttl_seconds=tle.TLE_TTL)
     monkeypatch.setattr(tle, "refresh_tle", lambda n, timeout=None: calls.append(n))
-    monkeypatch.setattr(tle, "refresh_starlink_trains", lambda timeout=None: calls.append("g"))
+    monkeypatch.setattr(tle, "refresh_starlink_trains",
+                        lambda timeout=None, launch_dates=None: calls.append("g"))
+    monkeypatch.setattr(tle, "_fetch_starlink_launch_dates",
+                        lambda timeout=None: calls.append("dates"))
 
     summary = tle.warm_cache(force=False)
 
@@ -201,7 +232,35 @@ def test_emits_one_failure_metric_and_a_per_key_success_metric(monkeypatch, fake
     per_key = [e for e in emitted if "TleWarmSuccess" in e]
     failures = [e for e in emitted if "TleWarmFailure" in e]
 
-    assert {e["Key"] for e in per_key} == {"ISS", "Hubble Telescope", "Tiangong", "starlink"}
+    assert {e["Key"] for e in per_key} == {"ISS", "Hubble Telescope", "Tiangong",
+                                           "starlink", "starlink-launch-dates"}
     assert all(e["TleWarmSuccess"] == 1 for e in per_key)
     assert all(e["TleCachedBytes"] > 0 for e in per_key)
     assert len(failures) == 1 and failures[0]["TleWarmFailure"] == 0
+
+    # A verified write of an empty list is a success by every other measure here,
+    # and for the train key an empty list is also the normal state between launches
+    # — which is how a filter that could never match anything stayed invisible.
+    by_key = {e["Key"]: e for e in per_key}
+    assert by_key["starlink"]["TleWarmItems"] == 1
+    assert by_key["starlink-launch-dates"]["TleWarmItems"] == 1
+
+
+def test_a_permanently_empty_train_list_is_still_visible_as_a_count(monkeypatch, fake_cache, capsys):
+    """The state that hid the broken filter: every key verified, ok=True, no trains.
+
+    Nothing here is a failure — an empty train list is the normal state between
+    launches — so the count is the only thing that separates "nothing tonight" from
+    "nothing, for weeks".
+    """
+    _ok_refreshers(monkeypatch, fake_cache, trains=0)
+    out = h.handler({}, None)
+
+    assert out["ok"] is True
+    assert out["results"]["starlink"]["count"] == 0
+
+    emitted = [json.loads(line) for line in capsys.readouterr().out.splitlines()
+               if line.startswith("{")]
+    starlink = next(e for e in emitted if e.get("Key") == "starlink")
+    assert starlink["TleWarmSuccess"] == 1, "a verified write of [] is still a write"
+    assert starlink["TleWarmItems"] == 0


### PR DESCRIPTION
## Summary

The Starlink train filter matched 0 of 10,740 satellites because `_parse_launch_date` read the International Designator's middle field as a day of the year. It is the launch's sequence number within its year: `1998-067A` is the ISS (launched 1998-11-20, not day 67 = March 8), and `2026-159` launched 2026-07-11, not day 159 = 2026-06-08. Every launch was re-dated into the first third of its year, so nothing fell inside the 21-day window. `satellites.py` held a second copy of the same parser feeding the user-visible "launched Nd ago".

A launch date is not recoverable from a TLE, so the warmer joins Celestrak's SATCAT on the designator and carries the date through the cached train entry. Without dates the filter fails closed and skips the group fetch: mean motion alone is not a train signal, since ~880 of the ~10,700 satellites in the group are above the threshold at any moment and most are old ones being lowered for re-entry.

Also:
- `_STARLINK_TRAIN_MM_MIN` 15.5 to 15.2. 15.5 (~345 km) described only the lowest insertion orbit; three of the four most recent launches with elements in the feed deployed at ~465 km and were dropped whole.
- `TleWarmItems` per key, so a verified write of an empty train list shows up as a count. That state is normal between launches and is how this stayed hidden.
- New cache key `tle|starlink|launch_dates`; train entries are now 4 elements. Three-element rows from the existing key still read, without a date.

## Still open upstream

The public GP catalogue has no elements for any launch after 2026-07-11, while SATCAT lists Starlink launches through 2026-08-12 with catalog numbers at or above 100000. `GROUP=last-30-days` is empty and `INTDES=`/`CATNR=` queries for those launches return "No GP data found". No trains are reportable today regardless of this fix. Documented in `docs/TLE_CACHE.md`; `TleWarmItems` on `Key=starlink` is where it shows.

## Test plan

- `pytest -q`: 1009 passed, 10 skipped.
- Filter run against the real 1.8 MB feed + SATCAT: 0 trains as of today; backdated to 2026-07-20 it yields 106 trains across 4 launches, 19 KB cached item, newest-first.
- Request path re-read from cache with `urlopen` wired to raise: no fetch.
- `PYNIGHTSKY_LIVE=1 pytest tests/test_provider_smoke.py::test_celestrak_satcat_live`: passed.
- `darkhours.py --coords 39.7392 -104.9903 --satellites` against real Celestrak: clean run, launch-dates key written (26 launches, newest 2026-08-12), trains `[]`, warm summary ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)