### PR TITLE
Pre-warm the API once per container, not once per request

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -36,12 +36,21 @@ from apps import jobs
 from .serializers import night_report_to_dict
 
 
+# Mangum builds a fresh LifespanCycle inside __call__, so this lifespan runs on EVERY
+# invocation rather than once at container init. Without this guard each request spawned a
+# thread and re-ran the DynamoDB probe below, an unmemoized GetItem. Set before the thread
+# starts, not inside it, so a request arriving mid-warm doesn't spawn a second one.
+_prewarm_started = False
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Pre-warm expensive resources in a daemon thread so the lifespan yields
-    # immediately and Lambda Web Adapter gets its readiness signal without delay.
-    # Previously this ran synchronously and caused LWA's 10s probe to time out.
-    if "LAMBDA_TASK_ROOT" in os.environ:
+    # Pre-warm expensive resources in a daemon thread so the lifespan yields immediately.
+    # This cannot reduce @initDuration: under Mangum it runs on the request path, not in
+    # Lambda's Init phase. Its only value is overlapping the warm with the first request.
+    global _prewarm_started
+    if "LAMBDA_TASK_ROOT" in os.environ and not _prewarm_started:
+        _prewarm_started = True
         import threading
 
         def _prewarm() -> None:

--- a/tests/test_api_lifespan_prewarm.py
+++ b/tests/test_api_lifespan_prewarm.py
@@ -1,0 +1,63 @@
+"""The API lifespan must pre-warm at most once per container.
+
+Mangum builds a fresh ``LifespanCycle`` inside ``__call__`` (mangum/adapter.py), so
+``lifespan()`` runs on every invocation rather than once at container init. Before the
+guard, each request spawned a daemon thread whose first step is an unmemoized DynamoDB
+GetItem — roughly one wasted read per request.
+"""
+import asyncio
+import threading
+
+import apps.api.main as main
+
+
+def _run_lifespan_cycles(n: int) -> None:
+    async def go():
+        for _ in range(n):
+            async with main.lifespan(main.app):
+                pass
+    asyncio.run(go())
+
+
+class _FakeThread:
+    """Records spawns without running the prewarm (which would hit the network)."""
+    spawned: list = []
+
+    def __init__(self, target=None, daemon=None):
+        self.target = target
+        type(self).spawned.append(target)
+
+    def start(self):
+        pass
+
+
+def _patch(monkeypatch):
+    _FakeThread.spawned = []
+    monkeypatch.setenv("LAMBDA_TASK_ROOT", "/var/task")
+    monkeypatch.setattr(main, "_prewarm_started", False)
+    monkeypatch.setattr(threading, "Thread", _FakeThread)
+
+
+def test_prewarm_spawns_once_across_many_invocations(monkeypatch):
+    _patch(monkeypatch)
+    _run_lifespan_cycles(5)
+    assert len(_FakeThread.spawned) == 1, (
+        "the prewarm thread must spawn once per container, not once per invocation"
+    )
+
+
+def test_guard_is_set_before_the_thread_starts(monkeypatch):
+    """Set inside the thread instead, and a burst would each spawn their own."""
+    _patch(monkeypatch)
+    _run_lifespan_cycles(1)
+    # The fake never runs the target, so a guard set inside _prewarm would still be False.
+    assert main._prewarm_started is True
+
+
+def test_no_prewarm_outside_lambda(monkeypatch):
+    _FakeThread.spawned = []
+    monkeypatch.delenv("LAMBDA_TASK_ROOT", raising=False)
+    monkeypatch.setattr(main, "_prewarm_started", False)
+    monkeypatch.setattr(threading, "Thread", _FakeThread)
+    _run_lifespan_cycles(3)
+    assert _FakeThread.spawned == []


### PR DESCRIPTION
Mangum runs the FastAPI lifespan on every invocation, so the prewarm thread respawned per request and re-ran an unmemoized DynamoDB `GetItem`. Now guarded to once per container.

`pytest -q`: 1188 passed, 38 skipped.