### PR TITLE
Let every satellite pass lead a train instead of consuming the scan window

### DIFF
--- a/darkhours/satellites.py
+++ b/darkhours/satellites.py
@@ -473,6 +473,67 @@ def _entry_launch_date(entry) -> Optional[date]:
         return None
 
 
+def _group_passes_into_trains(all_passes: list[dict]) -> list["StarlinkTrain"]:
+    """Collapse individual satellite passes into train groups.
+
+    *all_passes* must be sorted by rise time. A train is a run of passes whose rise
+    times are within _TRAIN_GAP_S of each other and whose rise azimuths are within
+    _TRAIN_AZ_TOLERANCE of the lead's, with at least _TRAIN_MIN_COUNT members.
+
+    Split out of starlink_train_passes so the grouping can be tested without
+    propagating real orbits: it had no direct test, which is how the cursor bug
+    below survived.
+    """
+    # Every pass gets a chance to lead a train, and only passes actually
+    # placed in a reported train are consumed.
+    #
+    # The cursor used to jump to wherever the forward scan stopped
+    # (``i = j``), which swallowed every pass in the scanned window — both
+    # the ones skipped for rising on a different azimuth and every member of
+    # a group too small to qualify. Two trains crossing the same window rise
+    # on different azimuths (Starlink flies 43°, 53°, 70° and 97°
+    # inclinations), so the second was silently dropped. The ``else i + 1``
+    # guard on that line could never fire: j starts at i + 1 and only
+    # increases, so ``j > i`` was always true.
+    trains: list[StarlinkTrain] = []
+    claimed: set[int] = set()
+    i = 0
+    while i < len(all_passes):
+        if i in claimed:
+            i += 1
+            continue
+        lead    = all_passes[i]
+        group   = [lead]
+        members = [i]
+        j       = i + 1
+        while j < len(all_passes):
+            cand = all_passes[j]
+            gap  = (cand["rise_time"] - group[-1]["rise_time"]).total_seconds()
+            if gap > _TRAIN_GAP_S:
+                break
+            if (j not in claimed
+                    and _az_diff(cand["rise_az"], lead["rise_az"]) <= _TRAIN_AZ_TOLERANCE):
+                group.append(cand)
+                members.append(j)
+            j += 1
+
+        if len(group) >= _TRAIN_MIN_COUNT:
+            trains.append(StarlinkTrain(
+                satellite_count = len(group),
+                first_rise      = lead["rise_time"],
+                last_rise       = group[-1]["rise_time"],
+                peak_alt_deg    = round(max(p["peak_alt"] for p in group), 1),
+                lead_az_deg     = round(lead["rise_az"], 1),
+                duration_min    = round(sum(p["dur_min"] for p in group) / len(group), 1),
+                moon_sep_deg    = lead["moon_sep"],
+                sky_dark        = lead["sky_dark"],
+                launch_date     = lead["launch_date"],
+            ))
+            claimed.update(members)
+        i += 1
+    return trains
+
+
 def starlink_train_passes(
     train_tles: list[tuple[str, str, str]],
     lat:        float,
@@ -567,37 +628,7 @@ def starlink_train_passes(
 
         all_passes.sort(key=lambda p: p["rise_time"])
 
-        # ── Group into trains ────────────────────────────────────────────────
-        trains: list[StarlinkTrain] = []
-        i = 0
-        while i < len(all_passes):
-            lead  = all_passes[i]
-            group = [lead]
-            j     = i + 1
-            while j < len(all_passes):
-                cand = all_passes[j]
-                gap  = (cand["rise_time"] - group[-1]["rise_time"]).total_seconds()
-                if gap > _TRAIN_GAP_S:
-                    break
-                if _az_diff(cand["rise_az"], lead["rise_az"]) <= _TRAIN_AZ_TOLERANCE:
-                    group.append(cand)
-                j += 1
-
-            if len(group) >= _TRAIN_MIN_COUNT:
-                trains.append(StarlinkTrain(
-                    satellite_count = len(group),
-                    first_rise      = lead["rise_time"],
-                    last_rise       = group[-1]["rise_time"],
-                    peak_alt_deg    = round(max(p["peak_alt"] for p in group), 1),
-                    lead_az_deg     = round(lead["rise_az"], 1),
-                    duration_min    = round(sum(p["dur_min"] for p in group) / len(group), 1),
-                    moon_sep_deg    = lead["moon_sep"],
-                    sky_dark        = lead["sky_dark"],
-                    launch_date     = lead["launch_date"],
-                ))
-            i = j if j > i else i + 1
-
-        return trains
+        return _group_passes_into_trains(all_passes)
 
     except Exception as e:
         log.warning("Starlink train computation failed: %s", e, exc_info=True)

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,7 @@ Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 | `test_date_tz.py` | `predictor.py` / `targets.py` | — | Date/timezone correctness (incl. the UTC-vs-local night_date regression) |
 | `test_timezone_finder.py` | `location.py` | — | Process-wide `TimezoneFinder`: built once, thread-safe under concurrent lookups, answers unchanged |
 | `test_dynamo_pool.py` | `_env.py` / `cache.py` / `feature_flags.py` / `circuit_breaker.py` | — | Every DynamoDB client sizes `max_pool_connections` above botocore's default; env override and bad-value fallback |
+| `test_starlink_train_grouping.py` | `satellites.py` | — | `_group_passes_into_trains`: interleaved trains both reported, sub-threshold groups release their passes, no satellite counted twice |
 | `test_weather_conditions.py` | `weather.py` | — | `rate_conditions()` all branches (cloud, seeing, wind, humidity, AOD/PM2.5, precip cap); Open-Meteo parsing; 7Timer merge tolerance |
 | `test_weather_fallback.py` | `weather.py` | — | Provider selection and fallback |
 | `test_moon_events.py` | `moon_events.py` | — / `eph` | `classify_full_moon()` boundaries; lunar-eclipse detection |

--- a/tests/test_starlink_train_grouping.py
+++ b/tests/test_starlink_train_grouping.py
@@ -1,0 +1,129 @@
+"""Grouping individual satellite passes into Starlink trains.
+
+_group_passes_into_trains had no direct test before this file — the grouping was
+inline in starlink_train_passes, which needs real orbits to reach. That is how the
+cursor bug these tests pin survived: the loop advanced to wherever its forward scan
+stopped, consuming passes it had skipped for rising on a different azimuth, so a
+second train crossing the same window was silently dropped.
+"""
+from datetime import datetime, timedelta, timezone
+
+from darkhours.satellites import (
+    _group_passes_into_trains,
+    _TRAIN_AZ_TOLERANCE,
+    _TRAIN_GAP_S,
+    _TRAIN_MIN_COUNT,
+)
+
+_T0 = datetime(2026, 8, 26, 3, 0, tzinfo=timezone.utc)
+
+
+def _pass(offset_s: float, az: float, *, peak: float = 40.0,
+          launch: str = "2026-08-19") -> dict:
+    return {
+        "rise_time":   _T0 + timedelta(seconds=offset_s),
+        "rise_az":     az,
+        "peak_alt":    peak,
+        "dur_min":     4.0,
+        "moon_sep":    90.0,
+        "sky_dark":    True,
+        "launch_date": launch,
+    }
+
+
+def _sorted(passes):
+    return sorted(passes, key=lambda p: p["rise_time"])
+
+
+# ---------------------------------------------------------------------------
+# the bug
+# ---------------------------------------------------------------------------
+
+def test_two_interleaved_trains_are_both_reported():
+    """The regression. Two trains crossing the same window on opposite azimuths,
+    their passes interleaved in time. Starlink flies several inclinations, so
+    simultaneous trains genuinely rise on different bearings."""
+    passes = _sorted(
+        [_pass(20 * k, 45.0) for k in range(_TRAIN_MIN_COUNT + 2)] +
+        [_pass(20 * k + 10, 225.0) for k in range(_TRAIN_MIN_COUNT + 2)]
+    )
+
+    trains = _group_passes_into_trains(passes)
+
+    assert len(trains) == 2, "the second train used to be swallowed by the cursor"
+    assert {round(t.lead_az_deg) for t in trains} == {45, 225}
+    assert all(t.satellite_count == _TRAIN_MIN_COUNT + 2 for t in trains)
+
+
+def test_a_group_below_the_minimum_does_not_consume_its_passes():
+    """A sub-threshold group is not a train, so its passes must stay available to
+    join one. They used to be consumed by the same cursor jump."""
+    short = [_pass(20 * k, 10.0) for k in range(_TRAIN_MIN_COUNT - 1)]
+    full  = [_pass(20 * k + 5, 200.0) for k in range(_TRAIN_MIN_COUNT)]
+
+    trains = _group_passes_into_trains(_sorted(short + full))
+
+    assert len(trains) == 1
+    assert trains[0].satellite_count == _TRAIN_MIN_COUNT
+    assert round(trains[0].lead_az_deg) == 200
+
+
+def test_no_satellite_is_counted_in_two_trains():
+    """Passes claimed by a reported train must not seed or join another."""
+    passes = _sorted(
+        [_pass(20 * k, 45.0) for k in range(_TRAIN_MIN_COUNT)] +
+        [_pass(20 * k + 8, 50.0) for k in range(_TRAIN_MIN_COUNT)]
+    )
+
+    trains = _group_passes_into_trains(passes)
+
+    assert sum(t.satellite_count for t in trains) <= len(passes)
+
+
+# ---------------------------------------------------------------------------
+# the existing contract, previously unpinned
+# ---------------------------------------------------------------------------
+
+def test_a_single_clean_train_is_reported():
+    passes = [_pass(20 * k, 120.0) for k in range(_TRAIN_MIN_COUNT + 3)]
+    trains = _group_passes_into_trains(passes)
+    assert len(trains) == 1
+    assert trains[0].satellite_count == _TRAIN_MIN_COUNT + 3
+    assert trains[0].first_rise == passes[0]["rise_time"]
+    assert trains[0].last_rise == passes[-1]["rise_time"]
+
+
+def test_too_few_satellites_is_not_a_train():
+    passes = [_pass(20 * k, 120.0) for k in range(_TRAIN_MIN_COUNT - 1)]
+    assert _group_passes_into_trains(passes) == []
+
+
+def test_a_time_gap_larger_than_the_limit_splits_the_group():
+    early = [_pass(20 * k, 120.0) for k in range(_TRAIN_MIN_COUNT)]
+    late  = [_pass(_TRAIN_GAP_S + 200 + 20 * k, 120.0) for k in range(_TRAIN_MIN_COUNT)]
+    trains = _group_passes_into_trains(_sorted(early + late))
+    assert len(trains) == 2
+
+
+def test_azimuth_outside_tolerance_is_not_a_member():
+    """One satellite rising well off the lead's bearing is a different object,
+    not a straggler."""
+    passes = _sorted(
+        [_pass(20 * k, 100.0) for k in range(_TRAIN_MIN_COUNT)] +
+        [_pass(15, 100.0 + _TRAIN_AZ_TOLERANCE + 15)]
+    )
+    trains = _group_passes_into_trains(passes)
+    assert len(trains) == 1
+    assert trains[0].satellite_count == _TRAIN_MIN_COUNT
+
+
+def test_empty_input_returns_empty():
+    assert _group_passes_into_trains([]) == []
+
+
+def test_train_summary_fields_come_from_the_group():
+    passes = [_pass(20 * k, 77.0, peak=30.0 + k) for k in range(_TRAIN_MIN_COUNT)]
+    train = _group_passes_into_trains(passes)[0]
+    assert train.peak_alt_deg == round(max(p["peak_alt"] for p in passes), 1)
+    assert round(train.lead_az_deg) == 77
+    assert train.launch_date == "2026-08-19"


### PR DESCRIPTION
## Summary

The train-grouping cursor jumped to wherever its forward scan stopped (`i = j`), which swallowed every pass in the scanned window — both the ones skipped for rising on a different azimuth and every member of a group too small to qualify. Two trains crossing the same window rise on different bearings, since Starlink flies 43°, 53°, 70° and 97° inclinations, so the second was silently dropped.

Twelve passes forming two clean trains at opposite azimuths reported one.

The tell was on the same line: `i = j if j > i else i + 1` could never take the `else` branch, because `j` starts at `i + 1` and only increases. Someone anticipated the case; the guard could not fire.

Now only passes actually placed in a reported train are consumed. The cursor otherwise advances one at a time, so every pass gets a chance to lead.

## Why there is a refactor in a bug fix

The loop moves out of `starlink_train_passes` into `_group_passes_into_trains`. Reaching it previously meant propagating real orbits over a real observer, so it had no direct test — which is how this survived. The extraction is what makes the regression testable.

## Test plan

- `python -m pytest -q` — 1046 passed, 10 skipped.
- New `tests/test_starlink_train_grouping.py`, nine tests. Two fail against the old cursor and pass against the new one (verified by restoring the old behaviour and re-running):
  - `test_two_interleaved_trains_are_both_reported`
  - `test_a_group_below_the_minimum_does_not_consume_its_passes`
- The other seven pin behaviour that was never covered at all: single clean train, minimum count, time-gap splitting, azimuth tolerance, no satellite counted twice, empty input, and summary-field derivation. All pass against both old and new code, which is the point — they are the guard rail for this change, not evidence for it.

Masked while the feed carried no recent launches (#237); live once trains appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)