### PR TITLE
Skip the reverse-geocode that date_only throws away, and time _resolve

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -103,6 +103,9 @@ app.add_middleware(
 # Structured access log: path, status, duration, Lambda request-id.
 _access_log = logging.getLogger("pynightsky.access")
 
+# Per-phase timing for _resolve(), which runs before assemble_night's own timings.
+_resolve_log = logging.getLogger(__name__)
+
 class _AccessLog(BaseHTTPMiddleware):
     async def dispatch(self, request: _Request, call_next):
         t0 = time.monotonic()
@@ -209,12 +212,25 @@ def _parse_date(s: str | None, field: str = "date") -> date:
     return d
 
 
-def _resolve(location: str | None, lat: float | None, lon: float | None):
+def _resolve(location: str | None, lat: float | None, lon: float | None,
+             *, need_display_name: bool = True):
     """Resolve a request's place to (lat, lon, display_name, ZoneInfo).
 
     For a lat/lon request, `_loc.reverse_geocode` itself checks the local POI/PAD-US
     index before falling back to the network settlement lookup — see its docstring.
+
+    *need_display_name* is False when the caller throws the name away (/night's
+    date_only drill-in). Only the raw-coord branch can honour it: for a named
+    request the geocode IS how the coordinates are found, so there is nothing to
+    skip. The coordinate string it substitutes is the same fallback a point over
+    water or an unreachable geocoder already produces.
+
+    Emits one timing line per resolve. assemble_night's own phase timings start
+    only after this returns, so resolution was previously unmeasured even though
+    it sits on the critical path of every /night and /calendar request. Phases
+    that did not run report -1, matching predictor.py's convention.
     """
+    _t0 = time.monotonic()
     if location:
         try:
             la, lo, disp, tz_name = _loc.resolve(location)
@@ -222,13 +238,28 @@ def _resolve(location: str | None, lat: float | None, lon: float | None):
             raise HTTPException(404, str(e))      # not found
         except RuntimeError as e:
             raise HTTPException(502, str(e))      # geocoder unreachable
+        _resolve_log.info(
+            "resolve timing mode=name | tz=%dms rev=%dms total=%dms",
+            -1, -1, round((time.monotonic() - _t0) * 1000),
+        )
         return la, lo, disp, ZoneInfo(tz_name)
     if lat is not None and lon is not None:
         try:
             tz = _loc.timezone_for(lat, lon)
         except ValueError as e:
             raise HTTPException(400, str(e))   # e.g. no timezone for the point
-        disp = _loc.reverse_geocode(lat, lon) or f"{lat:.4f}°, {lon:.4f}°"
+        _tz_ms = round((time.monotonic() - _t0) * 1000)
+        _t1 = time.monotonic()
+        if need_display_name:
+            disp = _loc.reverse_geocode(lat, lon) or f"{lat:.4f}°, {lon:.4f}°"
+            _rev_ms = round((time.monotonic() - _t1) * 1000)
+        else:
+            disp = f"{lat:.4f}°, {lon:.4f}°"
+            _rev_ms = -1
+        _resolve_log.info(
+            "resolve timing mode=coords | tz=%dms rev=%dms total=%dms",
+            _tz_ms, _rev_ms, round((time.monotonic() - _t0) * 1000),
+        )
         return lat, lon, disp, tz
     raise HTTPException(400, "Provide 'location' or both 'lat' and 'lon'.")
 
@@ -272,7 +303,9 @@ def night(
     date_only: bool = Query(False, description="Omit location-keyed fields (light_pollution/bortle_score/light_dome) the client already has from a prior full fetch for this location"),
 ):
     """Single-night report for a location/date (mirrors the CLI single-night path)."""
-    la, lo, disp, tz = _resolve(location, lat, lon)
+    # date_only discards display_name below, so don't pay to look it up. Raw coords
+    # only: a named request needs the geocode regardless (see _resolve).
+    la, lo, disp, tz = _resolve(location, lat, lon, need_display_name=not date_only)
     target = _parse_date(date)
     try:
         report = assemble_night(
@@ -294,8 +327,9 @@ def night(
     if date_only:
         # Location-keyed, not date-keyed — the client already has these from
         # the initial full fetch for this location and doesn't need them again.
-        # display_name is included here too, avoiding a wasted reverse-geocode/
-        # POI-index lookup on every "View Details" date-only click.
+        # display_name is included here too; _resolve was told to skip the
+        # reverse-geocode/POI-index lookup that would have produced it, so this
+        # pop discards a coordinate-string placeholder rather than real work.
         d.pop("light_pollution", None)
         d.pop("bortle_score", None)
         d.pop("light_dome", None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -355,12 +355,57 @@ def test_night_date_only_omits_location_fields():
     assert "light_pollution" not in d
     assert "bortle_score" not in d
     assert "light_dome" not in d
-    # display_name too — it's location-keyed like the others, and stripping it avoids
-    # a wasted reverse-geocode lookup on every "View Details" click.
+    # display_name too — it's location-keyed like the others.
     assert "display_name" not in d
     # Date-dependent fields are still present.
     assert isinstance(d["sunset"], str)
     assert d["phase_name"] and d["score"] is not None
+
+
+@pytest.mark.eph
+@requires_rasters
+def test_night_date_only_skips_the_reverse_geocode(monkeypatch):
+    """date_only pops display_name from the response, so the lookup that produces it
+    must never run. It used to: _resolve reverse-geocoded unconditionally and the
+    result was discarded a few lines later, on every "View Details" drill-in."""
+    def _boom(*a, **kw):
+        raise AssertionError("date_only /night should not reverse-geocode")
+    monkeypatch.setattr(main_mod._loc, "reverse_geocode", _boom)
+    r = client.get("/night", params={
+        "lat": 35.1983, "lon": -111.6513, "date": "2026-06-15",
+        "weather": "false", "targets": "false", "satellites": "false",
+        "date_only": "true",
+    })
+    assert r.status_code == 200
+    assert "display_name" not in r.json()
+
+
+@pytest.mark.eph
+@requires_rasters
+def test_night_without_date_only_still_reverse_geocodes(monkeypatch):
+    """The other half of the guard above: a full fetch must still name the place,
+    so the skip cannot quietly widen to every raw-coord request."""
+    monkeypatch.setattr(main_mod._loc, "reverse_geocode", lambda lat, lon: "Named Place")
+    r = client.get("/night", params={
+        "lat": 35.1983, "lon": -111.6513, "date": "2026-06-15",
+        "weather": "false", "targets": "false", "satellites": "false",
+    })
+    assert r.status_code == 200
+    assert r.json()["display_name"] == "Named Place"
+
+
+def test_resolve_by_name_still_geocodes_when_name_not_needed(monkeypatch):
+    """need_display_name is honoured only on the raw-coord branch: a named request
+    has to geocode to get coordinates at all, so the flag must not skip it."""
+    monkeypatch.setattr(
+        main_mod._loc, "resolve",
+        lambda name: (35.1983, -111.6513, "Flagstaff, AZ", "America/Phoenix"),
+    )
+    la, lo, disp, tz = main_mod._resolve("Flagstaff", None, None,
+                                         need_display_name=False)
+    assert (la, lo) == (35.1983, -111.6513)
+    assert disp == "Flagstaff, AZ"
+    assert str(tz) == "America/Phoenix"
 
 
 @pytest.mark.eph


### PR DESCRIPTION
## Summary

`date_only=true` pops `display_name` from the response, but `_resolve` looked it up unconditionally first, so every "View Details" drill-in paid a POI-index lookup (plus its network settlement fallback) for a field deleted a few lines later. The existing comment claimed the pop avoided that lookup; it never did.

`_resolve` now takes `need_display_name`. Only the raw-coord branch honours it: a named request geocodes regardless, since that is how its coordinates are found. The substituted coordinate string is the same fallback a point over water already produces.

Also adds one timing line per resolve, splitting `timezone_for` from `reverse_geocode`. `assemble_night`'s phase timings begin only after `_resolve` returns, so resolution was unmeasured despite sitting on the critical path of every `/night` and `/calendar`.

## Test plan

- `python -m pytest -q` — 1012 passed, 10 skipped.
- `test_night_date_only_skips_the_reverse_geocode` fails with the wiring reverted, passes with it.
- `test_night_without_date_only_still_reverse_geocodes` guards the skip from widening to full fetches.
- `test_resolve_by_name_still_geocodes_when_name_not_needed` covers the named branch ignoring the flag.
- Timing line confirmed against an injected delay in `reverse_geocode`, and reports -1 when skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)