### PR TITLE
Read the Starlink group as CSV so recent launches are visible again

### DIFF
--- a/darkhours/tle_provider.py
+++ b/darkhours/tle_provider.py
@@ -315,8 +315,17 @@ def _as_launch_dates(value) -> dict[str, date]:
 # Starlink train TLE acquisition
 # ---------------------------------------------------------------------------
 
+# CSV, not TLE. Celestrak assigns 6-digit catalog numbers to objects catalogued
+# from 2026-07-11 onward, and does not render those in the legacy TLE format at
+# all — a 5-character catalog field cannot hold them and Celestrak declined the
+# Alpha-5 stopgap for GP output, publishing JSON/XML/CSV/KVN instead. A
+# FORMAT=TLE request therefore silently returns a constellation frozen at the
+# last 5-digit launch, which is what made this feature report zero trains every
+# night: no launch inside _STARLINK_RECENT_DAYS was in the response to match.
+# Measured 2026-08-26: TLE 10,738 objects, newest launch 2026-159; CSV 10,989
+# objects, newest launch 2026-190, 253 of them with 6-digit catalog numbers.
 _STARLINK_GROUP_URL       = ("https://celestrak.org/NORAD/elements/gp.php"
-                             "?GROUP=starlink&FORMAT=TLE")
+                             "?GROUP=starlink&FORMAT=CSV")
 
 # The cache holds the *filtered* train list, never the raw group response.
 #
@@ -416,27 +425,62 @@ def _parse_satcat_launch_dates(csv_text: str, today: date) -> dict[str, date]:
     return out
 
 
+# OMM columns _filter_train_tles cannot work without. Checked explicitly so a
+# body that is not the CSV we asked for fails loudly instead of filtering to an
+# empty list: Celestrak answers some queries with a one-line "No GP data found"
+# under HTTP 200, and an empty result here is indistinguishable from a genuine
+# night with no trains. That ambiguity is what let a 45-day outage pass as
+# healthy, since the warmer reports `ok (0 trains)` either way.
+_OMM_REQUIRED_COLUMNS = ("OBJECT_NAME", "OBJECT_ID", "MEAN_MOTION", "EPOCH")
+
+
+def _omm_row_to_tle(row: dict) -> tuple[str, str] | None:
+    """Render one OMM CSV row as (line1, line2), or None if sgp4 rejects it.
+
+    The cache and everything downstream still hold TLE line pairs, so only the
+    handful of rows that survive the filter are converted — not the ~11,000 in
+    the response. Catalog numbers of 100000+ come back Alpha-5 encoded (100001 →
+    ``A0001``), which sgp4 and skyfield both read back to the original integer;
+    nothing on the train path reads the catalog number anyway.
+    """
+    from sgp4 import exporter, omm as _omm     # lazy: warmer path only
+    from sgp4.api import Satrec
+
+    try:
+        sat = Satrec()
+        _omm.initialize(sat, row)
+        line1, line2 = exporter.export_tle(sat)
+    except Exception as e:                      # malformed row, never fatal
+        log.debug("Skipping unconvertible OMM row %s: %s", row.get("OBJECT_ID"), e)
+        return None
+    return line1, line2
+
+
 def _filter_train_tles(
     raw: str, launch_dates: dict[str, date]
 ) -> list[tuple[str, str, str, str]]:
     """
-    Parse a multi-TLE block and return only raising-phase Starlinks from recent launches.
+    Parse a GP CSV response and return only raising-phase Starlinks from recent launches.
 
     Two-part filter:
-      1. Mean motion ≥ _STARLINK_TRAIN_MM_MIN — the satellite is still below every
+      1. Mean motion >= _STARLINK_TRAIN_MM_MIN — the satellite is still below every
          operational shell, so it has not been handed over to service yet.
       2. The launch is within _STARLINK_RECENT_DAYS, per *launch_dates* — an older
          batch has spread around its orbit and no longer crosses the sky as a train
          even while it is still raising.
 
     Recency is the load-bearing half, and it is why this needs the SATCAT. Mean
-    motion alone is not a train signal: ~880 of the ~10,700 satellites in the group
-    are above the threshold at any moment, and most are old satellites being lowered
-    for re-entry rather than new ones being raised.
+    motion alone is not a train signal: most satellites above the threshold are old
+    ones being lowered for re-entry rather than new ones being raised, and a
+    descending satellite speeds up exactly like a climbing one.
 
     An empty *launch_dates* therefore fails closed. Without dates the two populations
     are indistinguishable, and emitting the raising-phase set unfiltered would put
     hundreds of decaying satellites on screen labelled as trains.
+
+    ``OBJECT_ID`` carries the full international designator ("2026-160A"); the first
+    eight characters are the launch key, the same key _parse_satcat_launch_dates
+    builds on the other side of this join.
 
     Ordered newest launch first so _STARLINK_MAX_TRAINS truncates the oldest batch
     rather than an arbitrary one.
@@ -444,6 +488,8 @@ def _filter_train_tles(
     The recency cutoff is evaluated here, at filter time, and the result is what gets
     cached — so it is frozen for up to one refresh interval (6 h) against a 21-day
     window. That drift is immaterial; caching the raw block instead is what was not.
+
+    Raises ValueError if *raw* is not the OMM CSV we asked for.
     """
     if not launch_dates:
         log.error("No Starlink launch dates available — cannot tell a train from a "
@@ -451,27 +497,37 @@ def _filter_train_tles(
                   extra={"service": "celestrak"})
         return []
 
+    reader = csv.DictReader(io.StringIO(raw))
+    missing = [c for c in _OMM_REQUIRED_COLUMNS if c not in (reader.fieldnames or ())]
+    if missing:
+        raise ValueError(
+            f"Starlink group response is not OMM CSV — missing {', '.join(missing)}; "
+            f"body starts {raw[:80]!r}"
+        )
+
     cutoff = datetime.now(timezone.utc).date() - timedelta(days=_STARLINK_RECENT_DAYS)
 
-    lines  = [l.strip() for l in raw.splitlines() if l.strip()]
     dated: list[tuple[date, tuple[str, str, str, str]]] = []
     raising = 0
-    i = 0
-    while i + 2 <= len(lines) - 1:
-        name, l1, l2 = lines[i], lines[i + 1], lines[i + 2]
-        if l1.startswith("1 ") and l2.startswith("2 "):
-            mm = _parse_mean_motion(l2)
-            if mm is not None and mm >= _STARLINK_TRAIN_MM_MIN:
-                raising += 1
-                launched = launch_dates.get(_cospar_designator(l1) or "")
-                if launched is not None and launched >= cutoff:
-                    dated.append((launched, (name, l1, l2, launched.isoformat())))
-            i += 3
-        else:
-            i += 1
+    for row in reader:
+        try:
+            mm = float(row["MEAN_MOTION"])
+        except (TypeError, ValueError):
+            continue
+        if mm < _STARLINK_TRAIN_MM_MIN:
+            continue
+        raising += 1
+        launched = launch_dates.get((row.get("OBJECT_ID") or "")[:8])
+        if launched is None or launched < cutoff:
+            continue
+        lines = _omm_row_to_tle(row)
+        if lines is None:
+            continue
+        name = (row.get("OBJECT_NAME") or "").strip() or "STARLINK"
+        dated.append((launched, (name, lines[0], lines[1], launched.isoformat())))
 
     dated.sort(key=lambda entry: entry[0], reverse=True)
-    log.debug("Filtered %d Starlink train candidates from group TLE (%d raising)",
+    log.debug("Filtered %d Starlink train candidates from group CSV (%d raising)",
               len(dated), raising)
     return [entry for _, entry in dated]
 

--- a/docs/TLE_CACHE.md
+++ b/docs/TLE_CACHE.md
@@ -38,10 +38,18 @@ refuses any item over `_MAX_ITEM_BYTES` (380,000) and returns `False`.
 
 | Gate | Constant | Value | Source |
 |---|---|---|---|
-| mean motion ≥ | `_STARLINK_TRAIN_MM_MIN` | 15.2 rev/day | TLE line 2, cols 52-63 |
+| mean motion ≥ | `_STARLINK_TRAIN_MM_MIN` | 15.2 rev/day | OMM `MEAN_MOTION` |
 | launch within | `_STARLINK_RECENT_DAYS` | 21 days | SATCAT `LAUNCH_DATE` |
 
-Every operational Starlink shell is at or below ~15.12 rev/day (530–560 km).
+Measured against the 2026-08-26 feed (10,989 objects), the mean-motion gate at 15.2
+matches 9,603 — 89.4% of the constellation. Populated shells sit at 15.28, 15.32,
+15.33 and 15.34 rev/day (464–482 km), all above the threshold; 8,165 objects
+spanning launch years 2019–2026 fall in 15.25–15.35.
+
+Mean motion does not separate raising from decaying: a satellite being lowered for
+re-entry gains mean motion the same way a raising one has not yet lost it. Maximum
+among pre-2026 launches is 16.49, above the 16.10 maximum of the newest launch in
+the feed. `_STARLINK_RECENT_DAYS` is the only filter with separating power.
 
 Launch dates are **not** derivable from a TLE. The International Designator
 (line 1, cols 10-17) is `YYNNNPPP` where `NNN` is the launch's sequence number
@@ -49,23 +57,42 @@ within its year, not a day of the year: `1998-067A` is the ISS, launched
 1998-11-20. `_cospar_designator` returns `"YYYY-NNN"`; the date comes from SATCAT.
 
 An empty launch-date map fails the filter closed (0 trains, ERROR logged,
-`service=celestrak`) and skips the group fetch entirely.
+`service=celestrak`) and skips the group fetch entirely. A body that is not OMM CSV
+raises `ValueError` rather than filtering to an empty list.
 
 ## Upstream sources
 
 | Data | Endpoint | Update policy |
 |---|---|---|
 | tracked TLEs | `gp.php?CATNR=<id>&FORMAT=TLE` | 403 = unchanged since last download |
-| Starlink group | `gp.php?GROUP=starlink&FORMAT=TLE` | 2 h; 403 = unchanged |
+| Starlink group | `gp.php?GROUP=starlink&FORMAT=CSV` | 2 h; 403 = unchanged |
 | launch dates | `satcat/records.php?GROUP=starlink&FORMAT=CSV` | no download policy |
 
-GP element sets and SATCAT entries do not appear together. Observed 2026-08-23:
-SATCAT listed Starlink launches through 2026-08-12 (designators to `2026-184`,
-catalog numbers ≥ 100000), while GP data existed only through `2026-159`
-(2026-07-11). `GROUP=last-30-days` was empty, and `INTDES=`/`CATNR=` queries for
-the newer launches returned `No GP data found`. No trains are reportable while
-the newest GP launch is older than `_STARLINK_RECENT_DAYS`; `TleWarmItems` on
-`Key=starlink` is where that shows up.
+Objects catalogued from 2026-07-11 carry 6-digit catalog numbers. Celestrak does
+not render those in `FORMAT=TLE`; GP data for them is served in JSON/XML/CSV/KVN
+only. A `FORMAT=TLE` request returns the constellation truncated at the last
+5-digit launch.
+
+Measured 2026-08-26, same endpoint, same day:
+
+| Request | Objects | Newest launch | 6-digit |
+|---|---|---|---|
+| `GROUP=starlink&FORMAT=TLE` | 10,738 | `2026-159` | 0 |
+| `GROUP=starlink&FORMAT=CSV` | 10,989 | `2026-190` | 253 |
+
+The 2026-08-23 observations that `GROUP=last-30-days` was empty and `INTDES=` /
+`CATNR=` returned `No GP data found` were all `FORMAT=TLE` requests.
+`CATNR=100001&FORMAT=CSV` returns the object.
+
+Surviving rows are re-encoded as TLE line pairs on the way into the cache; catalog
+numbers ≥ 100000 become Alpha-5 (`100001` → `A0001`), which sgp4 and skyfield read
+back as the original integer. Nothing on the train path reads the catalog number.
+
+Objects with SpaceX provisional ids (9-digit, e.g. `799501431`) are not in GP and
+have no SATCAT row, so they carry no launch date and are filtered out. They appear
+once catalogued.
+
+`TleWarmItems` on `Key=starlink` is where a truncated feed shows up.
 
 ## Degradation (request path)
 

--- a/tests/test_tle_provider.py
+++ b/tests/test_tle_provider.py
@@ -91,9 +91,32 @@ class TestCosparDesignator:
 # _filter_train_tles — Starlink raising-phase filter
 # ---------------------------------------------------------------------------
 
+def _omm_csv(*sats) -> str:
+    """Build a GP CSV response (OMM) from (name, designator, mean_motion) triples.
+
+    The real feed is FORMAT=CSV: FORMAT=TLE cannot carry the 6-digit catalog numbers
+    Celestrak assigns to anything catalogued since 2026-07-11, so a TLE request
+    silently omits every recent launch — which is exactly what made this filter
+    report zero trains.
+    """
+    cols = ["OBJECT_NAME", "OBJECT_ID", "EPOCH", "MEAN_MOTION", "ECCENTRICITY",
+            "INCLINATION", "RA_OF_ASC_NODE", "ARG_OF_PERICENTER", "MEAN_ANOMALY",
+            "EPHEMERIS_TYPE", "CLASSIFICATION_TYPE", "NORAD_CAT_ID",
+            "ELEMENT_SET_NO", "REV_AT_EPOCH", "BSTAR", "MEAN_MOTION_DOT",
+            "MEAN_MOTION_DDOT"]
+    rows = [",".join(cols)]
+    for i, (name, designator, mm) in enumerate(sats):
+        rows.append(",".join([
+            name, designator, "2026-08-25T12:00:00.000000", f"{mm:.8f}",
+            ".0001000", "53.0000", "100.0000", "90.0000", "270.0000",
+            "0", "U", str(50000 + i), "999", "100", ".0001000", ".00000000", "0",
+        ]))
+    return "\n".join(rows)
+
+
 def _make_train_block() -> str:
     """
-    Build a multi-TLE block with four synthetic Starlink satellites:
+    Four synthetic Starlinks:
       RECENT-HIGH   — launch 2026-040, 5 days ago,  MM=15.60 → INCLUDE
       RECENT-LOW    — launch 2026-040, 5 days ago,  MM=15.06 → EXCLUDE (on station)
       OLD-HIGH      — launch 2026-030, 30 days ago, MM=15.70 → EXCLUDE (stale batch)
@@ -103,20 +126,12 @@ def _make_train_block() -> str:
     safest treated as recent. It is the opposite: an undatable satellite at high mean
     motion is far more likely to be an old one on its way down.
     """
-    def _l1(n: int, designator: str) -> str:
-        intl = f"{designator}  "[:8] if designator else "        "
-        return f"1 {n:05d}U {intl}24001.50000000  .00000000  00000-0  00000-0 0  9999"
-
-    def _l2(n: int, mm: float) -> str:
-        prefix = f"2 {n:05d}  51.6000 180.0000 0001000  90.0000 270.0000 "
-        return prefix + f"{mm:.8f}00001 0"
-
-    return "\n".join([
-        "STARLINK-RECENT-HIGH",  _l1(10001, "26040A"), _l2(10001, 15.60),
-        "STARLINK-RECENT-LOW",   _l1(10002, "26040B"), _l2(10002, 15.06),
-        "STARLINK-OLD-HIGH",     _l1(10003, "26030A"), _l2(10003, 15.70),
-        "STARLINK-UNKNOWN-DATE", _l1(10004, ""),       _l2(10004, 15.55),
-    ])
+    return _omm_csv(
+        ("STARLINK-RECENT-HIGH",   "2026-040A", 15.60),
+        ("STARLINK-RECENT-LOW",    "2026-040B", 15.06),
+        ("STARLINK-OLD-HIGH",      "2026-030A", 15.70),
+        ("STARLINK-UNKNOWN-DATE",  "",          15.55),
+    )
 
 
 _TODAY        = date.today()
@@ -149,12 +164,18 @@ class TestFilterTrainTles:
             assert len(entry) == 4          # (name, line1, line2, launch_date)
             assert entry[3] == (_TODAY - timedelta(days=5)).isoformat()
 
-    def test_empty_block_returns_empty(self):
-        assert _filter_train_tles("", _LAUNCH_DATES) == []
+    def test_empty_body_raises_rather_than_reporting_no_trains(self):
+        """An empty body is a broken fetch, not a quiet night. Returning [] here is
+        indistinguishable from a real result and is how a 45-day outage stayed
+        invisible — the warmer reports `ok (0 trains)` either way."""
+        with pytest.raises(ValueError, match="not OMM CSV"):
+            _filter_train_tles("", _LAUNCH_DATES)
 
-    def test_malformed_block_skipped_gracefully(self):
-        block = "JUNK LINE\nNOT A TLE\nALSO JUNK"
-        assert _filter_train_tles(block, _LAUNCH_DATES) == []
+    def test_non_csv_body_raises(self):
+        """Celestrak answers some queries with a one-line 'No GP data found' under
+        HTTP 200. That must reach the caller's error path, not the filter's."""
+        with pytest.raises(ValueError, match="not OMM CSV"):
+            _filter_train_tles("No GP data found", _LAUNCH_DATES)
 
     def test_no_launch_dates_matches_nothing(self):
         assert _filter_train_tles(self.block, {}) == []

--- a/tests/test_tle_request_path.py
+++ b/tests/test_tle_request_path.py
@@ -179,16 +179,25 @@ _DESIGNATOR = f"{_TODAY.year}-042"
 
 
 def _synthetic_group(n_sats: int, designator_suffix: str = "042") -> str:
-    """A GROUP=starlink-shaped block. The real one is ~1.8 MB / ~10,700 satellites."""
-    yy  = _TODAY.year % 100
-    out = []
+    """A GROUP=starlink-shaped GP CSV response. The real one is ~1.7 MB / ~11,000 rows.
+
+    CSV, not TLE: FORMAT=TLE omits every object with a 6-digit catalog number, which
+    since 2026-07-11 means every recent launch — the reason this filter reported zero.
+    """
+    cols = ["OBJECT_NAME", "OBJECT_ID", "EPOCH", "MEAN_MOTION", "ECCENTRICITY",
+            "INCLINATION", "RA_OF_ASC_NODE", "ARG_OF_PERICENTER", "MEAN_ANOMALY",
+            "EPHEMERIS_TYPE", "CLASSIFICATION_TYPE", "NORAD_CAT_ID",
+            "ELEMENT_SET_NO", "REV_AT_EPOCH", "BSTAR", "MEAN_MOTION_DOT",
+            "MEAN_MOTION_DDOT"]
+    designator = f"{_TODAY.year}-{designator_suffix}A"
+    out = [",".join(cols)]
     for i in range(n_sats):
         # Mean motion 15.90 → below every operational shell → raising phase.
-        out.append(f"STARLINK-{i:05d}")
-        out.append(f"1 {50000 + i:05d}U {yy:02d}{designator_suffix}A   26235.50000000  "
-                   f".00002182  00000+0  40768-4 0  9992")
-        out.append(f"2 {50000 + i:05d}  53.0000 100.0000 0001000  90.0000 270.0000 "
-                   f"15.90000000    10")
+        out.append(",".join([
+            f"STARLINK-{i:05d}", designator, "2026-08-25T12:00:00.000000",
+            "15.90000000", ".0001000", "53.0000", "100.0000", "90.0000", "270.0000",
+            "0", "U", str(50000 + i), "999", "100", ".0000408", ".00002182", "0",
+        ]))
     return "\n".join(out)
 
 
@@ -282,6 +291,43 @@ def test_cospar_designator_reads_a_launch_number_not_a_day_of_year():
     assert tle._cospar_designator(starlink) == "2026-159"
 
     assert tle._cospar_designator("1 25544U          24191.72490000") is None
+
+
+def test_six_digit_catalog_numbers_survive_the_filter():
+    """The bug, pinned.
+
+    Celestrak assigns 6-digit catalog numbers to everything catalogued since
+    2026-07-11 and does not render those objects in FORMAT=TLE at all. Asking for
+    TLE therefore returned a constellation frozen at the last 5-digit launch, no
+    launch inside the recency window matched, and the feature reported zero trains
+    every night for weeks while looking healthy.
+
+    A 5-character TLE catalog field cannot hold 100001, so the filter re-encodes it
+    Alpha-5 ("A0001") on the way into the cache. This asserts the number survives
+    that round trip rather than being silently truncated to 10000 — sgp4 parses a
+    raw 6-digit line without complaint and shifts every field one column.
+    """
+    from sgp4.api import Satrec
+
+    raw = _synthetic_group(1).replace(",50000,", ",100001,")
+    trains = tle._filter_train_tles(raw, _recent_launch_dates(days_ago=1))
+
+    assert len(trains) == 1
+    _name, line1, line2, _launched = trains[0]
+    assert Satrec.twoline2rv(line1, line2).satnum == 100001
+
+
+def test_tle_format_body_is_rejected_not_silently_empty():
+    """A FORMAT=TLE body reaching this filter means the URL regressed. It must raise:
+    returning [] is indistinguishable from a genuine night with no trains, which is
+    how the outage above stayed invisible."""
+    tle_text = "\n".join([
+        "STARLINK-1234",
+        "1 50000U 26042A   26235.50000000  .00002182  00000+0  40768-4 0  9992",
+        "2 50000  53.0000 100.0000 0001000  90.0000 270.0000 15.90000000    10",
+    ])
+    with pytest.raises(ValueError, match="not OMM CSV"):
+        tle._filter_train_tles(tle_text, _recent_launch_dates(days_ago=1))
 
 
 def test_filter_needs_launch_dates_and_fails_closed_without_them(caplog):


### PR DESCRIPTION
## Summary

Starlink train predictions have returned zero for weeks. Celestrak assigns 6-digit catalog numbers to objects catalogued from 2026-07-11 onward and does not render those in the legacy TLE format — the catalog field is five characters wide, and Celestrak declined the Alpha-5 stopgap for GP output, publishing JSON/XML/CSV/KVN instead. Our `FORMAT=TLE` request returned the constellation truncated at the last 5-digit launch, so nothing inside `_STARLINK_RECENT_DAYS` was in the response to match.

Same endpoint, same day:

| Request | Objects | Newest launch | 6-digit |
|---|---|---|---|
| `FORMAT=TLE` | 10,738 | `2026-159` | 0 |
| `FORMAT=CSV` | 10,989 | `2026-190` | 253 |

`_filter_train_tles` now parses OMM CSV. The join key is unchanged: `OBJECT_ID`'s first eight characters are the same launch key `_parse_satcat_launch_dates` builds on the other side. Only rows that survive the filter are re-encoded as TLE line pairs, so the cache and everything downstream keep their existing shape. Catalog numbers of 100000+ become Alpha-5 (`100001` → `A0001`), which sgp4 and skyfield read back as the original integer; nothing on the train path reads the catalog number.

A body that is not OMM CSV now raises rather than filtering to an empty list. Celestrak answers some queries with a one-line `No GP data found` under HTTP 200, and an empty result was indistinguishable from a genuine night with no trains — which is how this stayed invisible, since the warmer reports `ok (0 trains)` either way.

## Not in this PR

The mean-motion gate needs its own change. Measured against this feed, `_STARLINK_TRAIN_MM_MIN = 15.2` matches 89.4% of the constellation, and no threshold can separate raising from decaying satellites — one being lowered for re-entry gains mean motion the same way a raising one has not yet lost it. `docs/TLE_CACHE.md` now records what the feed shows instead of the shell figures it asserted before.

`_cospar_designator` and `_parse_mean_motion` are now unused by this path. Kept deliberately: they encode the launch-number-not-day-of-year invariant from #231 along with its regression test. Say the word and I'll remove them.

## Test plan

- `python -m pytest -q` — 1037 passed, 10 skipped.
- Verified against the live feed end to end: `refresh_starlink_trains` returns **101 trains across four launches**, cached value 18 KB (4.8% of the DynamoDB item budget), all 101 round-trip through `_as_tle_tuples` and build as skyfield `EarthSatellite`s.
- New `test_six_digit_catalog_numbers_survive_the_filter` pins `100001` through the Alpha-5 round trip — a raw 6-digit TLE line parses without complaint and silently shifts every field one column, so truncation would not otherwise fail loudly.
- New `test_tle_format_body_is_rejected_not_silently_empty` guards the URL against regressing to TLE.
- Both fixtures converted from TLE blocks to OMM CSV; the two tests that asserted silent-empty now assert the raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)