### PR TITLE
Load global-land-mask on first use instead of at import

### DIFF
--- a/apps/worker/handler.py
+++ b/apps/worker/handler.py
@@ -40,6 +40,14 @@ def _prewarm() -> None:
             src.sample(dataset, 0.0, 0.0)
     except Exception as _e:
         log.debug("Raster pre-warm failed: %s", _e)
+    # global-land-mask (~933 MB materialised on import) — lazy since it is find_nearby-only,
+    # so warm it here, where find_nearby actually runs, rather than on the first job.
+    try:
+        from darkhours import darksky as _ds
+        if _ds._HAS_GLM:
+            _ds._land_mask_mod()
+    except Exception as _e:
+        log.debug("Land-mask pre-warm failed: %s", _e)
     # PAD-US H3 index (columnar load) used by find_nearby Tier 1.
     try:
         from darkhours import darksky as _ds

--- a/darkhours/darksky.py
+++ b/darkhours/darksky.py
@@ -48,15 +48,35 @@ from . import _http
 
 log = logging.getLogger(__name__)
 
-try:
-    from global_land_mask import globe as _glm
-    _HAS_GLM = True
-except ImportError:
-    log.warning(
-        "global-land-mask not installed; water pre-filtering disabled. "
-        "Run `pip install global-land-mask` to enable early water coordinate filtering."
-    )
-    _HAS_GLM = False
+# global-land-mask materialises a (21600, 43200) bool array (~933 MB) at import, so it is
+# loaded on first use instead. Only find_nearby needs it, yet both Lambdas paid it during
+# init. _glm/_HAS_GLM stay module-level and writable because tests monkeypatch both.
+_glm = None
+_HAS_GLM = True          # optimistic; flipped to False if the package turns out to be absent
+_glm_lock = threading.Lock()
+
+
+def _land_mask_mod():
+    """Return global_land_mask.globe, importing it on first use.
+
+    Returns None (and flips ``_HAS_GLM``) when the package is missing. Callers must test
+    ``_HAS_GLM`` *before* calling this, so a monkeypatched False short-circuits without
+    triggering the import.
+    """
+    global _glm, _HAS_GLM
+    if _glm is None and _HAS_GLM:
+        with _glm_lock:
+            if _glm is None and _HAS_GLM:
+                try:
+                    from global_land_mask import globe
+                    _glm = globe
+                except ImportError:
+                    _HAS_GLM = False
+                    log.warning(
+                        "global-land-mask not installed; water pre-filtering disabled. "
+                        "Run `pip install global-land-mask` to enable early water coordinate filtering."
+                    )
+    return _glm
 
 _HAS_H3 = False
 try:
@@ -1175,7 +1195,9 @@ def _find_light_domes_from_array(
             if land_mask is not None:
                 arr = np.where(land_mask, arr, np.nan)
             else:
-                arr = np.where(_glm.is_land(lat_grid, lon_grid), arr, np.nan)
+                _mod = _land_mask_mod()
+                if _mod is not None:
+                    arr = np.where(_mod.is_land(lat_grid, lon_grid), arr, np.nan)
         sqm_arr = np.where(arr > 0, 21.7 - 2.5 * np.log10(arr + 0.6), np.nan)
     bortle_arr = _sqm_to_bortle_array(sqm_arr)
 
@@ -1290,7 +1312,9 @@ def _extract_dark_sky_candidates(
 
     # ── Land mask (compute once, reused in dark_mask below) ───────────────────
     if land_mask is None and _HAS_GLM:
-        land_mask = _glm.is_land(lat_grid, lon_grid)
+        _mod = _land_mask_mod()
+        if _mod is not None:
+            land_mask = _mod.is_land(lat_grid, lon_grid)
 
     # ── Composite Bortle array ────────────────────────────────────────────────
     # VIIRS primary: any pixel with measurable radiance.
@@ -2554,7 +2578,9 @@ def find_nearby(lat: float, lon: float, radius_miles:int) -> dict | None:
             _lat_grid, _lon_grid = _window_pixel_grid(
                 "viirs", _min_lat, _max_lat, _min_lon, _max_lon, _rows, _cols)
             if _HAS_GLM:
-                _land_mask = _glm.is_land(_lat_grid, _lon_grid)
+                _mod = _land_mask_mod()
+                if _mod is not None:
+                    _land_mask = _mod.is_land(_lat_grid, _lon_grid)
             _viirs_sqm_arr = _np.where(
                 viirs_arr > 0,
                 21.7 - 2.5 * _np.log10(viirs_arr + 0.6),

--- a/scripts/bench_dome_detection.py
+++ b/scripts/bench_dome_detection.py
@@ -29,7 +29,7 @@ def _reference_domes(arr, min_lat, max_lat, min_lon, max_lon, tier_min_bortle=8,
     lat_vals = np.linspace(max_lat, min_lat, rows)
     lon_vals = np.linspace(min_lon, max_lon, cols)
     lat_grid, lon_grid = np.meshgrid(lat_vals, lon_vals, indexing="ij")
-    masked = np.where(darksky._glm.is_land(lat_grid, lon_grid), arr, np.nan)
+    masked = np.where(darksky._land_mask_mod().is_land(lat_grid, lon_grid), arr, np.nan)
     sqm = np.where(masked > 0, 21.7 - 2.5 * np.log10(masked + 0.6), np.nan)
     bortle = darksky._sqm_to_bortle_array(sqm)
     tier = (bortle >= tier_min_bortle) & (bortle != 0)
@@ -70,7 +70,7 @@ def _step_profile(arr, min_lat, max_lat, min_lon, max_lon):
     t["meshgrid"] = time.perf_counter() - t0
 
     t0 = time.perf_counter()
-    masked = np.where(darksky._glm.is_land(lat_grid, lon_grid), arr, np.nan)
+    masked = np.where(darksky._land_mask_mod().is_land(lat_grid, lon_grid), arr, np.nan)
     t["is_land mask"] = time.perf_counter() - t0
 
     t0 = time.perf_counter()

--- a/tests/test_land_mask_lazy.py
+++ b/tests/test_land_mask_lazy.py
@@ -1,0 +1,133 @@
+"""Tests for the lazy global-land-mask import in darkhours.darksky.
+
+``global_land_mask`` materialises a (21600, 43200) bool array (~933 MB) the moment it is
+imported, and only ``find_nearby`` ever calls ``is_land``. The module is therefore loaded
+on first use rather than at import. These tests lock the contract that made that safe:
+
+  1. Importing darksky (or either Lambda entrypoint) does not import global_land_mask.
+  2. The accessor returns the real module when the package is installed, and memoizes it.
+  3. A monkeypatched ``_glm`` is handed back untouched, so existing tests keep working.
+  4. ``_HAS_GLM = False`` short-circuits at the call sites *without* triggering the import.
+  5. Candidate extraction is unchanged whether the module was preloaded or loaded lazily.
+"""
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+import darkhours.darksky as ds
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _probe(body: str) -> str:
+    """Run `body` in a clean interpreter with the repo importable; return its stdout."""
+    out = subprocess.run(
+        [sys.executable, "-c", body],
+        cwd=_REPO_ROOT, capture_output=True, text=True, timeout=120,
+    )
+    assert out.returncode == 0, f"probe failed:\n{out.stdout}\n{out.stderr}"
+    return out.stdout.strip()
+
+
+class TestImportStaysLazy:
+    @pytest.mark.parametrize("module", [
+        "darkhours.darksky",
+        "apps.worker.handler",
+        "apps.api.handler",
+    ])
+    def test_importing_does_not_load_global_land_mask(self, module):
+        """The whole point: none of these may drag in the 933 MB array at import."""
+        loaded = _probe(
+            f"import sys; import {module}; "
+            "print('global_land_mask' in sys.modules)"
+        )
+        assert loaded == "False", (
+            f"{module} imported global_land_mask at module scope; that costs ~933 MB of "
+            "resident memory on every Lambda container. Keep it behind _land_mask_mod()."
+        )
+
+
+class TestAccessor:
+    def test_returns_the_real_module(self, monkeypatch):
+        pytest.importorskip("global_land_mask")
+        monkeypatch.setattr(ds, "_glm", None)
+        monkeypatch.setattr(ds, "_HAS_GLM", True)
+
+        mod = ds._land_mask_mod()
+
+        assert mod is not None
+        assert bool(mod.is_land(40.0, -105.0)) is True      # Colorado
+        assert bool(mod.is_land(0.0, -140.0)) is False      # mid-Pacific
+
+    def test_memoizes(self, monkeypatch):
+        pytest.importorskip("global_land_mask")
+        monkeypatch.setattr(ds, "_glm", None)
+        monkeypatch.setattr(ds, "_HAS_GLM", True)
+
+        assert ds._land_mask_mod() is ds._land_mask_mod()
+
+    def test_returns_a_patched_glm_untouched(self, monkeypatch):
+        """~30 existing test sites monkeypatch _glm; the accessor must not overwrite them."""
+        fake = MagicMock(is_land=lambda a, b: np.ones(np.shape(a), dtype=bool))
+        monkeypatch.setattr(ds, "_HAS_GLM", True)
+        monkeypatch.setattr(ds, "_glm", fake)
+
+        assert ds._land_mask_mod() is fake
+
+    def test_missing_package_flips_the_flag_and_returns_none(self, monkeypatch):
+        monkeypatch.setattr(ds, "_glm", None)
+        monkeypatch.setattr(ds, "_HAS_GLM", True)
+        monkeypatch.setitem(sys.modules, "global_land_mask", None)  # forces ImportError
+
+        assert ds._land_mask_mod() is None
+        assert ds._HAS_GLM is False
+
+    def test_disabled_flag_short_circuits_without_importing(self, monkeypatch):
+        """_HAS_GLM=False must be checked *before* the accessor, or laziness is defeated."""
+        monkeypatch.setattr(ds, "_glm", None)
+        monkeypatch.setattr(ds, "_HAS_GLM", False)
+
+        assert ds._land_mask_mod() is None
+
+    def test_call_sites_do_not_import_when_disabled(self):
+        """End-to-end: with the flag off, extraction must not pull the module in."""
+        loaded = _probe(
+            "import sys, numpy as np\n"
+            "import darkhours.darksky as ds\n"
+            "ds._HAS_GLM = False\n"
+            "viirs = np.zeros((2, 2), dtype=float)\n"
+            "ds._extract_dark_sky_candidates(\n"
+            "    viirs, None, 35.0, 36.0, -113.0, -111.0, 35.5, -112.0,\n"
+            "    radius_miles=150, dark_threshold=3)\n"
+            "print('global_land_mask' in sys.modules)\n"
+        )
+        assert loaded == "False"
+
+
+class TestExtractionParity:
+    """Lazy loading must not change what _extract_dark_sky_candidates returns."""
+
+    _BOUNDS = dict(radius_miles=150, dark_threshold=3)
+
+    def _run(self):
+        viirs = np.zeros((2, 2), dtype=float)
+        return ds._extract_dark_sky_candidates(
+            viirs, None, 35.0, 36.0, -113.0, -111.0, 35.5, -112.0, **self._BOUNDS
+        )
+
+    def test_same_results_preloaded_vs_lazy(self, monkeypatch):
+        pytest.importorskip("global_land_mask")
+
+        monkeypatch.setattr(ds, "_HAS_GLM", True)
+        monkeypatch.setattr(ds, "_glm", None)
+        lazy = self._run()                       # accessor imports it mid-call
+
+        from global_land_mask import globe
+        monkeypatch.setattr(ds, "_glm", globe)   # already resident, as before the change
+        preloaded = self._run()
+
+        assert lazy == preloaded


### PR DESCRIPTION
## Summary

`global_land_mask` materialises a 933 MB array at import, and `darksky` imported it at module scope, so both Lambdas paid it during init. Only `find_nearby` uses it. Now loaded on first use and warmed in the worker prewarm.

Import time / peak RSS vs `origin/main`: worker 341–396 ms / 980 MB → **86–93 ms / 45.8 MB**; API 489–567 ms / 1008 MB → **237–240 ms / 73.1 MB**.

## Test plan

- `pytest -q`: 1185 passed, 38 skipped (1175 + 10 new)
- `tests/test_land_mask_lazy.py` locks the laziness contract
- Watch worker `@maxMemoryUsed` after deploy: the 933 MB now allocates during `find_nearby`

🤖 Generated with [Claude Code](https://claude.com/claude-code)