### PR TITLE
Size the DynamoDB connection pool on every client that builds one

### DIFF
--- a/darkhours/_env.py
+++ b/darkhours/_env.py
@@ -1,7 +1,8 @@
 """Tiny shared env-var parsing helper.
 
 Used by both circuit_breaker.py and rate_limiter.py for their "read once at
-import" boolean flags (PYNIGHTSKY_CIRCUIT_BREAKER_*, PYNIGHTSKY_RATE_LIMIT_*).
+import" boolean flags (PYNIGHTSKY_CIRCUIT_BREAKER_*, PYNIGHTSKY_RATE_LIMIT_*),
+and by every module that builds a DynamoDB client for the shared pool size.
 Deliberately provider-agnostic so neither of those two modules has to import
 the other just to share this — they otherwise never call into each other.
 """
@@ -12,3 +13,24 @@ import os
 
 def flag(name: str, default: str = "") -> bool:
     return os.environ.get(name, default).strip().lower() in ("1", "true", "yes", "on")
+
+
+# Every DynamoDB client the engine builds is sized from here (cache.py,
+# feature_flags.py, circuit_breaker.py). botocore's default of 10 is below
+# find_nearby's fan-out, and a connection returned to a full pool is discarded,
+# so the next caller pays a fresh TCP+TLS handshake. One knob rather than a
+# literal per client, so the three sites cannot drift apart.
+#
+# apps/provider_health/handler.py builds its own unconfigured client. It is a
+# scheduled monitor with no fan-out, and it ships in a separately deployed
+# stack, so it is deliberately left alone.
+DYNAMO_POOL_DEFAULT = 25
+
+
+def dynamo_pool() -> int:
+    """Per-client DynamoDB connection-pool size (PYNIGHTSKY_DYNAMO_POOL)."""
+    try:
+        return max(1, int(os.environ.get("PYNIGHTSKY_DYNAMO_POOL",
+                                         str(DYNAMO_POOL_DEFAULT))))
+    except ValueError:
+        return DYNAMO_POOL_DEFAULT

--- a/darkhours/cache.py
+++ b/darkhours/cache.py
@@ -15,6 +15,7 @@ import os
 import time
 from pathlib import Path
 
+from . import _env
 from . import ports
 
 log = logging.getLogger(__name__)
@@ -165,8 +166,8 @@ def _dynamo_table(table_name: str | None = None):
     # boto3 default of 10 connections is a separate pool per caller under concurrent
     # access within one container — the same "Connection pool is full, discarding
     # connection" churn the S3 client hit (see darksky.py's _s3()), just for
-    # DynamoDB. Bumped as a straightforward fix; PYNIGHTSKY_DYNAMO_POOL overrides it.
-    pool = int(os.environ.get("PYNIGHTSKY_DYNAMO_POOL", "25"))
+    # DynamoDB. Sizing lives in _env so every DynamoDB client shares one knob.
+    pool = _env.dynamo_pool()
     return boto3.resource(
         "dynamodb", region_name=region, config=Config(max_pool_connections=pool)
     ).Table(name)

--- a/darkhours/circuit_breaker.py
+++ b/darkhours/circuit_breaker.py
@@ -306,6 +306,9 @@ def _table():
                         connect_timeout=1.0,
                         read_timeout=1.0,
                         retries={"total_max_attempts": 1, "mode": "standard"},
+                        # Sized like every other DynamoDB client here; this one
+                        # bounded timeouts and retries but never the pool.
+                        max_pool_connections=_env.dynamo_pool(),
                     ),
                 ).Table(_HEALTH_TABLE)
     return _ddb_table

--- a/darkhours/feature_flags.py
+++ b/darkhours/feature_flags.py
@@ -124,6 +124,10 @@ def _table():
                         connect_timeout=1.0,
                         read_timeout=1.0,
                         retries={"total_max_attempts": 1, "mode": "standard"},
+                        # This Config set every bound except the pool, so the
+                        # client silently kept botocore's default of 10 while
+                        # find_nearby checked flags from a wider fan-out.
+                        max_pool_connections=_env.dynamo_pool(),
                     ),
                 ).Table(_TABLE)
     return _ddb_table

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,7 @@ Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 | `test_assemble_night_cycle_window.py` | `predictor.py` / `sky_events.py` | — / `eph` | Lunar-cycle dark-analysis window wiring in `assemble_night` |
 | `test_date_tz.py` | `predictor.py` / `targets.py` | — | Date/timezone correctness (incl. the UTC-vs-local night_date regression) |
 | `test_timezone_finder.py` | `location.py` | — | Process-wide `TimezoneFinder`: built once, thread-safe under concurrent lookups, answers unchanged |
+| `test_dynamo_pool.py` | `_env.py` / `cache.py` / `feature_flags.py` / `circuit_breaker.py` | — | Every DynamoDB client sizes `max_pool_connections` above botocore's default; env override and bad-value fallback |
 | `test_weather_conditions.py` | `weather.py` | — | `rate_conditions()` all branches (cloud, seeing, wind, humidity, AOD/PM2.5, precip cap); Open-Meteo parsing; 7Timer merge tolerance |
 | `test_weather_fallback.py` | `weather.py` | — | Provider selection and fallback |
 | `test_moon_events.py` | `moon_events.py` | — / `eph` | `classify_full_moon()` boundaries; lunar-eclipse detection |

--- a/tests/test_dynamo_pool.py
+++ b/tests/test_dynamo_pool.py
@@ -1,0 +1,96 @@
+"""Every DynamoDB client the engine builds must size its connection pool.
+
+botocore defaults to 10 connections. find_nearby fans out wider than that, and a
+connection handed back to a full pool is discarded rather than parked — so the
+next caller pays a fresh TCP+TLS handshake and the worker logs "Connection pool
+is full, discarding connection". cache.py had always set this; feature_flags.py
+and circuit_breaker.py set every other bound on their Config but not this one,
+which is the shape of bug these tests exist to catch.
+"""
+import os
+
+import pytest
+
+from darkhours import _env
+
+
+BOTOCORE_DEFAULT_POOL = 10
+
+
+# --------------------------------------------------------------------------
+# the shared knob
+# --------------------------------------------------------------------------
+
+def test_default_is_above_the_botocore_default():
+    assert _env.dynamo_pool() > BOTOCORE_DEFAULT_POOL
+
+
+def test_env_override_is_honoured(monkeypatch):
+    monkeypatch.setenv("PYNIGHTSKY_DYNAMO_POOL", "40")
+    assert _env.dynamo_pool() == 40
+
+
+def test_garbage_override_falls_back_to_the_default(monkeypatch):
+    """An unparseable value must not take the process down on first cache read."""
+    monkeypatch.setenv("PYNIGHTSKY_DYNAMO_POOL", "not-a-number")
+    assert _env.dynamo_pool() == _env.DYNAMO_POOL_DEFAULT
+
+
+def test_pool_is_never_zero(monkeypatch):
+    """botocore raises on a pool of 0; clamp rather than propagate."""
+    monkeypatch.setenv("PYNIGHTSKY_DYNAMO_POOL", "0")
+    assert _env.dynamo_pool() >= 1
+
+
+# --------------------------------------------------------------------------
+# each client actually applies it
+# --------------------------------------------------------------------------
+
+def _captured_config(monkeypatch, module, builder, table_env=None):
+    """Build a table handle with boto3 stubbed, returning the botocore Config."""
+    boto3 = pytest.importorskip("boto3")
+    seen = {}
+
+    class _FakeResource:
+        def Table(self, name):
+            return object()
+
+    def _fake_resource(service, **kwargs):
+        seen["service"] = service
+        seen["config"] = kwargs.get("config")
+        return _FakeResource()
+
+    monkeypatch.setattr(boto3, "resource", _fake_resource)
+    builder()
+    return seen["config"]
+
+
+def test_feature_flags_client_sizes_its_pool(monkeypatch):
+    from darkhours import feature_flags as ff
+    monkeypatch.setattr(ff, "_ddb_table", None)
+    cfg = _captured_config(monkeypatch, ff, ff._table)
+    assert cfg.max_pool_connections == _env.dynamo_pool()
+    assert cfg.max_pool_connections > BOTOCORE_DEFAULT_POOL
+    # The fail-fast bounds this module depends on must survive the change.
+    assert cfg.connect_timeout == 1.0
+    assert cfg.read_timeout == 1.0
+    monkeypatch.setattr(ff, "_ddb_table", None)
+
+
+def test_circuit_breaker_client_sizes_its_pool(monkeypatch):
+    from darkhours import circuit_breaker as cb
+    monkeypatch.setattr(cb, "_ddb_table", None)
+    cfg = _captured_config(monkeypatch, cb, cb._table)
+    assert cfg.max_pool_connections == _env.dynamo_pool()
+    assert cfg.max_pool_connections > BOTOCORE_DEFAULT_POOL
+    assert cfg.connect_timeout == 1.0
+    assert cfg.read_timeout == 1.0
+    monkeypatch.setattr(cb, "_ddb_table", None)
+
+
+def test_cache_client_sizes_its_pool(monkeypatch):
+    from darkhours import cache as _cache
+    monkeypatch.setenv("PYNIGHTSKY_CACHE_TABLE", "unit-test-table")
+    cfg = _captured_config(monkeypatch, _cache, _cache._dynamo_table)
+    assert cfg.max_pool_connections == _env.dynamo_pool()
+    assert cfg.max_pool_connections > BOTOCORE_DEFAULT_POOL


### PR DESCRIPTION
## Summary

`feature_flags._table()` and `circuit_breaker._table()` passed a botocore `Config` that bounded connect timeout, read timeout and retries, but not the connection pool, so both silently kept botocore's default of 10. `find_nearby` checks flags and breaker state from a wider fan-out than that, and a connection returned to a full pool is discarded rather than parked, so the next caller paid a fresh TCP+TLS handshake. The worker has been logging `Connection pool is full, discarding connection: dynamodb.us-east-1.amazonaws.com. Connection pool size: 10` steadily.

`cache.py` already sized its pool correctly. Its literal moves to `_env.dynamo_pool()` so all three clients share one knob and cannot drift apart; the default and the `PYNIGHTSKY_DYNAMO_POOL` override are unchanged. A bad override value now falls back instead of raising on the first cache read, and the size is clamped to at least 1 since botocore rejects a pool of 0.

`apps/provider_health/handler.py` builds its own unconfigured client and is deliberately left alone: a scheduled monitor with no fan-out, shipping in a separately deployed stack.

The fail-fast bounds both modules depend on (1 s connect, 1 s read, single attempt) are unchanged, and now asserted.

## Test plan

- `python -m pytest -q` — 1035 passed, 10 skipped.
- New `tests/test_dynamo_pool.py`: each of the three clients is built with boto3 stubbed and its `Config` inspected, asserting `max_pool_connections` is set and above botocore's default, plus that the fail-fast timeouts survive.
- `test_feature_flags_client_sizes_its_pool` fails with the kwarg removed and passes with it (verified by reverting).
- Env override, unparseable-value fallback, and the zero clamp covered.
- `tests/README.md` inventory updated.

Effect is visible in the worker log group: the warning should stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)