### PR TITLE
Set an explicit CloudFront origin read timeout

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -399,7 +399,13 @@ class LambdaApiStack(Stack):
         furl = fn.add_function_url(auth_type=lambda_.FunctionUrlAuthType.AWS_IAM)
 
         # --- CloudFront in front, with OAC SigV4-signing the IAM-auth Function URL ---
-        origin = origins.FunctionUrlOrigin.with_origin_access_control(furl)
+        # read_timeout: CloudFront's custom-origin default is 30s. An Init that overruns the
+        # 10s cap makes Lambda re-run init against the function timeout, so a cold start can
+        # cost ~10s aborted init + re-init + handler and cross 30s as a 504. 60s is the
+        # ceiling without a service-quota increase; the function itself times out at 120s.
+        origin = origins.FunctionUrlOrigin.with_origin_access_control(
+            furl, read_timeout=Duration.seconds(60),
+        )
 
         api_cache = cloudfront.CachePolicy(
             self, "ApiCachePolicy",


### PR DESCRIPTION
## Summary

The Function URL origin was built without `read_timeout`, so CloudFront applied its 30s custom-origin default. Confirmed on the deployed distribution (`OriginReadTimeout=30`).

Lambda retries the Init phase against the function timeout when Init overruns its 10s cap, so a cold start can cost an aborted init + a full re-init + the handler. Measured API handler p99 is 6.4s and max 16.0s; that sum can cross 30s and surface as a CloudFront 504.

60s is the ceiling without a service-quota increase; the function itself times out at 120s.

## Test plan

- `pytest -q`: 1175 passed, 38 skipped
- Isolated synth of the same construct: no `OriginReadTimeout` before, `OriginReadTimeout: 60` after
- Deployed distribution confirmed at 30s today

🤖 Generated with [Claude Code](https://claude.com/claude-code)