### PR TITLE
Derive Bortle class and LPI zone from the unrounded SQM

### DIFF
--- a/apps/web/src/format.ts
+++ b/apps/web/src/format.ts
@@ -334,7 +334,7 @@ export function moonUpAt(iso: string, moonrise: string | null, moonset: string |
 export function lpString(lp: LightPollution): string | null {
   if (lp.below_detection) return 'Light pollution data unavailable'
   if (lp.sqm == null) return null
-  return `SQM ${lp.sqm}  ·  Zone ${lp.lp_zone}  ·  Bortle ${lp.bortle_class}  (${lp.bortle_desc})  [${lp.source}]`
+  return `SQM ${lp.sqm.toFixed(2)}  ·  Zone ${lp.lp_zone}  ·  Bortle ${lp.bortle_class}  (${lp.bortle_desc})  [${lp.source}]`
 }
 
 /** 1–10 → a band used for color + label. */

--- a/apps/web/src/report/Nearby.tsx
+++ b/apps/web/src/report/Nearby.tsx
@@ -19,7 +19,7 @@ export function NearbyResults(
   { data: NearbyResult; imperial: boolean; originLat: number; originLon: number; onSelectLocation?: (lat: number, lon: number) => void },
 ) {
   const { origin_bortle, origin_sqm, radius_miles, results, light_domes, best_available } = data
-  const sqmStr = origin_sqm != null ? ` (SQM ${origin_sqm.toFixed(1)})` : ''
+  const sqmStr = origin_sqm != null ? ` (SQM ${origin_sqm.toFixed(2)})` : ''
   // Drive-time routing only runs on the AWS backend; on local it's never attempted and
   // every place carries drive_minutes=null for that reason alone. Only treat a null as
   // "routing tried and failed" (e.g. ferry-only crossing) when routing is active at all —
@@ -226,7 +226,7 @@ export function NearbyResults(
                             </div>
                           </td>
                           <td className={`wx-num nearby-bortle-col ${nearbyBortleClass(p.bortle_class)}`}>{p.bortle_class}</td>
-                          <td className="wx-num nearby-sqm-col">{p.sqm != null ? p.sqm.toFixed(1) : '—'}</td>
+                          <td className="wx-num nearby-sqm-col">{p.sqm != null ? p.sqm.toFixed(2) : '—'}</td>
                           <td className="wx-num nearby-dist-col">{distOf(p)}</td>
                           {routingActive && <td className="wx-num nearby-drive-col">{formatDriveTime(p.drive_minutes) ?? '—'}</td>}
                           <td className="wx-num nearby-dir-col">{p.direction} {mapLinkNode(p)}</td>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -7,12 +7,16 @@ export interface SkyEvent {
 }
 
 export interface LightPollution {
+  /** Quantised for display. bortle_class/lp_zone come from the unrounded value, so at
+   *  a threshold this figure can read as the adjacent class — the class is authoritative. */
   sqm: number | null
   bortle_class: number | null
   bortle_desc: string | null
   lp_zone: string | null
   below_detection: boolean
   source: string | null
+  /** Unrounded SQM the classification was derived from. */
+  sqm_raw?: number | null
 }
 
 export interface ScoreComponents {

--- a/darkhours/darksky.py
+++ b/darkhours/darksky.py
@@ -91,6 +91,13 @@ _FALCHI_GRID = _GRID_DIR / "world_atlas_2016"
 _L_NATURAL   = 0.252   # mcd/m²
 _SQM_NATURAL = 22.08   # mag/arcsec²
 
+# Decimal places the payload `sqm` carries. Classification runs on the unrounded value;
+# this is the display quantum only. At 1 dp the rendered figure lands exactly on a _BORTLE
+# threshold (all of which are 1 dp) often enough to read as the neighbouring class; 2 dp
+# reduces that to ~1.2% of CONUS pixels. Below the model's ±0.5–1.0 mag/arcsec² accuracy
+# either way — this governs presentation, not precision.
+_SQM_DISPLAY_DP = 2
+
 # Correction factor applied to Falchi luminance values before computing SQM.
 # The Falchi 2016 atlas is built on DMSP-OLS data (~2014), which reads 2–5×
 # lower than VIIRS for the same sites (Kyba et al. 2017).  At dark-sky sites
@@ -426,8 +433,12 @@ def radiance_to_sqm(radiance_nw: float) -> float:
         SQM ≈ 21.7 − 2.5 × log10(L + 0.6)
     The 0.6 offset represents natural airglow in the VIIRS band.
     Accuracy: ±0.5–1.0 mag/arcsec² (one Bortle class).
+
+    Returns the unrounded regression value. Quantise only at a display boundary
+    (`_SQM_DISPLAY_DP`); `sqm_to_bortle`/`sqm_to_zone` take the full-precision value,
+    since their thresholds are themselves fixed-decimal.
     """
-    return round(21.7 - 2.5 * math.log10(radiance_nw + 0.6), 1)
+    return 21.7 - 2.5 * math.log10(radiance_nw + 0.6)
 
 
 def luminance_to_sqm(la_mcd_m2: float) -> float:
@@ -436,11 +447,14 @@ def luminance_to_sqm(la_mcd_m2: float) -> float:
         SQM = 22.08 − 2.5 × log10((La + 0.252) / 0.252)
     0.252 mcd/m² is the Falchi (2016) natural sky reference.
     At La = 0: SQM = 22.08; at La = 0.252: SQM ≈ 21.3 (Bortle 3).
+
+    Returns the unrounded model value, matching `radiance_to_sqm`. Both branches are
+    now full precision — the La <= 0 branch always was, so the two exits agree.
     """
     if la_mcd_m2 <= 0.0:
         return _SQM_NATURAL
-    return round(_SQM_NATURAL - 2.5 * math.log10(
-        (la_mcd_m2 + _L_NATURAL) / _L_NATURAL), 1)
+    return _SQM_NATURAL - 2.5 * math.log10(
+        (la_mcd_m2 + _L_NATURAL) / _L_NATURAL)
 
 
 def sqm_to_bortle(sqm: float) -> tuple[int, str]:
@@ -479,12 +493,25 @@ def lookup(lat: float, lon: float) -> dict | None:
       2. Falchi 2016 — fallback for dark sites where VIIRS = 0
 
     Return dict keys:
-      sqm            float | None
+      sqm            float | None  — quantised to _SQM_DISPLAY_DP for presentation
       bortle_class   int | None
       bortle_desc    str | None
       lp_zone        str | None  — djlorenz zone ("0", "1a" … "7b")
       below_detection bool  — True only if both sources return 0/None
       source         str   — "VIIRS 2025" or "Falchi 2016"
+      sqm_raw        float — the unrounded SQM the classification was derived from
+
+    `bortle_class` and `lp_zone` are derived from the unrounded SQM, matching the
+    vectorized classifier in `_extract_dark_sky_candidates`. `sqm` carries the display
+    quantum, so at a threshold it can read as the adjacent class; the class is
+    authoritative.
+
+    `sqm_raw` is carried so a cached entry can be reclassified exactly without a raster
+    read. The cache key quantises the coordinate to 0.01°, coarser than either raster
+    pixel (VIIRS 0.00417°, Falchi 0.00833°), so the key cannot identify the pixel an
+    entry was read from; storing the reading itself sidesteps that. The sampled
+    coordinate is deliberately not stored — entries are shared across every caller
+    whose coordinate falls in the same cell.
 
     Returns None if the raster grids are unavailable or both reads fail.
     """
@@ -512,15 +539,16 @@ def lookup(lat: float, lon: float) -> dict | None:
         # VIIRS has a measurable signal — Falchi result already available but not needed.
         sqm = radiance_to_sqm(radiance)
         bortle_cls, bortle_d = sqm_to_bortle(sqm)
-        log.debug("Using VIIRS 2025: radiance=%.3f  SQM=%.1f  Bortle=%d",
+        log.debug("Using VIIRS 2025: radiance=%.3f  SQM=%.3f  Bortle=%d",
                   radiance, sqm, bortle_cls)
         result = {
-            "sqm":            sqm,
+            "sqm":            round(sqm, _SQM_DISPLAY_DP),
             "bortle_class":   bortle_cls,
             "bortle_desc":    bortle_d,
             "lp_zone":        sqm_to_zone(sqm),
             "below_detection": False,
             "source":         "VIIRS 2025",
+            "sqm_raw":        sqm,
         }
         _bortle_mem_cache[_cache_key] = result
         try:
@@ -542,15 +570,16 @@ def lookup(lat: float, lon: float) -> dict | None:
     scaled = luminance * _FALCHI_SCALE
     sqm = luminance_to_sqm(scaled)
     bortle_cls, bortle_d = sqm_to_bortle(sqm)
-    log.debug("Using Falchi 2016: luminance=%.4f  scaled=%.4f  SQM=%.1f  Bortle=%d",
+    log.debug("Using Falchi 2016: luminance=%.4f  scaled=%.4f  SQM=%.3f  Bortle=%d",
               luminance, scaled, sqm, bortle_cls)
     result = {
-        "sqm":            sqm,
+        "sqm":            round(sqm, _SQM_DISPLAY_DP),
         "bortle_class":   bortle_cls,
         "bortle_desc":    bortle_d,
         "lp_zone":        sqm_to_zone(sqm),
         "below_detection": False,
         "source":         "Falchi 2016",
+        "sqm_raw":        sqm,
     }
     _bortle_mem_cache[_cache_key] = result
     try:

--- a/darkhours/format_ctx.py
+++ b/darkhours/format_ctx.py
@@ -107,7 +107,7 @@ def lp_str(info: dict | None) -> str | None:
         return "Light pollution data unavailable"
     if info.get("sqm") is None:
         return None
-    return (f"SQM {info['sqm']}  ·  Zone {info['lp_zone']}"
+    return (f"SQM {info['sqm']:.2f}  ·  Zone {info['lp_zone']}"
             f"  ·  Bortle {info['bortle_class']}"
             f"  ({info['bortle_desc']})  [{info['source']}]")
 

--- a/darkhours/render_report.py
+++ b/darkhours/render_report.py
@@ -321,7 +321,7 @@ def print_targets(report: NightReport, ctx: FormatCtx) -> None:
             if lp and lp.get("bortle_class") is not None:
                 bc      = lp["bortle_class"]
                 sqm     = lp.get("sqm")
-                sqm_str = f", SQM {sqm:.1f}" if sqm is not None else ""
+                sqm_str = f", SQM {sqm:.2f}" if sqm is not None else ""
                 print(f"{label}:  none — site light pollution (Bortle {bc}{sqm_str})"
                       f" exceeds astrophotography contrast limits for all catalog objects.\n")
             else:
@@ -734,7 +734,7 @@ def print_nearby(result: dict | None, ctx: FormatCtx) -> None:
 
     origin = result["origin_bortle"]
     sqm    = result["origin_sqm"]
-    sqm_s  = f"  (SQM {sqm:.1f})" if sqm is not None else ""
+    sqm_s  = f"  (SQM {sqm:.2f})" if sqm is not None else ""
 
     if origin <= 1:
         print(f"  Origin is already Bortle {origin}{sqm_s} — optimal dark sky conditions.\n")
@@ -775,7 +775,7 @@ def print_nearby(result: dict | None, ctx: FormatCtx) -> None:
         (
             r["name"] or f"{r['lat']:.2f}°, {r['lon']:.2f}°",
             str(r["bortle_class"]),
-            f"{r['sqm']:.1f}" if r["sqm"] is not None else "—",
+            f"{r['sqm']:.2f}" if r["sqm"] is not None else "—",
             ctx.fmt_dist(r["distance_miles"]),
             r["direction"],
         )

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,7 +87,7 @@ python darkhours.py --location "Sedona, AZ" --date 2018-08-12 --targets --weathe
 ```
 Date:               2018-08-12
 Location:           Sedona, Coconino County, Arizona, United States  (34.8689°, -111.7614°)
-Light Pollution:    SQM 18.7  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]
+Light Pollution:    SQM 18.70  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]
 Moon:               New Moon  |  4.2% illuminated  |  363,111 km
 Meteor Showers:     Perseids · Peak night · ZHR 100
 Clear Dark Sky Hours:  6h 12m  ( 9:00 PM – 10:00 PM,  11:00 PM –  4:12 AM MST)  ·  avg 3.4h  ±2.7h over lunar cycle
@@ -147,16 +147,23 @@ Prime Targets  ( 7:18 PM –  5:45 AM MST):
   Triangulum Galaxy        4:12 AM @ 84°  130°(SE)                      Dark sky  10:58 PM @ 21° –  4:12 AM @ 84°
   Whirlpool Galaxy         8:51 PM @ 41°  305°(NW)                      Dark sky   8:51 PM @ 41° – 10:58 PM @ 21°
 
-Nearby Skies  (60 mi radius):
+Nearby Skies  (25 mi radius):
 
-  Nearest:  Bortle 1  ·  15 mi ENE  (Coconino, AZ)
+  Nearest:  Bortle 2  ·  3 mi E  (Cow Pies)
+  Darkest:  Bortle 1  ·  22 mi ESE  (Happy Jack Ranger Station)
 
-  Area                                 Bortle   SQM  Distance  Direction
-  -----------------------------------  ------  ----  --------  ---------
-  Coconino, AZ                              1  22.0     15 mi        ENE
-  Red Rock-Secret Mountain Wilderness       1  22.0     15 mi         NW
-  Wet Beaver Wilderness                     1  22.0     20 mi         SE
-  Sycamore Canyon Wilderness                1  22.0     20 mi        WNW
+  Area                          Bortle    SQM  Distance  Direction
+  ----------------------------  ------  -----  --------  ---------
+  Cow Pies                           2  21.74      3 mi          E
+  Sedona Overlook                    2  21.73      3 mi        NNE
+  Schnebley Hill Vista               2  21.80      4 mi        ENE
+  Encinoso Picnic Area               2  21.81      4 mi        NNE
+  Canyon Overlook                    2  21.81      4 mi          N
+  Vultee Arch                        2  21.82      5 mi        NNW
+  Bear Mtn                           2  21.72      6 mi        WNW
+  Fay Canyon Arch                    2  21.71      6 mi        WNW
+  Schnebly Hill Road Dispersed       2  21.88      7 mi        ENE
+  Happy Jack Ranger Station          1  22.00     22 mi        ESE
 ```
 
 ### Satellite passes
@@ -168,7 +175,7 @@ python darkhours.py --location "Sedona, AZ" --satellites
 ```
 Date:               2026-05-30
 Location:           Sedona, Coconino County, Arizona, United States  (34.8689°, -111.7614°)
-Light Pollution:    SQM 18.7  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]
+Light Pollution:    SQM 18.70  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]
 Moon:               Waxing Gibbous  |  99.9% illuminated  |  405,972 km  ·  *** Micromoon ***
 Clear Dark Sky Hours:  None (moon up all night)  ·  avg 2.8h  ±2.1h over lunar cycle
 Night Quality Score:  0.0/10  (Lunar 0.0 · Dark Hours 0.0 · Weather 9.0 · Bortle 3.3)
@@ -206,7 +213,7 @@ python darkhours.py --location "Sedona, AZ" --calendar --date 2026-06
 
 ```
 Calendar — Sedona, Coconino County, Arizona, United States
-Light Pollution:    SQM 18.7  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]  ·  Score 3.3/10
+Light Pollution:    SQM 18.70  ·  Zone 7a  ·  Bortle 7  (Suburban/urban transition)  [VIIRS 2025]  ·  Score 3.3/10
 June 2026
 
   Date        Night Quality Score  Dark Hours  Weather  Moon
@@ -528,7 +535,7 @@ One row per night across a calendar month. The Moon column shows the lunar inter
 
 ```
 Calendar — Grand Canyon Village, Coconino County, Arizona, United States
-Light Pollution:    SQM 21.9  ·  Zone 2a  ·  Bortle 2  (Truly dark sky)  [Falchi 2016]  ·  Score 8.9/10
+Light Pollution:    SQM 21.90  ·  Zone 2a  ·  Bortle 2  (Truly dark sky)  [Falchi 2016]  ·  Score 8.9/10
 March 2026
 
   Date        Night Quality Score  Dark Hours  Weather  Moon

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ markers =
          PYNIGHTSKY_RASTER_BUCKET + credentials are set; run with -m aws)
     live: smoke tests hitting real external provider APIs (Open-Meteo, 7Timer,
          Celestrak, Nominatim, AWS Location; skipped unless PYNIGHTSKY_LIVE=1)
+    raster: known-site classification basket against the on-disk VIIRS/Falchi grids
+         (skipped unless PYNIGHTSKY_RASTER_TESTS=1 and the ~15 GB grids are built
+         under ~/.darkhours/grid)

--- a/scripts/purge_bortle_stale.py
+++ b/scripts/purge_bortle_stale.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Delete bortle| cache entries whose class or zone predates the unrounded classifier.
+
+darksky.lookup() now derives bortle_class and lp_zone from the unrounded SQM. Entries
+written before that carry a class derived from a 1-decimal SQM, and they have no TTL
+(darksky.lookup writes them with ttl_seconds unset), so they never expire on their own.
+
+SELECTIVITY
+    A stored 1-decimal value S was rounded from some raw value in [S-0.05, S+0.05]. It
+    can only disagree with the unrounded classifier if that interval spans a _BORTLE or
+    _LORENZ_ZONES boundary. The candidate set is derived at runtime by evaluating
+    sqm_to_bortle/sqm_to_zone across each interval -- not from a hardcoded list, and not
+    from a threshold-membership test, which over-includes at interval endpoints.
+
+    Everything outside that set is provably unaffected and is left in place, so most of
+    the warm cache survives. Locally that is ~40% of bortle| entries preserved.
+
+    Candidates are deleted outright rather than recomputed and compared. The key
+    quantises to 0.01deg, which is coarser than either raster pixel (VIIRS 0.00417deg,
+    Falchi 0.00833deg), so the key does not identify the pixel the entry was read from
+    -- a recompute-and-compare would disagree with the original reading ~11% of the time
+    and could leave a stale entry in place. Deleting costs one raster read on next
+    access. lookup() now records the unrounded SQM (sqm_raw) in the payload, so future
+    passes can reclassify exactly without touching a raster or a coordinate.
+
+    Entries whose sqm is not a 1-decimal value were never rounded (the La <= 0 branch
+    returns the full-precision natural-sky constant) and are never candidates. Neither
+    are entries carrying sqm_raw, which only the current classifier writes -- so a
+    re-run still reports zero once live traffic has repopulated the cache.
+
+CAPACITY
+    cache_key is the partition key and Query cannot do begins_with on a partition key,
+    so a full scan is required. sqm lives inside a JSON string attribute, so it cannot
+    be filtered server-side either. The scan is paced (bounded page size, inter-page
+    sleep, adaptive retries, eventually-consistent reads) and reports consumed capacity.
+    Check `aws dynamodb describe-table` for BillingMode and size before a first run, and
+    run off-peak.
+
+The table name comes from PYNIGHTSKY_CACHE_TABLE (never hardcoded -- public repo).
+Dry-run is the default; pass --delete to actually remove items.
+
+Usage:
+  export PYNIGHTSKY_CACHE_TABLE=<table>   # discover per docs/ or cdk.out
+  python scripts/purge_bortle_stale.py                 # count + consumed RCU, no writes
+  python scripts/purge_bortle_stale.py --delete        # actually delete
+  python scripts/purge_bortle_stale.py --local         # ~/.darkhours/cache instead
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from darkhours.darksky import sqm_to_bortle, sqm_to_zone  # noqa: E402
+
+PREFIX = "bortle|"
+
+# Scan pacing. Deliberately conservative: this competes with production reads.
+PAGE_SIZE = 200
+PAGE_SLEEP_S = 0.10
+DELETE_SLEEP_EVERY = 25      # one batch_writer flush
+DELETE_SLEEP_S = 0.10
+
+
+def risky_values(lo: float = 10.0, hi: float = 22.4, step_points: int = 201) -> set[float]:
+    """1-decimal SQM values whose rounding interval spans a classification boundary.
+
+    Derived from the live threshold tables via the classifier functions themselves, so
+    it stays correct if either table is edited.
+    """
+    out = set()
+    for i in range(int(round(lo * 10)), int(round(hi * 10)) + 1):
+        s = round(i / 10.0, 1)
+        base_b, base_z = sqm_to_bortle(s)[0], sqm_to_zone(s)
+        for j in range(step_points):
+            x = (s - 0.05) + j * (0.10 / (step_points - 1))
+            if sqm_to_bortle(x)[0] != base_b or sqm_to_zone(x) != base_z:
+                out.add(s)
+                break
+    return out
+
+
+def is_candidate(value, risky: set[float]) -> bool:
+    """True if this cached payload could carry a class from the rounded classifier."""
+    if not isinstance(value, dict):
+        return False
+    # Entries written by the current classifier carry the unrounded SQM they were
+    # derived from. Their class is correct by construction, so the scan stays
+    # convergent as traffic repopulates the cache.
+    if "sqm_raw" in value:
+        return False
+    sqm = value.get("sqm")
+    if sqm is None:
+        return False
+    try:
+        sqm = float(sqm)
+    except (TypeError, ValueError):
+        return False
+    # Values that are not 1-decimal were never rounded onto a threshold.
+    if abs(sqm - round(sqm, 1)) > 1e-9:
+        return False
+    return round(sqm, 1) in risky
+
+
+# ── DynamoDB ────────────────────────────────────────────────────────────────
+
+def scan_candidates(table, risky: set[float]) -> tuple[list[str], int, float]:
+    """Return (candidate keys, total bortle| items seen, consumed RCU)."""
+    from boto3.dynamodb.conditions import Attr
+
+    paginator = table.meta.client.get_paginator("scan")
+    keys: list[str] = []
+    seen = 0
+    rcu = 0.0
+    # begins_with is applied server-side. It does not reduce RCU (the scan still reads
+    # every item) but it keeps non-bortle payloads off the wire and out of json.loads.
+    pages = paginator.paginate(
+        TableName=table.name,
+        FilterExpression=Attr("cache_key").begins_with(PREFIX),
+        ProjectionExpression="cache_key, #v",
+        ExpressionAttributeNames={"#v": "value"},
+        ReturnConsumedCapacity="TOTAL",
+        PaginationConfig={"PageSize": PAGE_SIZE},
+    )
+    for page in pages:
+        cap = page.get("ConsumedCapacity") or {}
+        rcu += float(cap.get("CapacityUnits", 0.0))
+        for item in page.get("Items", []):
+            key = item.get("cache_key", "")
+            if not key.startswith(PREFIX):
+                continue
+            seen += 1
+            try:
+                payload = json.loads(item.get("value", "null"))
+            except (TypeError, ValueError):
+                continue
+            if is_candidate(payload, risky):
+                keys.append(key)
+        time.sleep(PAGE_SLEEP_S)
+    return keys, seen, rcu
+
+
+def delete_keys(table, keys: list[str]) -> None:
+    """Batch-delete the given cache keys, paced so writes don't spike the table."""
+    with table.batch_writer() as batch:
+        for n, key in enumerate(keys, 1):
+            batch.delete_item(Key={"cache_key": key})
+            if n % DELETE_SLEEP_EVERY == 0:
+                time.sleep(DELETE_SLEEP_S)
+
+
+def run_dynamo(args, risky: set[float]) -> int:
+    import boto3
+    from botocore.config import Config
+    from botocore.exceptions import ClientError
+
+    table_name = os.environ.get("PYNIGHTSKY_CACHE_TABLE")
+    if not table_name:
+        print("PYNIGHTSKY_CACHE_TABLE is not set.", file=sys.stderr)
+        return 1
+
+    # Adaptive retries carry a client-side rate limiter that backs off on throttling.
+    cfg = Config(retries={"mode": "adaptive", "max_attempts": 10})
+    table = boto3.resource("dynamodb", config=cfg).Table(table_name)
+
+    try:
+        keys, seen, rcu = scan_candidates(table, risky)
+    except ClientError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if not seen:
+        print("No bortle| items found -- nothing to do.")
+        return 0
+
+    pct = 100.0 * len(keys) / seen
+    print(f"bortle| items scanned : {seen}")
+    print(f"candidates            : {len(keys)}  ({pct:.1f}%)")
+    print(f"preserved             : {seen - len(keys)}  ({100 - pct:.1f}%)")
+    print(f"consumed read units   : {rcu:.1f}")
+
+    if args.verbose:
+        for key in keys:
+            print(f"  {key}")
+
+    if args.delete:
+        try:
+            delete_keys(table, keys)
+        except ClientError as e:
+            print(f"Error during delete: {e}", file=sys.stderr)
+            return 1
+        print(f"Deleted {len(keys)} bortle| items.")
+    else:
+        print(f"Dry run: {len(keys)} items would be deleted (re-run with --delete).")
+    return 0
+
+
+# ── Local file cache ────────────────────────────────────────────────────────
+
+def run_local(args, risky: set[float]) -> int:
+    from darkhours.cache import _CACHE_DIR
+
+    cache_dir = Path(_CACHE_DIR)
+    if not cache_dir.exists():
+        print(f"No local cache at {cache_dir} -- nothing to do.")
+        return 0
+
+    # Filenames are sha256 hashes; the original key lives in the JSON body.
+    candidates: list[Path] = []
+    seen = 0
+    for path in cache_dir.glob("*.json"):
+        try:
+            entry = json.loads(path.read_text())
+        except Exception:
+            continue
+        if not str(entry.get("key", "")).startswith(PREFIX):
+            continue
+        seen += 1
+        if is_candidate(entry.get("value"), risky):
+            candidates.append(path)
+
+    if not seen:
+        print("No bortle| entries in the local cache -- nothing to do.")
+        return 0
+
+    pct = 100.0 * len(candidates) / seen
+    print(f"bortle| entries       : {seen}")
+    print(f"candidates            : {len(candidates)}  ({pct:.1f}%)")
+    print(f"preserved             : {seen - len(candidates)}  ({100 - pct:.1f}%)")
+
+    if args.delete:
+        for path in candidates:
+            path.unlink(missing_ok=True)
+        print(f"Deleted {len(candidates)} local bortle| entries.")
+    else:
+        print(f"Dry run: {len(candidates)} entries would be deleted (re-run with --delete).")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--delete", action="store_true",
+                        help="actually delete the items (default: dry run)")
+    parser.add_argument("--local", action="store_true",
+                        help="operate on ~/.darkhours/cache instead of DynamoDB")
+    parser.add_argument("--verbose", action="store_true",
+                        help="list every candidate key")
+    args = parser.parse_args()
+
+    risky = risky_values()
+    print(f"candidate SQM values ({len(risky)}): "
+          f"{' '.join(f'{v:.1f}' for v in sorted(risky))}\n")
+
+    return run_local(args, risky) if args.local else run_dynamo(args, risky)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Test Suite
 
-877 tests across 39 files (as of 2026-07-23). A default run is offline and
+1212 tests across 50 files (as of 2026-08-26). A default run is offline and
 deterministic — everything external is opt-in via markers.
 
 ## How to run
@@ -14,6 +14,9 @@ python3 -m pytest -q -m "not eph"
 
 # Coverage report
 python3 -m pytest --cov=darkhours --cov-report=term-missing -q
+
+# Known-site classification basket (opt-in, requires the local raster grids)
+PYNIGHTSKY_RASTER_TESTS=1 python3 -m pytest -q -m raster
 
 # Real AWS integration tests (opt-in, requires credentials + resource env vars)
 PYNIGHTSKY_BACKEND=aws python3 -m pytest -q -m aws
@@ -30,6 +33,7 @@ PYNIGHTSKY_LIVE=1 python3 -m pytest -q -m live
 | `eph` | Locally by default | `de421.bsp` ephemeris file in the package directory |
 | `aws` | Only when explicitly opted in | `PYNIGHTSKY_BACKEND=aws` + live DynamoDB/S3 + credentials + cache/raster env vars |
 | `live` | Only with `PYNIGHTSKY_LIVE=1` | Network access to the real providers (Open-Meteo, 7Timer, Celestrak, Nominatim, AWS Location) |
+| `raster` | Only with `PYNIGHTSKY_RASTER_TESTS=1` | The ~15 GB VIIRS + Falchi grids built under `~/.darkhours/grid` |
 
 Unmarked tests are hermetic: no network, no ephemeris, no rasters.
 

--- a/tests/test_darksky_classification.py
+++ b/tests/test_darksky_classification.py
@@ -1,0 +1,210 @@
+"""
+Classification pipeline tests: raster value → SQM → Bortle class / LPI zone.
+
+`tests/test_darksky_formulas.py` covers each conversion in isolation. This file covers
+the *composition*, which is where the scalar path (`darksky.lookup`) and the vectorized
+path (`_extract_dark_sky_candidates`) have to agree: both classify the same pixel, so
+both must quantise the SQM the same way before thresholding it.
+
+Offline — the raster source is a MagicMock seamed on `sample`, following the fixture
+shape in `tests/test_darksky_routing_flag.py`.
+"""
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from darkhours import darksky as ds
+
+
+# Bortle thresholds, brightest-first, excluding the 0.0 catch-all sentinel.
+_THRESHOLDS = [t for t, _, _ in ds._BORTLE if t > 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Inverse conversions — build a raster value that lands on a chosen SQM
+# ---------------------------------------------------------------------------
+
+def _radiance_for_sqm(sqm: float) -> float:
+    """VIIRS radiance (nW/cm²/sr) whose regression value is exactly *sqm*."""
+    return 10.0 ** ((21.7 - sqm) / 2.5) - 0.6
+
+
+def _luminance_for_sqm(sqm: float) -> float:
+    """Falchi luminance (mcd/m², pre-_FALCHI_SCALE) whose model value is exactly *sqm*."""
+    scaled = ds._L_NATURAL * (10.0 ** ((ds._SQM_NATURAL - sqm) / 2.5) - 1.0)
+    return scaled / ds._FALCHI_SCALE
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def raster(monkeypatch):
+    """Inject (viirs, falchi) point samples and run lookup() with both caches bypassed."""
+    values = {"viirs": 0.0, "falchi": 0.0}
+
+    fake_src = MagicMock()
+    fake_src.sample.side_effect = lambda dataset, lat, lon: values[dataset]
+    fake_backend = MagicMock(raster_source=fake_src)
+    monkeypatch.setattr(ds.ports, "get_backend", lambda: fake_backend)
+    monkeypatch.setattr(ds.cache, "get", lambda k: None)
+    monkeypatch.setattr(ds.cache, "set", lambda k, v, ttl_seconds=None: True)
+
+    def _lookup(viirs=0.0, falchi=0.0, lat=40.0, lon=-100.0):
+        values["viirs"], values["falchi"] = viirs, falchi
+        ds._bortle_mem_cache.clear()
+        return ds.lookup(lat, lon)
+
+    ds._bortle_mem_cache.clear()
+    yield _lookup
+    ds._bortle_mem_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Array-path reference — mirrors _extract_dark_sky_candidates
+# ---------------------------------------------------------------------------
+
+def _array_path_class(viirs: float, falchi: float) -> int:
+    """Bortle class the vectorized path assigns to this pixel."""
+    v = np.array([[viirs]], dtype=np.float64)
+    f = np.array([[falchi]], dtype=np.float64)
+    sqm_viirs = np.where(v > 0, 21.7 - 2.5 * np.log10(v + 0.6), np.nan)
+    bortle = ds._sqm_to_bortle_array(sqm_viirs)
+
+    scaled = f * ds._FALCHI_SCALE
+    sqm_falchi = np.where(
+        scaled > 0,
+        ds._SQM_NATURAL - 2.5 * np.log10((scaled + ds._L_NATURAL) / ds._L_NATURAL),
+        np.nan,
+    )
+    falchi_bortle = ds._sqm_to_bortle_array(sqm_falchi)
+    viirs_zero = v == 0
+    falchi_bortle = np.where(np.isnan(sqm_falchi) & viirs_zero, 1, falchi_bortle)
+    bortle = np.where(viirs_zero & (bortle == 0), falchi_bortle, bortle)
+    return int(bortle[0, 0])
+
+
+# ---------------------------------------------------------------------------
+# The guard: both paths must classify the same pixel identically
+# ---------------------------------------------------------------------------
+
+class TestPipelineParity:
+    """Rounding the SQM before thresholding it makes these two disagree."""
+
+    @pytest.mark.parametrize("threshold", _THRESHOLDS)
+    @pytest.mark.parametrize("offset", [-0.049, -0.03, -0.01, -0.001, 0.0, 0.001, 0.03])
+    def test_viirs_band_around_every_threshold(self, raster, threshold, offset):
+        """Every [T-0.05, T) band, the exact boundary, and just above it."""
+        target = threshold + offset
+        radiance = _radiance_for_sqm(target)
+        if radiance <= 0:          # above the VIIRS airglow ceiling — Falchi's job
+            pytest.skip("SQM unreachable on the VIIRS branch")
+        result = raster(viirs=radiance)
+        assert result["bortle_class"] == _array_path_class(radiance, 0.0)
+
+    @pytest.mark.parametrize("threshold", _THRESHOLDS)
+    @pytest.mark.parametrize("offset", [-0.049, -0.03, -0.01, -0.001, 0.0, 0.001, 0.03])
+    def test_falchi_band_around_every_threshold(self, raster, threshold, offset):
+        target = threshold + offset
+        luminance = _luminance_for_sqm(target)
+        if luminance <= 0:
+            pytest.skip("SQM unreachable on the Falchi branch")
+        result = raster(viirs=0.0, falchi=luminance)
+        assert result["bortle_class"] == _array_path_class(0.0, luminance)
+
+    def test_no_input_reads_darker_than_the_unrounded_value(self, raster):
+        """Quantisation must never promote a pixel toward a darker class."""
+        for target in np.arange(16.0, 22.2, 0.01):
+            radiance = _radiance_for_sqm(float(target))
+            if radiance <= 0:
+                continue
+            result = raster(viirs=radiance)
+            expected, _ = ds.sqm_to_bortle(ds.radiance_to_sqm(radiance))
+            assert result["bortle_class"] >= expected, (
+                f"SQM {target:.3f} classified darker than the unrounded value"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Payload contract
+# ---------------------------------------------------------------------------
+
+class TestPayload:
+    def test_sqm_carries_the_display_quantum(self, raster):
+        for target in (21.9533, 20.4471, 18.0129):
+            radiance = _radiance_for_sqm(target)
+            result = raster(viirs=radiance)
+            assert abs(result["sqm"] - target) <= 0.005
+            assert result["sqm"] == round(result["sqm"], ds._SQM_DISPLAY_DP)
+
+    def test_carries_the_unrounded_sqm_for_exact_reclassification(self, raster):
+        """A cached entry must be reclassifiable without a raster read: the key
+        quantises the coordinate to 0.01°, coarser than either raster pixel, so it
+        cannot identify the pixel the entry came from."""
+        result = raster(viirs=1.0)
+        assert result["sqm_raw"] == ds.radiance_to_sqm(1.0)
+        assert ds.sqm_to_bortle(result["sqm_raw"])[0] == result["bortle_class"]
+        assert ds.sqm_to_zone(result["sqm_raw"]) == result["lp_zone"]
+
+    def test_does_not_record_the_caller_coordinate(self, raster):
+        """Entries are shared by every caller in the same 0.01° cell, so a stored
+        coordinate would be echoed back to the next one."""
+        result = raster(viirs=1.0, lat=41.6626, lon=-77.8261)
+        assert "lat" not in result and "lon" not in result
+
+    def test_class_and_zone_agree_with_the_unrounded_sqm(self, raster):
+        for target in np.arange(17.0, 22.2, 0.017):
+            luminance = _luminance_for_sqm(float(target))
+            if luminance <= 0:
+                continue
+            result = raster(viirs=0.0, falchi=luminance)
+            raw = ds.luminance_to_sqm(luminance * ds._FALCHI_SCALE)
+            assert result["bortle_class"] == ds.sqm_to_bortle(raw)[0]
+            assert result["lp_zone"] == ds.sqm_to_zone(raw)
+
+
+# ---------------------------------------------------------------------------
+# Pinned reference reading
+# ---------------------------------------------------------------------------
+
+class TestCherrySpringsReference:
+    """Falchi 2016 at Cherry Springs SP (41.6626, -77.8261): 0.0104002 mcd/m².
+
+    x _FALCHI_SCALE = 0.0312007 -> SQM 21.9533. Sits 0.047 below the Bortle 1
+    threshold (22.0) and 0.023 above the zone 1a/1b boundary (21.93), so it exercises
+    both threshold tables at once.
+    """
+
+    FALCHI = 0.010400230996310711
+
+    def test_class(self, raster):
+        assert raster(viirs=0.0, falchi=self.FALCHI)["bortle_class"] == 2
+
+    def test_zone(self, raster):
+        assert raster(viirs=0.0, falchi=self.FALCHI)["lp_zone"] == "1b"
+
+    def test_sqm(self, raster):
+        assert raster(viirs=0.0, falchi=self.FALCHI)["sqm"] == pytest.approx(21.95, abs=0.005)
+
+    def test_matches_the_array_path(self, raster):
+        result = raster(viirs=0.0, falchi=self.FALCHI)
+        assert result["bortle_class"] == _array_path_class(0.0, self.FALCHI)
+
+
+# ---------------------------------------------------------------------------
+# Source selection is unchanged by this work — pinned so it stays that way
+# ---------------------------------------------------------------------------
+
+class TestSourceSelection:
+    def test_measurable_viirs_wins(self, raster):
+        assert raster(viirs=5.0, falchi=1.0)["source"] == "VIIRS 2025"
+
+    def test_viirs_zero_falls_back_to_falchi(self, raster):
+        assert raster(viirs=0.0, falchi=1.0)["source"] == "Falchi 2016"
+
+    def test_falchi_zero_is_natural_sky(self, raster):
+        result = raster(viirs=0.0, falchi=0.0)
+        assert result["sqm"] == pytest.approx(ds._SQM_NATURAL, abs=0.005)
+        assert result["bortle_class"] == 1

--- a/tests/test_darksky_formulas.py
+++ b/tests/test_darksky_formulas.py
@@ -33,9 +33,12 @@ class TestRadianceToSqm:
         expected = round(21.7 - 2.5 * math.log10(L + 0.6), 1)
         assert radiance_to_sqm(L) == pytest.approx(expected, abs=0.05)
 
-    def test_result_rounded_to_one_decimal(self):
+    def test_returns_the_unrounded_regression_value(self):
+        """The Bortle thresholds are themselves fixed-decimal, so the conversion must
+        not pre-quantise onto them. Display rounding belongs in lookup()."""
         sqm = radiance_to_sqm(2.5)
-        assert sqm == round(sqm, 1)
+        assert sqm == pytest.approx(21.7 - 2.5 * math.log10(2.5 + 0.6), abs=1e-12)
+        assert sqm != round(sqm, 1)
 
     def test_monotone_decreasing(self):
         """Higher radiance (more light) → lower SQM (brighter sky)."""
@@ -73,9 +76,17 @@ class TestLuminanceToSqm:
         sqm = luminance_to_sqm(-1.0)
         assert sqm == pytest.approx(22.08, abs=0.05)
 
-    def test_result_rounded_to_one_decimal(self):
+    def test_returns_the_unrounded_model_value(self):
         sqm = luminance_to_sqm(0.5)
-        assert sqm == round(sqm, 1)
+        expected = 22.08 - 2.5 * math.log10((0.5 + 0.252) / 0.252)
+        assert sqm == pytest.approx(expected, abs=1e-12)
+        assert sqm != round(sqm, 1)
+
+    def test_both_branches_carry_the_same_precision(self):
+        """The La <= 0 branch always returned the full-precision constant; the model
+        branch now matches it, so the two exits agree."""
+        assert luminance_to_sqm(0.0) == 22.08
+        assert luminance_to_sqm(0.0) == pytest.approx(22.08, abs=1e-12)
 
 
 # ---------------------------------------------------------------------------
@@ -152,3 +163,49 @@ class TestSqmToZone:
 
     def test_returns_string(self):
         assert isinstance(sqm_to_zone(20.0), str)
+
+
+# ---------------------------------------------------------------------------
+# Classifier parity — scalar sqm_to_bortle vs the vectorized _sqm_to_bortle_array
+# ---------------------------------------------------------------------------
+
+class TestClassifierParity:
+    """A standing invariant, not a regression guard.
+
+    These two helpers have always agreed on identical input; what differed was the
+    SQM each was handed (see tests/test_darksky_classification.py, which covers the
+    composition). Pinned so a future edit to either table or either lookup keeps them
+    in step.
+    """
+
+    def test_agree_across_the_stored_value_range(self):
+        """Domain starts well below 17.0: radiance_to_sqm is unbounded below and real
+        readings reach ~14."""
+        import numpy as np
+
+        from darkhours.darksky import _sqm_to_bortle_array
+
+        xs = np.arange(13.0, 22.4, 0.001)
+        scalar = np.array([sqm_to_bortle(float(x))[0] for x in xs], dtype=np.int8)
+        assert np.array_equal(scalar, _sqm_to_bortle_array(xs))
+
+    def test_agree_on_exact_threshold_values(self):
+        """`>=` against `searchsorted(side="right")` — equality is the only place the
+        two implementations could diverge, and arange never lands on a threshold."""
+        import numpy as np
+
+        from darkhours.darksky import _BORTLE, _sqm_to_bortle_array
+
+        xs = np.array([t for t, _, _ in _BORTLE], dtype=np.float64)
+        scalar = np.array([sqm_to_bortle(float(x))[0] for x in xs], dtype=np.int8)
+        assert np.array_equal(scalar, _sqm_to_bortle_array(xs))
+
+    def test_nan_is_the_one_documented_asymmetry(self):
+        """The array path reserves 0 for ocean/nodata; the scalar path has no such
+        sentinel and falls through to 9. Callers must not feed it NaN."""
+        import numpy as np
+
+        from darkhours.darksky import _sqm_to_bortle_array
+
+        assert sqm_to_bortle(float("nan"))[0] == 9
+        assert int(_sqm_to_bortle_array(np.array([np.nan]))[0]) == 0

--- a/tests/test_darksky_known_sites.py
+++ b/tests/test_darksky_known_sites.py
@@ -1,0 +1,151 @@
+"""
+Known-site classification basket, run against the real rasters.
+
+Marked `raster`: needs the on-disk VIIRS + Falchi grids (~15 GB), so it is opt-in and
+never runs in CI. Gated on an explicit env var rather than on the grids merely being
+present, so a default run stays machine-independent. Run with:
+
+    PYNIGHTSKY_RASTER_TESTS=1 python -m pytest -q -m raster
+
+WHAT THIS LAYER DOES AND DOES NOT COVER
+---------------------------------------
+Tolerance is ±1 class, matching the accuracy `radiance_to_sqm` documents (±0.5–1.0
+mag/arcsec², one Bortle class). At that tolerance this file cannot detect a
+single-class threshold error — a consensus-2 site reading Bortle 1 passes. Threshold
+and quantisation behaviour is covered exactly, offline, in
+`tests/test_darksky_classification.py`. What this file catches is directional drift
+in the raster pipeline: a change of source data, scale factor, or sampling that moves
+the whole basket.
+
+BASKET SELECTION
+----------------
+Sites carry a DarkSky International certification or a widely published
+classification; nothing is included on an unsourced estimate. Coordinates are pinned
+because at a threshold the class swings a full step on pixel choice — Big Cypress
+reads Bortle 2 at its visitor center and 3 at Oasis, 12 miles away.
+
+Twelve of the 25 sites sit above Bortle 1, so a bias toward darker classifications has
+somewhere to show up. A basket of only pristine parks would not: Bortle 1 is the floor
+of the scale, and a darker-biased error is invisible against a floor.
+
+Town coordinates read the immediate light source rather than a metro average — that is
+what a point sample of VIIRS radiance is, and the consensus values below are chosen for
+the pinned coordinate, not the wider place.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from darkhours import darksky as ds
+
+pytestmark = pytest.mark.raster
+
+
+# (name, lat, lon, consensus Bortle class, basis)
+BASKET = [
+    # ── Certified dark-sky sites ────────────────────────────────────────────
+    ("Big Bend NP, TX",          29.2705, -103.3018, 1, "DarkSky Park, Gold Tier"),
+    ("Cosmic Campground, NM",    33.4794, -108.9214, 1, "DarkSky Sanctuary"),
+    ("Great Basin NP, NV",       38.9833, -114.3000, 1, "DarkSky Park"),
+    ("Death Valley NP, CA",      37.0100, -117.4500, 1, "DarkSky Park, Gold Tier"),
+    ("Natural Bridges NM, UT",   37.6083, -110.0137, 2, "first DarkSky Park (2007)"),
+    ("Great Sand Dunes NP, CO",  37.7325, -105.5120, 2, "DarkSky Park"),
+    ("Bryce Canyon NP, UT",      37.5930, -112.1871, 2, "DarkSky Park"),
+    ("Chaco Culture NHP, NM",    36.0606, -107.9559, 2, "DarkSky Park"),
+    ("Cherry Springs SP, PA",    41.6626,  -77.8261, 2, "DarkSky Park, Gold Tier"),
+    ("Zion NP, UT",              37.2982, -113.0263, 2, "DarkSky Park"),
+    ("Mont-Megantic, QC",        45.4550,  -71.1520, 2, "first DarkSky Reserve (2007)"),
+    ("Joshua Tree NP, CA",       33.7400, -115.8150, 3, "DarkSky Park"),
+    ("Headlands, MI",            45.7808,  -84.7736, 3, "DarkSky Park"),
+    ("Acadia NP, ME",            44.3290,  -68.1830, 3, "published classification"),
+    ("Cape Cod Ntl Seashore, MA", 41.9200, -69.9800, 3, "published classification"),
+    ("Shenandoah NP, VA",        38.5220,  -78.4370, 4, "DarkSky Park"),
+    ("Sterling Forest SP, NY",   41.1900,  -74.2500, 3, "darksky._dark_threshold docstring"),
+    ("Torrey, UT",               38.2990, -111.4190, 4, "Capitol Reef DarkSky gateway town"),
+
+    # ── Populated places: headroom at the bright end ────────────────────────
+    ("Flagstaff, AZ",            35.1983, -111.6513, 6, "first DarkSky City (2001)"),
+    ("Sedona, AZ",               34.8697, -111.7610, 7, "DarkSky Community"),
+    ("Boulder, CO",              40.0150, -105.2705, 8, "published classification"),
+    ("Tucson, AZ",               32.2226, -110.9747, 8, "published classification"),
+    ("Phoenix, AZ",              33.4484, -112.0740, 9, "metro core"),
+    ("Denver, CO",               39.7392, -104.9903, 9, "metro core"),
+    ("Times Square, NY",         40.7580,  -73.9855, 9, "metro core"),
+]
+
+TOLERANCE = 1
+
+
+def _grids_available() -> bool:
+    for stem in (ds._VIIRS_GRID, ds._FALCHI_GRID):
+        if not (Path(f"{stem}.bin").exists() and Path(f"{stem}.json").exists()):
+            return False
+    return True
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_local_grids():
+    if os.environ.get("PYNIGHTSKY_RASTER_TESTS") != "1":
+        pytest.skip("set PYNIGHTSKY_RASTER_TESTS=1 to run the known-site basket")
+    if os.environ.get("PYNIGHTSKY_BACKEND", "local") != "local":
+        pytest.skip("known-site basket runs against the local grids")
+    if not _grids_available():
+        pytest.skip(f"raster grids not built under {ds._GRID_DIR}")
+
+
+@pytest.fixture(scope="module")
+def classified(require_local_grids):
+    """Classify the whole basket once, bypassing both cache layers."""
+    real_get, real_set = ds.cache.get, ds.cache.set
+    ds.cache.get = lambda k: None
+    ds.cache.set = lambda k, v, ttl_seconds=None: True
+    try:
+        out = {}
+        for name, lat, lon, consensus, basis in BASKET:
+            ds._bortle_mem_cache.clear()
+            result = ds.lookup(lat, lon)
+            assert result is not None, f"{name}: raster read failed"
+            out[name] = (result, consensus, basis)
+        return out
+    finally:
+        ds.cache.get, ds.cache.set = real_get, real_set
+        ds._bortle_mem_cache.clear()
+
+
+@pytest.mark.parametrize("name,lat,lon,consensus,basis", BASKET)
+def test_site_within_tolerance(classified, name, lat, lon, consensus, basis):
+    result, _, _ = classified[name]
+    got = result["bortle_class"]
+    assert abs(got - consensus) <= TOLERANCE, (
+        f"{name} ({basis}): consensus Bortle {consensus}, model {got} "
+        f"(SQM {result['sqm']}, {result['source']})"
+    )
+
+
+def test_cherry_springs_matches_consensus_exactly(classified):
+    """The reported case. Consensus is Bortle 2 and the tolerance above would accept
+    1, so this pins it exactly."""
+    result, consensus, _ = classified["Cherry Springs SP, PA"]
+    assert result["bortle_class"] == consensus == 2
+    assert result["lp_zone"] == "1b"
+
+
+def test_basket_spans_the_scale(classified):
+    """A basket clustered at the Bortle 1 floor cannot show a darker-biased shift."""
+    classes = {r["bortle_class"] for r, _, _ in classified.values()}
+    assert min(classes) == 1
+    assert max(classes) >= 8
+    above_floor = sum(1 for r, _, _ in classified.values() if r["bortle_class"] > 1)
+    assert above_floor >= 12, "too few sites with headroom toward darker"
+
+
+def test_no_site_is_off_by_more_than_one_in_either_direction(classified):
+    """Reported as one list so a systematic shift reads as a pattern, not 25 failures."""
+    offenders = [
+        f"{name}: consensus {consensus}, model {r['bortle_class']} "
+        f"(SQM {r['sqm']}, {r['source']})"
+        for name, (r, consensus, _) in classified.items()
+        if abs(r["bortle_class"] - consensus) > TOLERANCE
+    ]
+    assert not offenders, "sites outside ±1 class:\n  " + "\n  ".join(offenders)


### PR DESCRIPTION
## Summary
- `lookup()` classifies from the unrounded SQM; payload `sqm` quantised to 2 dp for display, with `sqm_raw` for exact reclassification
- Display consumers updated to 2 dp (CLI report, context line, web report)
- `scripts/purge_bortle_stale.py` removes cache entries carrying a class from the previous quantisation; selective by derived SQM value, dry-run default
- New offline classification-pipeline tests and an opt-in known-site basket behind a `raster` marker

Measured across 4000 CONUS coordinates: scalar-vs-vectorized class agreement 89.85% -> 100%.

## Test plan
- `python -m pytest -q` — 1175 passed, 38 skipped
- `PYNIGHTSKY_RASTER_TESTS=1 python -m pytest -q -m raster` — 28 passed
- `cd apps/web && npm run build`
- `scripts/purge_bortle_stale.py --local` — dry run, `--delete`, re-run reports 0

## Post-merge
Run `scripts/purge_bortle_stale.py` after the deploy completes. Production dry run: 3040 of 9222 `bortle|` items are candidates, 67% of the cache preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)