### PR TITLE
Narrow the Starlink train window to 4 days and age it on read

### DIFF
--- a/darkhours/tle_provider.py
+++ b/darkhours/tle_provider.py
@@ -268,14 +268,16 @@ def cached_starlink_trains() -> tuple[list[tuple[str, str, str, str | None]], bo
     """
     key = _STARLINK_TRAINS_CACHE_KEY
 
+    # Pruned on read: the list is built by the warmer, a separate hand-deployed stack, so
+    # a window change would otherwise stay inert here.
     trains = _cache.get(key)
     if trains is not None:
-        return _as_tle_tuples(trains), False, None
+        return _prune_expired_trains(_as_tle_tuples(trains)), False, None
 
     trains = _cache.get_stale(key)
     if trains is not None:
         log.warning("Serving expired Starlink train TLEs — the warmer has not refreshed them")
-        return _as_tle_tuples(trains), True, None
+        return _prune_expired_trains(_as_tle_tuples(trains)), True, None
 
     msg = "no cached Starlink train TLEs — the warmer has not populated them"
     log.error("%s", msg, extra={"service": "celestrak"})
@@ -351,7 +353,9 @@ _STARLINK_LAUNCH_DATES_CACHE_KEY = "tle|starlink|launch_dates"
 # dropped batches deployed directly at ~465 km — three of the four most recent
 # launches in the feed on 2026-08-23.
 _STARLINK_TRAIN_MM_MIN    = 15.2
-_STARLINK_RECENT_DAYS     = 21     # only launches within this window can form a visible train
+# A batch reads as a train for 1-3 nights after deployment, then spreads around the orbit
+# — while still raising, so the mean-motion filter alone keeps it.
+_STARLINK_RECENT_DAYS     = 4      # only launches within this window can form a visible train
 
 # The cached launch-date map is pruned to this window. The filter only ever asks
 # about _STARLINK_RECENT_DAYS; the wider margin keeps the item small (tens of
@@ -459,35 +463,12 @@ def _omm_row_to_tle(row: dict) -> tuple[str, str] | None:
 def _filter_train_tles(
     raw: str, launch_dates: dict[str, date]
 ) -> list[tuple[str, str, str, str]]:
-    """
-    Parse a GP CSV response and return only raising-phase Starlinks from recent launches.
+    """Return only raising-phase Starlinks from recent launches, newest first.
 
-    Two-part filter:
-      1. Mean motion >= _STARLINK_TRAIN_MM_MIN — the satellite is still below every
-         operational shell, so it has not been handed over to service yet.
-      2. The launch is within _STARLINK_RECENT_DAYS, per *launch_dates* — an older
-         batch has spread around its orbit and no longer crosses the sky as a train
-         even while it is still raising.
-
-    Recency is the load-bearing half, and it is why this needs the SATCAT. Mean
-    motion alone is not a train signal: most satellites above the threshold are old
-    ones being lowered for re-entry rather than new ones being raised, and a
-    descending satellite speeds up exactly like a climbing one.
-
-    An empty *launch_dates* therefore fails closed. Without dates the two populations
-    are indistinguishable, and emitting the raising-phase set unfiltered would put
-    hundreds of decaying satellites on screen labelled as trains.
-
-    ``OBJECT_ID`` carries the full international designator ("2026-160A"); the first
-    eight characters are the launch key, the same key _parse_satcat_launch_dates
-    builds on the other side of this join.
-
-    Ordered newest launch first so _STARLINK_MAX_TRAINS truncates the oldest batch
-    rather than an arbitrary one.
-
-    The recency cutoff is evaluated here, at filter time, and the result is what gets
-    cached — so it is frozen for up to one refresh interval (6 h) against a 21-day
-    window. That drift is immaterial; caching the raw block instead is what was not.
+    Keeps mean motion >= _STARLINK_TRAIN_MM_MIN and launches within
+    _STARLINK_RECENT_DAYS. Recency is the load-bearing half: a decaying satellite
+    speeds up exactly like a climbing one, so mean motion alone cannot tell them
+    apart and empty *launch_dates* fails closed.
 
     Raises ValueError if *raw* is not the OMM CSV we asked for.
     """
@@ -537,10 +518,7 @@ def _prune_expired_trains(
 ) -> list[tuple[str, str, str, str | None]]:
     """Drop cached entries whose launch has aged out of the train window.
 
-    Celestrak's 403 means the group has not changed, so there is nothing to
-    re-filter — but the 21-day window has still moved since the list was built, and
-    the raw block is deliberately not kept. Each entry carries its own launch date,
-    so the cached list can be aged without refetching anything.
+    Each entry carries its own launch date, so the list ages without refetching.
     """
     cutoff = datetime.now(timezone.utc).date() - timedelta(days=_STARLINK_RECENT_DAYS)
     kept: list[tuple[str, str, str, str | None]] = []

--- a/tests/test_tle_provider.py
+++ b/tests/test_tle_provider.py
@@ -9,6 +9,7 @@ import pytest
 
 from darkhours import tle_provider as tle_mod
 from darkhours.tle_provider import (
+    _STARLINK_RECENT_DAYS,
     _cospar_designator,
     _filter_train_tles,
     _parse_mean_motion,
@@ -117,10 +118,10 @@ def _omm_csv(*sats) -> str:
 def _make_train_block() -> str:
     """
     Four synthetic Starlinks:
-      RECENT-HIGH   — launch 2026-040, 5 days ago,  MM=15.60 → INCLUDE
-      RECENT-LOW    — launch 2026-040, 5 days ago,  MM=15.06 → EXCLUDE (on station)
-      OLD-HIGH      — launch 2026-030, 30 days ago, MM=15.70 → EXCLUDE (stale batch)
-      UNKNOWN-DATE  — blank designator,             MM=15.55 → EXCLUDE (undatable)
+      RECENT-HIGH   — launch 2026-040, inside the window, MM=15.60 → INCLUDE
+      RECENT-LOW    — launch 2026-040, inside the window, MM=15.06 → EXCLUDE (on station)
+      OLD-HIGH      — launch 2026-030, 30 days ago,       MM=15.70 → EXCLUDE (stale batch)
+      UNKNOWN-DATE  — blank designator,                   MM=15.55 → EXCLUDE (undatable)
 
     UNKNOWN-DATE used to be included on the theory that an unknown launch date was
     safest treated as recent. It is the opposite: an undatable satellite at high mean
@@ -136,7 +137,7 @@ def _make_train_block() -> str:
 
 _TODAY        = date.today()
 _LAUNCH_DATES = {
-    "2026-040": _TODAY - timedelta(days=5),
+    "2026-040": _TODAY - timedelta(days=_STARLINK_RECENT_DAYS - 1),
     "2026-030": _TODAY - timedelta(days=30),
 }
 
@@ -162,7 +163,7 @@ class TestFilterTrainTles:
     def test_each_result_carries_its_launch_date(self):
         for entry in self.results:
             assert len(entry) == 4          # (name, line1, line2, launch_date)
-            assert entry[3] == (_TODAY - timedelta(days=5)).isoformat()
+            assert entry[3] == (_TODAY - timedelta(days=_STARLINK_RECENT_DAYS - 1)).isoformat()
 
     def test_empty_body_raises_rather_than_reporting_no_trains(self):
         """An empty body is a broken fetch, not a quiet night. Returning [] here is

--- a/tests/test_tle_request_path.py
+++ b/tests/test_tle_request_path.py
@@ -250,14 +250,15 @@ def test_cached_starlink_trains_reads_an_empty_list_as_data_not_as_a_miss(monkey
 
 def test_cached_starlink_trains_round_trips_the_json_shape(monkeypatch):
     """The cache stores JSON, so tuples come back as lists — callers expect tuples."""
+    fresh_launch = (_TODAY - timedelta(days=1)).isoformat()
     cache = _StateCache(fresh={
-        tle._STARLINK_TRAINS_CACHE_KEY: [["S-1", "1 aaa", "2 bbb", "2026-08-12"]]
+        tle._STARLINK_TRAINS_CACHE_KEY: [["S-1", "1 aaa", "2 bbb", fresh_launch]]
     })
     monkeypatch.setattr(tle, "_cache", cache)
 
     trains, _, _ = tle.cached_starlink_trains()
 
-    assert trains == [("S-1", "1 aaa", "2 bbb", "2026-08-12")]
+    assert trains == [("S-1", "1 aaa", "2 bbb", fresh_launch)]
 
 
 def test_cached_starlink_trains_tolerates_a_three_element_row(monkeypatch):
@@ -266,9 +267,28 @@ def test_cached_starlink_trains_tolerates_a_three_element_row(monkeypatch):
     cache = _StateCache(fresh={tle._STARLINK_TRAINS_CACHE_KEY: [["S-1", "1 aaa", "2 bbb"]]})
     monkeypatch.setattr(tle, "_cache", cache)
 
-    trains, _, _ = tle.cached_starlink_trains()
+    assert tle._as_tle_tuples(cache.get(tle._STARLINK_TRAINS_CACHE_KEY)) == [
+        ("S-1", "1 aaa", "2 bbb", None)]
 
-    assert trains == [("S-1", "1 aaa", "2 bbb", None)]
+    # An undated row cannot be aged, so the read-path prune drops it.
+    trains, _, _ = tle.cached_starlink_trains()
+    assert trains == []
+
+
+def test_cached_starlink_trains_ages_out_stale_launches_on_read(monkeypatch):
+    """The window is enforced on read, not only when the warmer refreshes."""
+    inside  = (_TODAY - timedelta(days=1)).isoformat()
+    outside = (_TODAY - timedelta(days=tle._STARLINK_RECENT_DAYS + 1)).isoformat()
+    cache = _StateCache(fresh={tle._STARLINK_TRAINS_CACHE_KEY: [
+        ["S-new", "1 aaa", "2 bbb", inside],
+        ["S-old", "1 ccc", "2 ddd", outside],
+    ]})
+    monkeypatch.setattr(tle, "_cache", cache)
+
+    trains, stale, error = tle.cached_starlink_trains()
+
+    assert [t[0] for t in trains] == ["S-new"]
+    assert stale is False and error is None
 
 
 # ---------------------------------------------------------------------------
@@ -368,7 +388,7 @@ def test_filter_carries_the_launch_date_and_orders_newest_first():
     raw = _synthetic_group(2) + "\n" + _synthetic_group(2, designator_suffix="041")
     dates = {
         _DESIGNATOR:      _TODAY - timedelta(days=2),
-        older_designator: _TODAY - timedelta(days=9),
+        older_designator: _TODAY - timedelta(days=tle._STARLINK_RECENT_DAYS - 1),
     }
 
     trains = tle._filter_train_tles(raw, dates)
@@ -377,7 +397,7 @@ def test_filter_carries_the_launch_date_and_orders_newest_first():
     assert all(len(t) == 4 for t in trains)
     assert [t[3] for t in trains] == [
         (_TODAY - timedelta(days=2)).isoformat()] * 2 + [
-        (_TODAY - timedelta(days=9)).isoformat()] * 2
+        (_TODAY - timedelta(days=tle._STARLINK_RECENT_DAYS - 1)).isoformat()] * 2
 
 
 def test_satcat_parsing_keeps_recent_launches_keyed_by_designator():


### PR DESCRIPTION
Starlink batches read as trains for 1-3 nights after deployment, then spread around the orbit while still raising, so the mean-motion filter alone keeps them. 21d → 4d halves the propagated set and drops detections sourced from launches 16-20 days old. Also prunes on read, since the cached list is built by the warmer — a separate, hand-deployed stack — so the window would otherwise stay inert on the request path.

`pytest -q`: 1189 passed, 38 skipped.