### PR TITLE
Byte-compile the application source at bundle time

### DIFF
--- a/cdk/lambda_api_stack.py
+++ b/cdk/lambda_api_stack.py
@@ -162,7 +162,14 @@ class LambdaApiStack(Stack):
                         "bash", "-c",
                         "pip install --no-cache-dir -r requirements-api.txt "
                         "-t /asset-output "
-                        "&& cp -r darkhours apps cache /asset-output/",
+                        "&& cp -r darkhours apps cache /asset-output/ "
+                        # pip byte-compiles what it installs, but this cp does not, so the
+                        # app's own modules shipped as bare .py and recompiled on every cold
+                        # start (/var/task is read-only, so the .pyc never persists).
+                        # unchecked-hash: mtimes do not survive packaging, so a timestamp
+                        # .pyc would be treated as stale and recompiled anyway.
+                        "&& python3 -m compileall -q --invalidation-mode unchecked-hash "
+                        "/asset-output/darkhours /asset-output/apps",
                     ],
                 ),
             ),
@@ -302,7 +309,14 @@ class LambdaApiStack(Stack):
                         "bash", "-c",
                         "pip install --no-cache-dir -r requirements.txt "
                         "python-json-logger aws-xray-sdk -t /asset-output "
-                        "&& cp -r darkhours apps cache /asset-output/",
+                        "&& cp -r darkhours apps cache /asset-output/ "
+                        # pip byte-compiles what it installs, but this cp does not, so the
+                        # app's own modules shipped as bare .py and recompiled on every cold
+                        # start (/var/task is read-only, so the .pyc never persists).
+                        # unchecked-hash: mtimes do not survive packaging, so a timestamp
+                        # .pyc would be treated as stale and recompiled anyway.
+                        "&& python3 -m compileall -q --invalidation-mode unchecked-hash "
+                        "/asset-output/darkhours /asset-output/apps",
                     ],
                 ),
             ),


### PR DESCRIPTION
## Summary

Both bundling commands pip-install dependencies (which pip byte-compiles) and then `cp -r darkhours apps cache` on top. The staging helpers strip `__pycache__`, so the application's own 46 modules shipped as bare `.py`. `/var/task` is read-only, so every cold start of both functions recompiled them and threw the result away.

`unchecked-hash` rather than the default timestamp mode: packaging does not preserve mtimes, so timestamp `.pyc` are treated as stale and recompiled anyway.

A modest win, roughly the same order as one avoided import, but it costs nothing and lands squarely in `Function init`.

## Test plan

- `pytest -q`: 1175 passed, 38 skipped
- Reconstructed both bundling shell commands from the AST to confirm they are well-formed
- Simulated a read-only `/var/task` with `.py` mtimes rewritten after compiling, importing `apps.worker.handler`:

  | tree | import |
  |---|---|
  | bare `.py` (today) | 0.41–0.45 s |
  | `timestamp` `.pyc` | 0.40 s |
  | `unchecked-hash` `.pyc` | **0.38 s** |

Local dev and tests are unaffected: `compileall` runs only inside the CDK bundling container, against `/asset-output`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)