### PR TITLE
Build the TimezoneFinder once per process instead of once per call

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -80,6 +80,12 @@ async def lifespan(app: FastAPI):
                 jobs._sqs()   # build the boto3 SQS client off the first enqueue's path
             except Exception as _e:
                 logging.getLogger(__name__).debug("SQS pre-warm failed: %s", _e)
+            try:
+                # Parse timezonefinder's binary data once, here, instead of on the
+                # first /night or /calendar to reach this container.
+                _loc._timezone_finder()
+            except Exception as _e:
+                logging.getLogger(__name__).debug("Timezone index pre-warm failed: %s", _e)
 
         threading.Thread(target=_prewarm, daemon=True).start()
     yield

--- a/darkhours/location.py
+++ b/darkhours/location.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -174,8 +175,37 @@ def _geocode_query(name: str) -> str:
     return name
 
 
+# One TimezoneFinder for the process. Constructing one parses its bundled binary
+# data, which dwarfs the timezone_at() lookup it enables — hundreds of
+# milliseconds against microseconds. This used to be constructed per call and
+# discarded, so every caller paid the setup to use it exactly once.
+#
+# Shared behind a lock rather than one instance per thread: the API serves sync
+# endpoints from a threadpool, timezonefinder makes no thread-safety guarantee we
+# verified, and a per-thread instance would pay the construction again per thread
+# and hold another copy of the data. Serializing a 12 µs lookup costs nothing at
+# any concurrency this serves, so the lock buys safety for free.
+#
+# apps/api/main.py's lifespan pre-warm builds this during init so the one
+# construction stays off the first request's path.
+_tf = None
+_tf_lock = threading.Lock()
+
+
+def _timezone_finder() -> TimezoneFinder:
+    """Return the process-wide TimezoneFinder, building it on first use."""
+    global _tf
+    if _tf is None:
+        with _tf_lock:
+            if _tf is None:
+                _tf = TimezoneFinder()
+    return _tf
+
+
 def _tz_name_for(lat: float, lon: float) -> str:
-    tz_name = TimezoneFinder().timezone_at(lat=lat, lng=lon)
+    finder = _timezone_finder()
+    with _tf_lock:
+        tz_name = finder.timezone_at(lat=lat, lng=lon)
     if not tz_name:
         raise ValueError(f"Could not determine timezone for {lat}, {lon}")
     return tz_name

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,7 @@ Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 | `test_condition_vectors.py` | `predictor.py` | — | Per-target viability vectors: cloud/transparency blocks, light-dome and lunar-proximity blockers, effective windows, rollup |
 | `test_assemble_night_cycle_window.py` | `predictor.py` / `sky_events.py` | — / `eph` | Lunar-cycle dark-analysis window wiring in `assemble_night` |
 | `test_date_tz.py` | `predictor.py` / `targets.py` | — | Date/timezone correctness (incl. the UTC-vs-local night_date regression) |
+| `test_timezone_finder.py` | `location.py` | — | Process-wide `TimezoneFinder`: built once, thread-safe under concurrent lookups, answers unchanged |
 | `test_weather_conditions.py` | `weather.py` | — | `rate_conditions()` all branches (cloud, seeing, wind, humidity, AOD/PM2.5, precip cap); Open-Meteo parsing; 7Timer merge tolerance |
 | `test_weather_fallback.py` | `weather.py` | — | Provider selection and fallback |
 | `test_moon_events.py` | `moon_events.py` | — / `eph` | `classify_full_moon()` boundaries; lunar-eclipse detection |

--- a/tests/test_timezone_finder.py
+++ b/tests/test_timezone_finder.py
@@ -1,0 +1,90 @@
+"""The process-wide TimezoneFinder in location.py.
+
+Constructing a TimezoneFinder parses its bundled binary data, which costs orders
+of magnitude more than the timezone_at() lookup it enables. The original
+_tz_name_for built one per call and threw it away, so these tests pin the
+construction count, not just the answers — the answers were always right.
+"""
+import threading
+
+import pytest
+
+from darkhours import location as loc
+
+
+@pytest.fixture(autouse=True)
+def _reset_finder():
+    """Start each test with no finder built, and leave none behind."""
+    loc._tf = None
+    yield
+    loc._tf = None
+
+
+@pytest.fixture
+def counting_finder(monkeypatch):
+    """Replace TimezoneFinder with a counting subclass; yields the call list."""
+    calls: list[int] = []
+    real = loc.TimezoneFinder
+
+    class _Counting(real):
+        def __init__(self, *a, **kw):
+            calls.append(1)
+            super().__init__(*a, **kw)
+
+    monkeypatch.setattr(loc, "TimezoneFinder", _Counting)
+    return calls
+
+
+def test_finder_is_built_once_across_many_lookups(counting_finder):
+    """The regression guard: 25 lookups, one construction."""
+    for _ in range(25):
+        assert loc._tz_name_for(35.1983, -111.6513) == "America/Phoenix"
+    assert len(counting_finder) == 1
+
+
+@pytest.mark.parametrize("lat, lon, expected", [
+    (35.1983, -111.6513, "America/Phoenix"),   # Flagstaff, AZ — no DST
+    (51.4779,  -0.0015,  "Europe/London"),     # Greenwich
+    (-33.8568, 151.2153, "Australia/Sydney"),  # southern hemisphere
+])
+def test_known_coordinates_resolve_to_known_zones(lat, lon, expected):
+    """Sharing one instance must not change any answer."""
+    assert loc._tz_name_for(lat, lon) == expected
+
+
+def test_concurrent_lookups_agree_and_still_build_once(counting_finder):
+    """The API serves sync endpoints from a threadpool, so concurrent callers are
+    the normal case. All must agree, and none may build a second finder."""
+    results: list[str] = []
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(8)
+
+    def _worker():
+        try:
+            barrier.wait()          # maximise overlap on the first construction
+            results.append(loc._tz_name_for(35.1983, -111.6513))
+        except BaseException as e:  # noqa: BLE001 — surfaced by the assert below
+            errors.append(e)
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors
+    assert results == ["America/Phoenix"] * 8
+    assert len(counting_finder) == 1
+
+
+def test_unresolvable_point_still_raises(monkeypatch):
+    """The ValueError contract is unchanged. Stubbed rather than driven from real
+    coordinates: timezonefinder answers the open ocean with an Etc/GMT zone, so
+    there is no lat/lon that reaches this branch."""
+    class _Nothing:
+        def timezone_at(self, **kw):
+            return None
+
+    monkeypatch.setattr(loc, "_tf", _Nothing())
+    with pytest.raises(ValueError, match="Could not determine timezone"):
+        loc._tz_name_for(0.0, -140.0)


### PR DESCRIPTION
## Summary

`location._tz_name_for` constructed a fresh `TimezoneFinder` on every call, parsed its bundled binary data, ran one `timezone_at()` lookup against it, and discarded it. Construction costs orders of magnitude more than the lookup it enables, and every caller paid it: `/night`, `/calendar`, and the geocode paths on a cache miss.

Now one instance for the process, built lazily under a lock. Shared behind that lock rather than one instance per thread: the API serves sync endpoints from a threadpool, timezonefinder makes no thread-safety guarantee I verified, and a per-thread instance would pay the construction again per thread and hold another copy of the data. Serializing a microsecond lookup costs nothing, so the lock buys safety for free.

The lifespan pre-warm builds it during init, alongside the existing ephemeris and light-dome warm-ups, so the single construction stays off the first request to reach a container.

No behaviour change: same lookup, same answers, same `ValueError` contract.

Found by the `resolve timing` line added in #233, which splits `timezone_for` from `reverse_geocode`. That line stays in place, so the effect is visible in the same log field without new instrumentation.

## Test plan

- `python -m pytest -q` — 1028 passed, 10 skipped.
- New `tests/test_timezone_finder.py`: construction count pinned at one across 25 sequential lookups and across 8 threads released from a barrier; known coordinates still resolve to known zones; the `ValueError` path preserved.
- Both construction-count guards fail against the old implementation and pass against the new one (verified by reverting the change and re-running).
- `tests/README.md` inventory updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)