### PR TITLE
Bundle sgp4 into the warmer Lambda

### DIFF
--- a/cdk/warmer_stack.py
+++ b/cdk/warmer_stack.py
@@ -12,6 +12,8 @@ so the public repo carries no identifiers.
 import os
 import pathlib
 import shutil
+import subprocess
+import sys
 
 from aws_cdk import (
     CfnOutput,
@@ -31,12 +33,30 @@ from constructs import Construct
 _REPO = pathlib.Path(__file__).resolve().parents[1]
 
 
+# The only third-party package the warmer path imports. tle_provider renders the
+# filtered Starlink rows from OMM back into TLE line pairs with sgp4.exporter, so
+# the group refresh raises ModuleNotFoundError without it — caught, logged, and
+# reported as a warm failure, which is how this was found rather than by anything
+# silently degrading.
+_WARMER_PIP_DEPS = ("sgp4==2.27",)
+
+# Matches the Function's architecture and runtime below. Wheels are downloaded for
+# the target platform rather than this host's, so no Docker and no cross-compile —
+# which is what keeps this stack deployable from a laptop.
+_WARMER_PLATFORM       = "manylinux2014_x86_64"
+_WARMER_PYTHON_VERSION = "3.13"
+
+
 def _stage_warmer_code() -> str:
-    """Stage just the source the warmer needs into a clean dir (no Docker, no deps).
+    """Stage the source the warmer needs, plus its one dependency, into a clean dir.
 
     boto3 comes from the Lambda runtime; rasterio/skyfield are never imported by the
-    warmer path, so only the source tree is shipped. de421.bsp (16 MB ephemeris) and
+    warmer path, so nothing else is shipped. de421.bsp (16 MB ephemeris) and
     apps/api (FastAPI) are intentionally left out — the warmer imports neither.
+
+    sgp4 is installed with --platform/--only-binary so pip fetches the Linux wheel
+    regardless of the host: a macOS wheel here would import fine locally and fail in
+    Lambda, which is the failure mode worth designing out.
     """
     stage = _REPO / "cdk" / ".warmer_build"
     if stage.exists():
@@ -46,6 +66,13 @@ def _stage_warmer_code() -> str:
     (stage / "apps").mkdir(parents=True)
     shutil.copy(_REPO / "apps" / "__init__.py", stage / "apps" / "__init__.py")
     shutil.copytree(_REPO / "apps" / "warmer", stage / "apps" / "warmer", ignore=_ignore)
+
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--quiet", "--target", str(stage),
+         "--platform", _WARMER_PLATFORM, "--python-version", _WARMER_PYTHON_VERSION,
+         "--only-binary=:all:", *_WARMER_PIP_DEPS],
+        check=True,
+    )
     return str(stage)
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 | `test_aws_location.py` | `location.py` / `darksky.py` | — | AWS Location geocoding + GeoRoutes drive times (mocked boto3), per-leg cache |
 | `test_api.py` | `apps/api/main.py` | — / `eph` | All endpoints, input validation, DoS guards, error paths |
 | `test_jobs.py` | `apps/jobs.py` | — | Inline/SQS job lifecycle, worker handler, 202→done flow |
-| `test_warmer.py` | `apps/warmer` | — | TLE warmer handler: warm-all-ok, failure reporting, stale detection |
+| `test_warmer.py` | `apps/warmer` | — | TLE warmer handler: warm-all-ok, failure reporting, stale detection ; deployment bundle covers every third-party import |
 | `test_aws_smoke.py` | `darksky.py` / `cache.py` | `aws` | Real DynamoDB cache round-trip; real S3 grid lookups (VIIRS + Falchi) |
 | `test_provider_smoke.py` | providers | `live` | Live connectivity: Open-Meteo, 7Timer, Celestrak GP + SATCAT, Nominatim, AWS Location |
 

--- a/tests/test_warmer.py
+++ b/tests/test_warmer.py
@@ -264,3 +264,87 @@ def test_a_permanently_empty_train_list_is_still_visible_as_a_count(monkeypatch,
     starlink = next(e for e in emitted if e.get("Key") == "starlink")
     assert starlink["TleWarmSuccess"] == 1, "a verified write of [] is still a write"
     assert starlink["TleWarmItems"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Deployment bundle — the warmer ships source plus a pinned dependency list
+# ---------------------------------------------------------------------------
+
+def test_every_third_party_import_is_bundled_or_runtime_provided():
+    """The warmer Lambda is not built from requirements.txt.
+
+    cdk/warmer_stack.py stages the source tree and pip-installs exactly
+    _WARMER_PIP_DEPS; boto3/botocore come from the Lambda runtime. Anything else the
+    warmer path imports is simply absent in production, and the first sign is a
+    ModuleNotFoundError at refresh time — which is how a working local change shipped
+    broken once already.
+
+    Run in a subprocess so the shared pytest session's imports do not pollute the
+    answer, and the group filter is exercised rather than merely imported: sgp4 is
+    imported lazily inside the conversion, so importing the handler alone reports
+    nothing at all.
+    """
+    import json
+    import pathlib
+    import subprocess
+    import sys
+
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo / "cdk"))
+    try:
+        from warmer_stack import _WARMER_PIP_DEPS
+    finally:
+        sys.path.pop(0)
+
+    probe = r"""
+import json, pathlib, sys, sysconfig
+from datetime import date, timedelta
+import apps.warmer.handler                      # noqa: F401
+from darkhours import tle_provider as tle
+
+today = date.today()
+cols = ("OBJECT_NAME,OBJECT_ID,EPOCH,MEAN_MOTION,ECCENTRICITY,INCLINATION,"
+        "RA_OF_ASC_NODE,ARG_OF_PERICENTER,MEAN_ANOMALY,EPHEMERIS_TYPE,"
+        "CLASSIFICATION_TYPE,NORAD_CAT_ID,ELEMENT_SET_NO,REV_AT_EPOCH,BSTAR,"
+        "MEAN_MOTION_DOT,MEAN_MOTION_DDOT")
+row = ("STARLINK-1,2026-160A,2026-08-25T12:00:00.000000,15.90000000,.0001000,"
+       "53.0000,100.0000,90.0000,270.0000,0,U,100001,999,100,.0001000,.00000000,0")
+# Exercises the lazy sgp4 import inside _omm_row_to_tle.
+out = tle._filter_train_tles(cols + chr(10) + row, {"2026-160": today})
+assert len(out) == 1, out
+
+site = pathlib.Path(sysconfig.get_paths()["purelib"]).resolve()
+ext = set()
+for name, mod in list(sys.modules.items()):
+    if "." in name or mod is None:
+        continue
+    f = getattr(mod, "__file__", None)
+    if not f:
+        continue
+    try:
+        pth = pathlib.Path(f).resolve()
+    except (OSError, ValueError):
+        continue
+    if site in pth.parents:
+        ext.add(name.lower())
+print(json.dumps(sorted(ext)))
+"""
+    res = subprocess.run([sys.executable, "-c", probe], capture_output=True,
+                         text=True, cwd=str(repo),
+                         env={"PATH": "/usr/bin:/bin", "PYTHONPATH": str(repo)})
+    assert res.returncode == 0, f"probe failed: {res.stderr[-600:]}"
+    imported = set(json.loads(res.stdout))
+
+    bundled = {d.split("==")[0].replace("-", "_").lower() for d in _WARMER_PIP_DEPS}
+    runtime_provided = {"boto3", "botocore", "s3transfer", "jmespath", "dateutil",
+                        "urllib3", "six"}
+
+    unaccounted = imported - bundled - runtime_provided
+    assert not unaccounted, (
+        f"the warmer path imports {sorted(unaccounted)} but cdk/warmer_stack.py "
+        f"bundles only {sorted(bundled)} — these would be missing in Lambda"
+    )
+    assert "sgp4" in imported, (
+        "expected the filter to import sgp4; if the conversion moved, this test is "
+        "no longer exercising the dependency it exists to guard"
+    )

--- a/tests/test_warmer.py
+++ b/tests/test_warmer.py
@@ -289,12 +289,22 @@ def test_every_third_party_import_is_bundled_or_runtime_provided():
     import subprocess
     import sys
 
+    import ast
+
     repo = pathlib.Path(__file__).resolve().parents[1]
-    sys.path.insert(0, str(repo / "cdk"))
-    try:
-        from warmer_stack import _WARMER_PIP_DEPS
-    finally:
-        sys.path.pop(0)
+    # Read the literal out of the source rather than importing warmer_stack: that
+    # module imports aws_cdk, which lives in cdk/requirements.txt and is absent from
+    # the test environment, so importing it here fails CI while passing on any
+    # machine that happens to have the CDK installed.
+    stack_src = (repo / "cdk" / "warmer_stack.py").read_text()
+    deps_node = next(
+        (n.value for n in ast.parse(stack_src).body
+         if isinstance(n, ast.Assign)
+         and any(getattr(tgt, "id", None) == "_WARMER_PIP_DEPS" for tgt in n.targets)),
+        None,
+    )
+    assert deps_node is not None, "_WARMER_PIP_DEPS not found in cdk/warmer_stack.py"
+    _WARMER_PIP_DEPS = ast.literal_eval(deps_node)
 
     probe = r"""
 import json, pathlib, sys, sysconfig


### PR DESCRIPTION
## Summary

#237 made `tle_provider` render filtered Starlink rows from OMM back into TLE line pairs with `sgp4.exporter`. The warmer Lambda is not built from `requirements.txt` — `warmer_stack` stages the source tree and nothing else, on the premise that the warmer path imports no third-party code beyond the boto3 the runtime provides. That stopped being true, so the first group refresh after deploying #237 raised `ModuleNotFoundError: No module named 'sgp4'`.

It failed safely: logged, counted as a warm failure, stale value retained, alarm fired. But #237 was inert in production.

`sgp4` is now installed into the stage with `--platform` / `--only-binary` so pip fetches the manylinux x86_64 wheel matching the Function's architecture rather than the host's. A macOS wheel would import cleanly on a laptop and fail in Lambda, which is the failure mode worth designing out — verified the staged extension is `ELF 64-bit x86-64` while the host's is `Mach-O arm64`. The bundle goes from 0.2 MB to 1.3 MB and still needs no Docker, so the stack stays deployable from a laptop.

## Test plan

- `python -m pytest -q` — 1038 passed, 10 skipped.
- New `test_every_third_party_import_is_bundled_or_runtime_provided` walks what the warmer path actually imports and compares it against `_WARMER_PIP_DEPS` plus the runtime-provided set. Two details that matter:
  - it runs in a **subprocess**, because the shared pytest session has aws_cdk, numpy and h3 loaded and pollutes any `sys.modules` walk;
  - it **exercises the group filter** rather than importing the handler, because `sgp4` is imported lazily inside the conversion — an import-only probe reports zero third-party modules and would have passed while production was broken.
- Removing `sgp4` from `_WARMER_PIP_DEPS` fails it with `the warmer path imports ['sgp4'] but cdk/warmer_stack.py bundles only []` (verified).
- Staged bundle inspected: `sgp4/vallado_cpp.abi3.so` is ELF x86-64, `exporter.py` and `omm.py` present, 1.30 MB total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)