### PR TITLE
Stop shipping uvicorn into the API Lambda package

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,7 +1,6 @@
 # Runtime dependencies for the API zip Lambda = engine runtime + web layer.
 -r requirements.txt
 fastapi==0.141.1
-uvicorn[standard]==0.52.4
 mangum==0.21.0
 python-json-logger==4.2.0
 aws-xray-sdk==2.15.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 -r requirements-api.txt   # engine + API (FastAPI) so test_api.py can import the app
+uvicorn[standard]==0.52.4  # local dev server only; Lambda is served by Mangum, not uvicorn.
+                        # [standard] keeps `--reload` (watchfiles) working per apps/api/main.py.
 pytest==9.1.1
 moto[dynamodb]==5.2.2   # in-process AWS mock for hermetic adapter contract tests
 httpx==0.28.1           # FastAPI TestClient transport


### PR DESCRIPTION
## Summary

Lambda serves the app through Mangum (`apps/api/handler.py`), never uvicorn, which appears in application code only in a docstring at `apps/api/main.py:7`. Shipping `uvicorn[standard]` cost 9 packages that are downloaded, unzipped and page-faulted on every cold start and never executed.

Resolved dependency graphs confirm nothing else needs them: dropping it removes `uvicorn`, `uvloop`, `httptools`, `websockets`, `watchfiles`, `pyyaml`, `python-dotenv`, `click`, `h11` — while `fastapi`, `starlette` and `mangum` stay. **24.5 MB unzipped on linux aarch64.**

The API asset was at ~247 MB against Lambda's 250 MB unzipped quota, so this is also headroom: the next `numpy` or `botocore` bump would have failed deploy.

Moved to `requirements-dev.txt` with the `[standard]` extra retained so `uvicorn apps.api.main:app --reload` and `.claude/launch.json` keep working. CI installs `requirements-dev.txt`, so the test gate is unaffected.

## Test plan

- `pytest -q`: 1175 passed, 38 skipped
- `pip install --dry-run` on both files: API resolves 35 packages with none of the uvicorn family; dev resolves 62 including uvicorn + watchfiles
- Confirmed no runtime `import uvicorn` anywhere in `apps/`, `darkhours/`, `cdk/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)